### PR TITLE
bug - dont update existing list

### DIFF
--- a/queries.sql
+++ b/queries.sql
@@ -126,8 +126,7 @@ INSERT INTO subscriber_lists (subscriber_id, list_id, status)
         UNNEST($6),
         (CASE WHEN $4='blacklisted' THEN 'unsubscribed'::subscription_status ELSE 'unconfirmed' END)
     )
-    ON CONFLICT (subscriber_id, list_id) DO UPDATE
-    SET status = (CASE WHEN $4='blacklisted' THEN 'unsubscribed'::subscription_status ELSE 'unconfirmed' END);
+    ON CONFLICT (subscriber_id, list_id) DO NOTHING;
 
 -- name: delete-subscribers
 -- Delete one or more subscribers by ID or UUID.


### PR DESCRIPTION
Suppose if a user is in mailing list A and has optin-confirmed, and now I create a new list called B, and if I add this user under B list, Previously confirmed also becomes unconfirmed.