### PR TITLE
Adding Safe templating function for keeping HTML comments

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -353,6 +353,9 @@ func (m *Manager) TemplateFuncs(c *models.Campaign) template.FuncMap {
 		"L": func() *i18n.I18n {
 			return m.i18n
 		},
+		"Safe": func(safeHTML string) template.HTML {
+			return template.HTML(safeHTML)
+		},
 	}
 }
 


### PR DESCRIPTION
Closes #270
According to https://stackoverflow.com/questions/34348072/go-html-comments-are-not-rendered