### PR TITLE
chore: Pass the binary path correctly to `make`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
 
     hooks:
       # stuff executables with static assets.
-      post: make pack-bin bin={{ .Path }}
+      post: make pack-bin BIN={{ .Path }}
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
Based on https://github.com/knadh/listmonk/commit/afef994e6d66b8e881924cb8cbe30f20e1507474
the binary variable `BIN` was changed. The same needs to be updated
in `.goreleaser.yml` config as well.