### PR TITLE
fix: incorrect git tag being injected as version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LAST_COMMIT := $(shell git rev-parse --short HEAD)
 LAST_COMMIT_DATE := $(shell git show -s --format=%ci ${LAST_COMMIT})
-VERSION := $(shell git describe)
+VERSION := $(shell git describe --tags)
 BUILDSTR := ${VERSION} (${LAST_COMMIT} $(shell date -u +"%Y-%m-%dT%H:%M:%S%z"))
 
 BIN := listmonk


### PR DESCRIPTION
Git tag version injected via Makefile is incorrect since `git describe` doesn't consider annotated tags but all the recent releases are lightweight tags. So instead use `git describe --tags` command which also considers recent lightweight tag.

Related  #197