### PR TITLE
frontend: Enable vue filenameHashing

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -13,5 +13,5 @@ module.exports = {
   indexPath: './frontend/index.html',
 
   productionSourceMap: false,
-  filenameHashing: false,
+  filenameHashing: true,
 };


### PR DESCRIPTION
Currently, recompiling and serving the frontend breaks when listmonk is behind a caching proxy, like Cloudflare.

Vue supports cache busting, which adds a digest hash of the file to the name of all js, css, and other frontend assets. This allows the latest versions to be served easily when the listmonk binary is updated.