### PR TITLE
fix: incorrect csv import example on frontend

### DIFF
--- a/frontend/src/views/Import.vue
+++ b/frontend/src/views/Import.vue
@@ -99,14 +99,12 @@
           <code className="csv-row">
             <span>user1@mail.com,</span>
             <span>"User One",</span>
-            <span>{'"{""age"": 42, ""planet"": ""Mars""}"'}</span>
+            <span>"{""age"": 42, ""planet"": ""Mars""}"</span>
           </code><br />
           <code className="csv-row">
             <span>user2@mail.com,</span>
             <span>"User Two",</span>
-            <span>
-              {'"{""age"": 24, ""job"": ""Time Traveller""}"'}
-            </span>
+            <span>"{""age"": 24, ""job"": ""Time Traveller""}"</span>
           </code>
         </blockquote>
       </div>


### PR DESCRIPTION
The example given for CSV import on `Import.vue` is incorrect since field `attributes` value is not a valid JSON. The previous example copy-pasted was throwing following CSV parse error.

```
2020/10/03 17:59:38 processing 'email-sample.csv'
2020/10/03 17:59:38 error reading CSV 'parse error on line 2, column 28: bare " in non-quoted-field'
```

Previous incorrect example  

```
email,name,attributes
user1@mail.com,"User One",{'"{""age"": 42, ""planet"": ""Mars""}"'}
user2@mail.com,"User Two", {'"{""age"": 24, ""job"": ""Time Traveller""}"'}
```

Should ideally be something like below

```
email,name,attributes
user1@mail.com,"User One","{""age"": 42, ""planet"": ""Mars""}"
user2@mail.com,"User Two","{""age"": 24, ""job"": ""Time Traveller""}"
```