### PR TITLE
Cleanup sample config

### DIFF
--- a/config-demo.toml
+++ b/config-demo.toml
@@ -1,15 +1,15 @@
 [app]
-    # Interface and port where the app will run its webserver.
-    address = "0.0.0.0:9000"
+# Interface and port where the app will run its webserver.
+address = "0.0.0.0:9000"
 
 # Database.
 [db]
-    host = "demo-db"
-    port = 5432
-    user = "listmonk"
-    password = "listmonk"
-    database = "listmonk"
-    ssl_mode = "disable"
-    max_open = 25
-    max_idle = 25
-    max_lifetime = "300s"
+host = "demo-db"
+port = 5432
+user = "listmonk"
+password = "listmonk"
+database = "listmonk"
+ssl_mode = "disable"
+max_open = 25
+max_idle = 25
+max_lifetime = "300s"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,6 +1,6 @@
 [app]
 # Interface and port where the app will run its webserver.
-address = "0.0.0.0:9000"
+address = "localhost:9000"
 
 # BasicAuth authentication for the admin dashboard. This will eventually
 # be replaced with a better multi-user, role-based authentication system.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,5 +1,8 @@
 [app]
-# Interface and port where the app will run its webserver.
+# Interface and port where the app will run its webserver.  The default value
+# of localhost will only listen to connections from the current machine. To
+# listen on all interfaces use '0.0.0.0'. To listen on the default web address
+# port, use port 80 (this will require running with elevated permissions).
 address = "localhost:9000"
 
 # BasicAuth authentication for the admin dashboard. This will eventually

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,22 +1,22 @@
 [app]
-    # Interface and port where the app will run its webserver.
-    address = "0.0.0.0:9000"
+# Interface and port where the app will run its webserver.
+address = "0.0.0.0:9000"
 
-    # BasicAuth authentication for the admin dashboard. This will eventually
-    # be replaced with a better multi-user, role-based authentication system.
-    # IMPORTANT: Leave both values empty to disable authentication on admin
-    # only where an external authentication is already setup.
-    admin_username = "listmonk"
-    admin_password = "listmonk"
+# BasicAuth authentication for the admin dashboard. This will eventually
+# be replaced with a better multi-user, role-based authentication system.
+# IMPORTANT: Leave both values empty to disable authentication on admin
+# only where an external authentication is already setup.
+admin_username = "listmonk"
+admin_password = "listmonk"
 
 # Database.
 [db]
-    host = "db"
-    port = 5432
-    user = "listmonk"
-    password = "listmonk"
-    database = "listmonk"
-    ssl_mode = "disable"
-    max_open = 25
-    max_idle = 25
-    max_lifetime = "300s"
+host = "db"
+port = 5432
+user = "listmonk"
+password = "listmonk"
+database = "listmonk"
+ssl_mode = "disable"
+max_open = 25
+max_idle = 25
+max_lifetime = "300s"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -11,7 +11,7 @@ admin_password = "listmonk"
 
 # Database.
 [db]
-host = "db"
+host = "localhost"
 port = 5432
 user = "listmonk"
 password = "listmonk"


### PR DESCRIPTION
See commit message comments for details. The TOML formatting wasn't invalid, it's just non-traditional and annoyed me a lot. The other two changes to sample configs are just sysadmin convenience and more safety out of the box.