### PR TITLE
frontend: pass advanced query to API when enabled

### DIFF
--- a/frontend/src/views/Subscribers.vue
+++ b/frontend/src/views/Subscribers.vue
@@ -414,6 +414,10 @@ export default Vue.extend({
 
     // Turns the value into the simple input field into an SQL query expression.
     fullQueryExp() {
+      if (this.isSearchAdvanced) {
+        return this.queryParams.fullQuery;
+      }
+
       const q = this.queryParams.query.replace(/'/g, "''").trim();
       if (!q) {
         return '';

--- a/frontend/src/views/Subscribers.vue
+++ b/frontend/src/views/Subscribers.vue
@@ -395,6 +395,7 @@ export default Vue.extend({
         data.ids = this.bulk.checked.map((s) => s.id);
       } else {
         // 'All' is selected, perform by query.
+        data.query = this.fullQueryExp;
         fn = this.$api.addSubscribersToListsByQuery;
       }
 


### PR DESCRIPTION
Fixes #150

Apologies if this is the wrong way to do it, frontend isn't my strong point - feel free to close if there's a better option, did a quick patch for now since it was holding us up.

This also fixes a bug that caused the query to not be passed to the API when adding/removing `Select all` users from a list, which isn't mentioned in the original issue since I didn't discover it until after fixing the search.