### PR TITLE
fix: rename Github Token secret variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
           version: latest
           args: --parallelism 1 --rm-dist --skip-validate
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since `GITHUB_TOKEN` is automatically injected in build
pipelines, we don't need to generate and add our custom token here.