### PR TITLE
Prevent mistakes adding the OS and Arch on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ deps:
 # Build the backend to ./listmonk.
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -o ${BIN} -ldflags="-s -w -X 'main.buildString=${BUILDSTR}' -X 'main.versionString=${VERSION}'" cmd/*.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${BIN} -ldflags="-s -w -X 'main.buildString=${BUILDSTR}' -X 'main.versionString=${VERSION}'" cmd/*.go
 
 # Run the backend.
 .PHONY: run


### PR DESCRIPTION
After minutes trying understand why my build are not working, I found where I'm doing wrong, so, I build on Darwin and run the binary on Linux. Just to prevent this kinda of mistakes, I added the flags `GOOS` and `GOARCH` explicit on the Makefile.