### PR TITLE
refactor: switch to internal app package from main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,15 @@ deps:
 # Build steps.
 .PHONY: build
 build:
-	go build -o ${BIN} -ldflags="-s -w -X 'main.buildString=${BUILDSTR}' -X 'main.versionString=${VERSION}'" cmd/*.go
+	go build -o ${BIN} -ldflags="-s -w -X 'main.buildString=${BUILDSTR}' -X 'main.versionString=${VERSION}'" ./cmd/listmonk
 
 .PHONY: build-frontend
 build-frontend:
 	export VUE_APP_VERSION="${VERSION}" && cd frontend && yarn build
 
 .PHONY: run
-run: build
-	./${BIN}
+run: 
+	go run ./cmd/listmonk	
 
 .PHONY: run-frontend
 run-frontend:

--- a/cmd/listmonk/main.go
+++ b/cmd/listmonk/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/knadh/listmonk/internal/app"
+)
+
+var (
+	buildString   string
+	versionString string
+)
+
+func main() {
+	app.Run(buildString, versionString)
+}

--- a/internal/app/admin.go
+++ b/internal/app/admin.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"

--- a/internal/app/campaigns.go
+++ b/internal/app/campaigns.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"crypto/subtle"

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"encoding/json"

--- a/internal/app/lists.go
+++ b/internal/app/lists.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"fmt"

--- a/internal/app/manager_db.go
+++ b/internal/app/manager_db.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"github.com/gofrs/uuid"

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"

--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"

--- a/internal/app/public.go
+++ b/internal/app/public.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"

--- a/internal/app/queries.go
+++ b/internal/app/queries.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"encoding/json"

--- a/internal/app/subscribers.go
+++ b/internal/app/subscribers.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"

--- a/internal/app/templates.go
+++ b/internal/app/templates.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"database/sql"

--- a/internal/app/updates.go
+++ b/internal/app/updates.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"encoding/json"

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"


### PR DESCRIPTION
This commit moves all the logic in the main package
to a new internal app package and adds a new simpler main.go
to the cmd/app main package.

With this refactor we remove the global state during the init and
scope the global vars that we had earlier. This might help with
testing (if needed) later on as well.

The biggest benefit of this refactor for new users and developers
is running `go run cmd/app/main.go` to get started with listmonk.


----

#