### PR TITLE
feat: Add separate config for demo setup, tweak docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 frontend/node_modules/
 frontend/.cache/
 frontend/yarn.lock
+frontend/build/
 .vscode/
 
 config.toml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,3 +40,4 @@ dockers:
     dockerfile: Dockerfile
     extra_files:
     - config.toml.sample
+    - config-demo.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /listmonk
 COPY listmonk .
 COPY config.toml.sample config.toml
+COPY config-demo.toml .
 CMD ["./listmonk"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,9 +8,26 @@
 
 You can checkout the [docker-compose.yml](docker-compose.yml) to get an idea of how to run `listmonk` with `PostgreSQL` together using Docker.
 
-- `docker-compose up -d app db` to run all the services together.
-- `docker-compose run --rm app ./listmonk --install` to setup the DB.
+- **Run the services**: `docker-compose up -d app db` to run all the services together. If this is a first time setup, you will see some errors related to DB which occur because migrations haven't been applied yet. Don't worry, follow the next step.
+- **Apply DB migrations**: `docker-compose run --rm app ./listmonk --install`.
+-  Ensure that both the containers are in running state before proceeding. If the app container is not `up`, you might need to restart the app container once: `docker-compose restart app`. 
 - Visit `http://localhost:9000`.
+
+### Mounting a custom config file
+
+You are expected to tweak [config.toml.sample](config.toml.sample) for actual use with your custom settings. To mount the `config.toml` file,
+you can add the following section to `docker-compose.yml`:
+
+```
+  app:
+    <<: *app-defaults
+    depends_on:
+      - db
+    volume:
+    - ./path/on/host/config.toml/:/listmonk/config.toml
+```
+
+This will `mount` your local `config.toml` inside the container at `listmonk/config.toml`.
 
 _NOTE_: This `docker-compose` file works with Docker Engine 18.06.0+ and `docker-compose` which supports file format 3.7.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ See the [configuration Wiki page](https://github.com/knadh/listmonk/wiki/Configu
 
 You can pull the official Docker Image from [Docker Hub](https://hub.docker.com/r/listmonk/listmonk).
 
-You can checkout the [docker-compose.yml](docker-compose.yml) to get an idea of how to run `listmonk` with `PostgreSQL` together using Docker (also see [configuring with environment variables](https://github.com/knadh/listmonk/wiki/Configuration)).
+You can checkout the [docker-compose.yml](docker-compose.yml) to get an idea of how to run `listmonk` with `PostgreSQL` together using Docker (also see [configuring with environment variables](https://github.com/knadh/listmonk/wiki/Configuration)). Please visit [INSTALL.md](INSTALL.md) for detailed instructions on how to setup Listmonk with Docker.
 
-- `docker-compose up -d app db` to run all the services together.
-- `docker-compose run --rm app ./listmonk --install` to setup the DB.
-- Visit `http://localhost:9000`.
+**Alternatively**, to run a demo of listmonk, you can quickly spin up a local setup with:
 
-Alternatively, to run a demo of listmonk, you can quickly spin up a container `docker-compose up -d demo-db demo-app`. NOTE: This doesn't persist Postgres data after you stop and remove the container, this setup is intended only for demo. _DO NOT_ use the demo setup in production.
+`docker-compose up -d demo-db demo-app`.
+
+**NOTE:** This doesn't persist Postgres data after you stop and remove the container, this setup is intended only for demo. _DO NOT_ use the demo setup in production.
 
 ### Other deployments
 

--- a/config-demo.toml
+++ b/config-demo.toml
@@ -73,7 +73,7 @@ allow_wipe = false
 
 # Database.
 [db]
-host = "db"
+host = "demo-db"
 port = 5432
 user = "listmonk"
 password = "listmonk"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   demo-app:
     <<: *app-defaults
-    command: [sh, -c, "yes | ./listmonk --install && ./listmonk"]
+    command: [sh, -c, "yes | ./listmonk --install --config config-demo.toml && ./listmonk --config config-demo.toml"]
     depends_on: 
       - demo-db
 


### PR DESCRIPTION
This PR makes the following changes:

- Add  `config-demo.toml` to `Dockerfile` which uses the db host
`demo-db`. This is more suited for demo setups. For normal docker installations
the db host is changed back to `db` which is a better sane default.
- Reworded `INSTALL.md` and `README.md` for more clarity on docker
installation and configuration.

