### PR TITLE
update instructions for local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ listmonk is a standalone, self-hosted, newsletter and mailing list manager. It i
 
 ### Installation and use
 
-- Download the [latest release](https://github.com/knadh/listmonk/releases) and extract the listmonk binary somewhere.
-- Run `./listmonk --new-config` to generate a sample `config.toml` and add your configuration (SMTP and Postgres DB credentials primarily).
+- Download the [latest release](https://github.com/knadh/listmonk/releases) for your platform and extract the listmonk binary. For example: `tar -C $HOME/listmonk -xzf listmonk_$VERSION_$OS_$ARCH.tar.gz`
+- Navigate to the directory containing the binary (`cd $HOME/listmonk`) and run `./listmonk --new-config` to generate a sample `config.toml` and add your configuration (SMTP and Postgres DB credentials primarily).
 - `./listmonk --install` to setup the DB.
 - Run `./listmonk` and visit `http://localhost:9000`.
 - Since there is no user auth yet, it's best to put listmonk behind a proxy like Nginx and setup basicauth on all endpoints except for the few endpoints that need to be public. Here is a [sample nginx config](https://github.com/knadh/listmonk/wiki/Production-Nginx-config) for production use.


### PR DESCRIPTION
- Add suggestion to place the listmonk binary and config file in a separate folder instead of cluttering the default downloads folder