### PR TITLE
Add support for custom headers

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -110,11 +110,15 @@ max_idle = 10
         wait_timeout = "5s"
 
         # The number of times a message should be retried if sending fails.
-	    max_msg_retries = 2
+	max_msg_retries = 2
 
         # Enable STARTTLS.
         tls_enabled = true
         tls_skip_verify = false
+
+        # Array of headers to add to each email sent from this server
+        # omit if you don't want to add any custom headers
+        inject_headers = [ "Custom-Header-Key:custom-value" ]
 
     [smtp.postal]
         enabled = false
@@ -145,7 +149,7 @@ max_idle = 10
         wait_timeout = "5s"
 
         # The number of times a message should be retried if sending fails.
-	    max_msg_retries = 2
+	max_msg_retries = 2
 
         # Enable STARTTLS.
         tls_enabled = true


### PR DESCRIPTION
Implements #121 

Custom headers are specified as an array under `inject_headers` in config.toml. Headers are only added if both the key and value are at least 1 char, after being split by `:`.

Keys and values are not validated as the textproto package used by smtppool believes it to be better to send invalid headers rather than drop them, which also matches the behaviour of most other mail clients.

I have tested it with the `X-SES-CONFIGURATION-SET` header used by AWS to select a particular SES configuration to send the mail under, as well as sending with no additional headers, which behaves identically to the pre-PR code base. 

Signed-off-by: raghavsood <r@raghavsood.com>