### PR TITLE
fix: inconsistent active link on sidebar navigation

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,6 +32,7 @@
                 </b-menu-item><!-- dashboard -->
 
                 <b-menu-item :expanded="activeGroup.lists"
+                  :active="activeGroup.lists"
                   icon="format-list-bulleted-square" label="Lists">
                   <b-menu-item :to="{name: 'lists'}" tag="router-link"
                     :active="activeItem.lists"
@@ -43,6 +44,7 @@
                 </b-menu-item><!-- lists -->
 
                 <b-menu-item :expanded="activeGroup.subscribers"
+                  :active="activeGroup.subscribers"
                   icon="account-multiple" label="Subscribers">
                   <b-menu-item :to="{name: 'subscribers'}" tag="router-link"
                     :active="activeItem.subscribers"
@@ -54,6 +56,7 @@
                 </b-menu-item><!-- subscribers -->
 
                 <b-menu-item :expanded="activeGroup.campaigns"
+                  :active="activeGroup.campaigns"
                     icon="rocket-launch-outline" label="Campaigns">
                   <b-menu-item :to="{name: 'campaigns'}" tag="router-link"
                     :active="activeItem.campaigns"
@@ -138,6 +141,10 @@ export default Vue.extend({
       this.activeItem = { [to.name]: true };
       if (to.meta.group) {
         this.activeGroup = { [to.meta.group]: true };
+      } else {
+        // Reset activeGroup to collapse menu items on navigating
+        // to non group items from sidebar
+        this.activeGroup = {};
       }
     },
   },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -56,7 +56,7 @@
                 </b-menu-item><!-- subscribers -->
 
                 <b-menu-item :expanded="activeGroup.campaigns"
-                  :active="activeGroup.campaigns"
+                    :active="activeGroup.campaigns"
                     icon="rocket-launch-outline" label="Campaigns">
                   <b-menu-item :to="{name: 'campaigns'}" tag="router-link"
                     :active="activeItem.campaigns"


### PR DESCRIPTION
## PR Summary

This PR has a fix for inconsistent active sidebar link on routing to links not in groups.

<details>
<summary>Previous Behaviour</summary>
<img src="https://user-images.githubusercontent.com/18097732/91052458-1fdb1100-e63f-11ea-8ba1-c385df463af4.gif" alt="Broken">
</details>

<details>
<summary>After Fix</summary>
<img src="https://user-images.githubusercontent.com/18097732/91052231-cb379600-e63e-11ea-982a-6ae8d8eb8202.gif" alt="Fixed"
>
</details>

## The problems
**This problem occurs when navigating from a group item to a non group item**. There are two problems to be solved here.
1. The group item is not collapsed.
1. The active state is not transferred.

## Solutions

### The group item not collapsed

We watch the route and change the `activeGroup` based on the current route. The `expanded` attribute of the `b-menu-item` component is overridden to toggle based on the value of the relevant key in the `activeGroup` object. 

https://github.com/knadh/listmonk/blob/0f055eacb87030b55970f4870ff3a0b22b0dcaef/frontend/src/App.vue#L135-L142

Here, on navigating to a non group item, the route `meta` does not have a `group` attribute, this means that the condition that changes the expanded state is not triggered.

We can fix this by setting the `activeGroup` to `{}`.

> An alternate solution is to fetch the `from` along with `to` from the route object and explicitly set the activeGroup to `{ [from.meta.group]: false }`, but since we are reassigning the the activeGroup always, it's not prudent to do so. Besides other problems like deep watching etc may occur.

### The active state is not transferred.
For the sidebar menu items, the code overrides the `expanded` state referring to the `activeGroup` object. However, for Buefy the expanded and active state is not explicitly linked, overriding one means the other has to be managed by the developer as well. 

The fix was simple to pass the `active` prop as well.