### PR TITLE
fix: inconsistent sidebar group toggle on navigation

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,6 +33,7 @@
 
                 <b-menu-item :expanded="activeGroup.lists"
                   :active="activeGroup.lists"
+                  v-on:update:active="(state) => toggleGroup('lists', state)"
                   icon="format-list-bulleted-square" label="Lists">
                   <b-menu-item :to="{name: 'lists'}" tag="router-link"
                     :active="activeItem.lists"
@@ -45,6 +46,7 @@
 
                 <b-menu-item :expanded="activeGroup.subscribers"
                   :active="activeGroup.subscribers"
+                  v-on:update:active="(state) => toggleGroup('subscribers', state)"
                   icon="account-multiple" label="Subscribers">
                   <b-menu-item :to="{name: 'subscribers'}" tag="router-link"
                     :active="activeItem.subscribers"
@@ -56,8 +58,9 @@
                 </b-menu-item><!-- subscribers -->
 
                 <b-menu-item :expanded="activeGroup.campaigns"
-                    :active="activeGroup.campaigns"
-                    icon="rocket-launch-outline" label="Campaigns">
+                  :active="activeGroup.campaigns"
+                  v-on:update:active="(state) => toggleGroup('campaigns', state)"
+                  icon="rocket-launch-outline" label="Campaigns">
                   <b-menu-item :to="{name: 'campaigns'}" tag="router-link"
                     :active="activeItem.campaigns"
                     icon="rocket-launch-outline" label="All campaigns"></b-menu-item>
@@ -150,6 +153,9 @@ export default Vue.extend({
   },
 
   methods: {
+    toggleGroup(group, state) {
+      this.activeGroup = state ? { [group]: true } : {};
+    },
     reloadApp() {
       this.$api.reloadApp().then(() => {
         this.$utils.toast('Reloading app ...');

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -8,7 +8,7 @@ module.exports = {
   // and the URI for assets are tightly coupled. This is handled in the Go app
   // by using stuffbin aliases.
   assetsDir: 'frontend',
-  
+
   // Move the index.html file from dist/index.html to dist/frontend/index.html
   indexPath: './frontend/index.html',
 


### PR DESCRIPTION
## PR Summary

This PR has a fix for inconsistent sidebar toggle for group items.

<details>
<summary>Previous Behaviour</summary>
<img src="https://user-images.githubusercontent.com/18097732/91184910-d0faad80-e70a-11ea-99fd-697bbcea547b.gif">
</details>

<details>
<summary>After Fix</summary>
<img src="https://user-images.githubusercontent.com/18097732/91184923-d48e3480-e70a-11ea-998f-65cbfd6e244c.gif">
</details>

## The problem
Unlike the previous problem (fixed [here](https://github.com/knadh/listmonk/pull/181)), this problem occurs when navigating between group items. From the [buefy docs](https://buefy.org/documentation/menu/) the behaviour that is intended is for only one group to be expanded at a time. This is not happening properly.

There is a peculiar collapse behaviour as seen below. 

![bad-collapse-1](https://user-images.githubusercontent.com/18097732/91186044-2daa9800-e70c-11ea-9582-0489f052ce6a.gif)

<details>
<summary>Another peculiar behaviour</summary>
<img src="https://user-images.githubusercontent.com/18097732/91186040-2be0d480-e70c-11ea-9421-5be021b8d9c7.gif">
</details>



## Solutions
The reason such a behaviour exists is that the state of the component is managed by our code using `activeGroup`. We watch the route and change the `activeGroup` based on the current route. 


https://github.com/knadh/listmonk/blob/0f055eacb87030b55970f4870ff3a0b22b0dcaef/frontend/src/App.vue#L135-L142

However, on expand or collapse of a group, no event is triggered. The fix after figuring this out becomes pretty straightforward. `BMenuItem` has two UI "mutations", one is routing, the other is a toggle expand and collapse (both triggered by a click event). **There is an event for route already, however there is no trigger on expand or collpase.**

Buefy has a `onClick` handler for `BMenuItem`, which looks like the following

```javascript
onClick(event) {
	// Some JS magic Jimmy doesn't need to see
	this.$emit('update:expanded', this.newActive)
	if (menu && menu.activable) {
		this.newActive = true
		this.$emit('update:active', this.newActive)
	}
}
```
The `this.newActive` returns the current state of the group (whether it's expanded or collapsed) it is emitted via the `update:active` event, which we can listen on. This PR adds that event.

Depending on `update:active` is not the most elegant solution, since the event is not intended for this. The alternate is to completely override the `onClick` event for this, which defeats the purpose of using the component library in the first place.

## Links

- [Previous Fix](https://github.com/knadh/listmonk/pull/181)
- [Buefy Docs](https://buefy.org/documentation/menu/)
- [MenuItem.vue](https://github.com/buefy/buefy/blob/dev/src/components/menu/MenuItem.vue)
