### PR TITLE
fix: Remove root URI on frontend

### DIFF
--- a/frontend/src/Campaign.js
+++ b/frontend/src/Campaign.js
@@ -91,7 +91,7 @@ class Editor extends React.PureComponent {
       new Delta()
         .retain(range.index)
         .delete(range.length)
-        .insert({ image: this.props.config.rootURL + uri }),
+        .insert({ image: uri }),
       null
     )
   }


### PR DESCRIPTION
Removes appending root URI in `img src` from frontend which broke the rendering
of S3 URLs in campaign templates.

Closes https://github.com/knadh/listmonk/issues/101