### PR TITLE
Fix: campaign field names

### DIFF
--- a/frontend/src/views/TemplateForm.vue
+++ b/frontend/src/views/TemplateForm.vue
@@ -13,7 +13,7 @@
         <section expanded class="modal-card-body">
             <b-field :label="$t('globals.fields.name')" label-position="on-border">
             <b-input :maxlength="200" :ref="'focus'" v-model="form.name"
-                placeholder="$t('globals.fields.name')" required></b-input>
+                :placeholder="$t('globals.fields.name')" required></b-input>
             </b-field>
 
             <b-field :label="$t('globals.fields.rawHTML')" label-position="on-border">

--- a/frontend/src/views/TemplateForm.vue
+++ b/frontend/src/views/TemplateForm.vue
@@ -16,7 +16,7 @@
                 :placeholder="$t('globals.fields.name')" required></b-input>
             </b-field>
 
-            <b-field :label="$t('globals.fields.rawHTML')" label-position="on-border">
+            <b-field :label="$t('templates.rawHTML')" label-position="on-border">
             <b-input v-model="form.body" type="textarea" required />
             </b-field>
 


### PR DESCRIPTION
Issue:

![image](https://user-images.githubusercontent.com/15109533/113013872-b8b7a900-9199-11eb-9233-1758ebda53d8.png)

1. Added : for placeholder property
2. Added `rawHTML` under `fields` namespace
https://github.com/knadh/listmonk/blob/6dbcfee0801148c23cbb0444d15c7dce28bd672d/frontend/src/views/TemplateForm.vue#L19