### PR TITLE
feat: Add shell script for demo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Visit [listmonk.app](https://listmonk.app)
 The latest image is available on DockerHub at `listmonk/listmonk:latest`. Use the sample [docker-compose.yml](https://github.com/knadh/listmonk/blob/master/docker-compose.yml) to run listmonk and Postgres DB with docker-compose as follows:
 
 #### Demo
-`docker-compose up -d demo-db demo-app`
+
+```bash
+mkdir listmonk-demo
+sh -c "$(curl -sSL https://raw.githubusercontent.com/knadh/listmonk/master/install-demo.sh)"
+```
 
 The demo does not persist Postgres after the containers are removed. DO NOT use this demo setup in production.
 

--- a/install-demo.sh
+++ b/install-demo.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+# Listmonk demo setup using `docker-compose`.
+#
+# See https://listmonk.app/docs/installation/ for detailed installation steps.
+#
+
+
+check_dependency() {
+	if ! command -v curl > /dev/null; then
+		echo "curl is not installed."
+		exit 1
+    fi
+
+	if ! command -v docker > /dev/null; then
+		echo "docker is not installed."
+		exit 1
+    fi
+
+	if ! command -v docker-compose > /dev/null; then
+		echo "docker-compose is not installed."
+		exit 1
+	fi
+}
+
+setup_containers() {
+    curl -o docker-compose.yml https://raw.githubusercontent.com/knadh/listmonk/master/docker-compose.yml
+    docker-compose up -d demo-db demo-app
+}
+
+show_output(){
+    echo -e "\nListmonk is now up and running. Visit http://localhost:9000 in your browser.\n"
+}
+
+
+check_dependency
+setup_containers
+show_output


### PR DESCRIPTION
Adds a simple `shell` script to setup a demo installation of `listmonk`. 