### PR TITLE
[WIP] Refactor database methods behind interface

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -62,7 +62,7 @@ func handleGetDashboardCharts(c echo.Context) error {
 		out types.JSONText
 	)
 
-	if err := app.queries.GetDashboardCharts(&out); err != nil {
+	if err := app.store.GetDashboardCharts(&out); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching", "name", "dashboard charts", "error", pqErrMsg(err)))
 	}
@@ -77,7 +77,7 @@ func handleGetDashboardCounts(c echo.Context) error {
 		out types.JSONText
 	)
 
-	if err := app.queries.GetDashboardCounts(&out); err != nil {
+	if err := app.store.GetDashboardCounts(&out); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching", "name", "dashboard stats", "error", pqErrMsg(err)))
 	}

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -62,7 +62,7 @@ func handleGetDashboardCharts(c echo.Context) error {
 		out types.JSONText
 	)
 
-	if err := app.queries.GetDashboardCharts.Get(&out); err != nil {
+	if err := app.queries.GetDashboardCharts(&out); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching", "name", "dashboard charts", "error", pqErrMsg(err)))
 	}
@@ -77,7 +77,7 @@ func handleGetDashboardCounts(c echo.Context) error {
 		out types.JSONText
 	)
 
-	if err := app.queries.GetDashboardCounts.Get(&out); err != nil {
+	if err := app.queries.GetDashboardCounts(&out); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching", "name", "dashboard stats", "error", pqErrMsg(err)))
 	}

--- a/cmd/campaigns.go
+++ b/cmd/campaigns.go
@@ -140,11 +140,19 @@ func handleGetCampaigns(c echo.Context) error {
 	}
 
 	// Lazy load stats.
-	if err := out.Results.LoadStats(app.queries.GetCampaignStats); err != nil {
+	stats, err := app.queries.GetCampaignStats(out.Results.GetIDs())
+	if err != nil {
 		app.log.Printf("error fetching campaign stats: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
 				"name", "{globals.terms.campaign}", "error", pqErrMsg(err)))
+	}
+	for i, c := range stats {
+		if c.CampaignID == out.Results[i].CampaignID {
+			out.Results[i].Lists = c.Lists
+			out.Results[i].Views = c.Views
+			out.Results[i].Clicks = c.Clicks
+		}
 	}
 
 	if single {

--- a/cmd/campaigns.go
+++ b/cmd/campaigns.go
@@ -109,15 +109,16 @@ func handleGetCampaigns(c echo.Context) error {
 		order = sortDesc
 	}
 
-	stmt := fmt.Sprintf(app.queries.QueryCampaigns, orderBy, order)
-
 	// Unsafe to ignore scanning fields not present in models.Campaigns.
-	if err := db.Select(&out.Results, stmt, id, pq.StringArray(status), query, pg.Offset, pg.Limit); err != nil {
+	results, err := app.queries.QueryCampaigns(id, pg.Offset, pg.Limit, status, query, orderBy, order)
+	if err != nil {
 		app.log.Printf("error fetching campaigns: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
 				"name", "{globals.terms.campaign}", "error", pqErrMsg(err)))
 	}
+	out.Results = results
+
 	if single && len(out.Results) == 0 {
 		return echo.NewHTTPError(http.StatusBadRequest,
 			app.i18n.Ts("campaigns.notFound", "name", "{globals.terms.campaign}"))

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -214,7 +214,7 @@ func subscriberExists(next echo.HandlerFunc, params ...string) echo.HandlerFunc 
 		)
 
 		var exists bool
-		if err := app.queries.SubscriberExists(&exists, 0, subUUID); err != nil {
+		if err := app.store.SubscriberExists(&exists, 0, subUUID); err != nil {
 			app.log.Printf("error checking subscriber existence: %v", err)
 			return c.Render(http.StatusInternalServerError, tplMessage,
 				makeMsgTpl(app.i18n.T("public.errorTitle"), "",

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -214,7 +214,7 @@ func subscriberExists(next echo.HandlerFunc, params ...string) echo.HandlerFunc 
 		)
 
 		var exists bool
-		if err := app.queries.SubscriberExists.Get(&exists, 0, subUUID); err != nil {
+		if err := app.queries.SubscriberExists(&exists, 0, subUUID); err != nil {
 			app.log.Printf("error checking subscriber existence: %v", err)
 			return c.Render(http.StatusInternalServerError, tplMessage,
 				makeMsgTpl(app.i18n.T("public.errorTitle"), "",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -212,7 +212,7 @@ func initQueries(sqlFile string, db *sqlx.DB, fs stuffbin.FileSystem, prepareQue
 	}
 
 	// Prepare queries.
-	var q Queries
+	q := Queries{db: db}
 	if err := goyesqlx.ScanToStruct(&q, qMap, db.Unsafe()); err != nil {
 		lo.Fatalf("error preparing SQL queries: %v", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -325,9 +325,7 @@ func initCampaignManager(q *Queries, cs *constants, app *App) *manager.Manager {
 func initImporter(q *Queries, db *sqlx.DB, app *App) *subimporter.Importer {
 	return subimporter.New(
 		subimporter.Options{
-			UpsertStmt:         q.UpsertSubscriber.Stmt,
-			BlocklistStmt:      q.UpsertBlocklistSubscriber.Stmt,
-			UpdateListDateStmt: q.UpdateListsDate.Stmt,
+			Store: q,
 			NotifCB: func(subject string, data interface{}) error {
 				app.sendNotification(app.constants.NotifyEmails, subject, notifTplImport, data)
 				return nil

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/jmoiron/sqlx/types"
 	"github.com/knadh/goyesql/v2"
 	goyesqlx "github.com/knadh/goyesql/v2/sqlx"
 	"github.com/knadh/koanf"
@@ -222,16 +221,11 @@ func initQueries(sqlFile string, db *sqlx.DB, fs stuffbin.FileSystem, prepareQue
 }
 
 // initSettings loads settings from the DB.
-func initSettings(q *sqlx.Stmt) {
-	var s types.JSONText
-	if err := q.Get(&s); err != nil {
-		lo.Fatalf("error reading settings from DB: %s", pqErrMsg(err))
-	}
-
+func initSettings(settings json.RawMessage) {
 	// Setting keys are dot separated, eg: app.favicon_url. Unflatten them into
 	// nested maps {app: {favicon_url}}.
 	var out map[string]interface{}
-	if err := json.Unmarshal(s, &out); err != nil {
+	if err := json.Unmarshal(settings, &out); err != nil {
 		lo.Fatalf("error unmarshalling settings from DB: %v", err)
 	}
 	if err := ko.Load(confmap.Provider(out, "."), nil); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -283,7 +283,7 @@ func initI18n(lang string, fs stuffbin.FileSystem) *i18n.I18n {
 }
 
 // initCampaignManager initializes the campaign manager.
-func initCampaignManager(q *Queries, cs *constants, app *App) *manager.Manager {
+func initCampaignManager(s Store, cs *constants, app *App) *manager.Manager {
 	campNotifCB := func(subject string, data interface{}) error {
 		return app.sendNotification(cs.NotifyEmails, subject, notifTplCampaign, data)
 	}
@@ -311,15 +311,15 @@ func initCampaignManager(q *Queries, cs *constants, app *App) *manager.Manager {
 		SlidingWindow:         ko.Bool("app.message_sliding_window"),
 		SlidingWindowDuration: ko.Duration("app.message_sliding_window_duration"),
 		SlidingWindowRate:     ko.Int("app.message_sliding_window_rate"),
-	}, newManagerDB(q), campNotifCB, app.i18n, lo)
+	}, newManagerDB(s), campNotifCB, app.i18n, lo)
 
 }
 
 // initImporter initializes the bulk subscriber importer.
-func initImporter(q *Queries, db *sqlx.DB, app *App) *subimporter.Importer {
+func initImporter(s Store, db *sqlx.DB, app *App) *subimporter.Importer {
 	return subimporter.New(
 		subimporter.Options{
-			Store: q,
+			Store: s,
 			NotifCB: func(subject string, data interface{}) error {
 				app.sendNotification(app.constants.NotifyEmails, subject, notifTplImport, data)
 				return nil

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -47,7 +47,7 @@ func install(lastVer string, db *sqlx.DB, fs stuffbin.FileSystem, prompt bool) {
 	}
 
 	// Load the queries.
-	var q Queries
+	q := Queries{db: db}
 	if err := goyesqlx.ScanToStruct(&q, qMap, db.Unsafe()); err != nil {
 		lo.Fatalf("error loading SQL queries: %v", err)
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -77,22 +77,24 @@ func install(lastVer string, db *sqlx.DB, fs stuffbin.FileSystem, prompt bool) {
 	}
 
 	// Sample subscriber.
-	if _, err := q.UpsertSubscriber.Exec(
+	if err := q.UpsertSubscriber(
 		uuid.Must(uuid.NewV4()),
 		"john@example.com",
 		"John Doe",
-		`{"type": "known", "good": true, "city": "Bengaluru"}`,
+		models.SubscriberAttribs{"type": "known", "good": true, "city": "Bengaluru"},
 		pq.Int64Array{int64(defList)},
-		true); err != nil {
+		true,
+		nil); err != nil {
 		lo.Fatalf("Error creating subscriber: %v", err)
 	}
-	if _, err := q.UpsertSubscriber.Exec(
+	if err := q.UpsertSubscriber(
 		uuid.Must(uuid.NewV4()),
 		"anon@example.com",
 		"Anon Doe",
-		`{"type": "unknown", "good": true, "city": "Bengaluru"}`,
+		models.SubscriberAttribs{"type": "unknown", "good": true, "city": "Bengaluru"},
 		pq.Int64Array{int64(optinList)},
-		true); err != nil {
+		true,
+		nil); err != nil {
 		lo.Fatalf("Error creating subscriber: %v", err)
 	}
 

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -50,7 +50,7 @@ func handleGetLists(c echo.Context) error {
 		order = sortAsc
 	}
 
-	results, err := app.queries.QueryLists(listID, pg.Offset, pg.Limit, orderBy, order)
+	results, err := app.store.QueryLists(listID, pg.Offset, pg.Limit, orderBy, order)
 	if err != nil {
 		app.log.Printf("error fetching lists: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -110,7 +110,7 @@ func handleCreateList(c echo.Context) error {
 	// Insert and read ID.
 	var newID int
 	o.UUID = uu.String()
-	if err := app.queries.CreateList(&newID,
+	if err := app.store.CreateList(&newID,
 		o.UUID,
 		o.Name,
 		o.Type,
@@ -145,7 +145,7 @@ func handleUpdateList(c echo.Context) error {
 		return err
 	}
 
-	res, err := app.queries.UpdateList(id,
+	res, err := app.store.UpdateList(id,
 		o.Name, o.Type, o.Optin, pq.StringArray(normalizeTags(o.Tags)))
 	if err != nil {
 		app.log.Printf("error updating list: %v", err)
@@ -179,7 +179,7 @@ func handleDeleteLists(c echo.Context) error {
 		ids = append(ids, id)
 	}
 
-	if err := app.queries.DeleteLists(ids); err != nil {
+	if err := app.store.DeleteLists(ids); err != nil {
 		app.log.Printf("error deleting lists: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorDeleting",

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -108,7 +108,7 @@ func handleCreateList(c echo.Context) error {
 	// Insert and read ID.
 	var newID int
 	o.UUID = uu.String()
-	if err := app.queries.CreateList.Get(&newID,
+	if err := app.queries.CreateList(&newID,
 		o.UUID,
 		o.Name,
 		o.Type,
@@ -143,7 +143,7 @@ func handleUpdateList(c echo.Context) error {
 		return err
 	}
 
-	res, err := app.queries.UpdateList.Exec(id,
+	res, err := app.queries.UpdateList(id,
 		o.Name, o.Type, o.Optin, pq.StringArray(normalizeTags(o.Tags)))
 	if err != nil {
 		app.log.Printf("error updating list: %v", err)
@@ -177,7 +177,7 @@ func handleDeleteLists(c echo.Context) error {
 		ids = append(ids, id)
 	}
 
-	if _, err := app.queries.DeleteLists.Exec(ids); err != nil {
+	if err := app.queries.DeleteLists(ids); err != nil {
 		app.log.Printf("error deleting lists: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorDeleting",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ const (
 type App struct {
 	fs         stuffbin.FileSystem
 	db         *sqlx.DB
-	queries    *Queries
+	store      Store
 	constants  *constants
 	manager    *manager.Manager
 	importer   *subimporter.Importer
@@ -63,10 +63,10 @@ var (
 	lo     = log.New(io.MultiWriter(os.Stdout, bufLog), "",
 		log.Ldate|log.Ltime|log.Lshortfile)
 
-	ko      = koanf.New(".")
-	fs      stuffbin.FileSystem
-	db      *sqlx.DB
-	queries *Queries
+	ko    = koanf.New(".")
+	fs    stuffbin.FileSystem
+	db    *sqlx.DB
+	store Store
 
 	buildString   string
 	versionString string
@@ -158,9 +158,9 @@ func main() {
 	// Load i18n language map.
 	app.i18n = initI18n(app.constants.Lang, fs)
 
-	_, app.queries = initQueries(queryFilePath, db, fs, true)
-	app.manager = initCampaignManager(app.queries, app.constants, app)
-	app.importer = initImporter(app.queries, db, app)
+	_, app.store = initQueries(queryFilePath, db, fs, true)
+	app.manager = initCampaignManager(app.store, app.constants, app)
+	app.importer = initImporter(app.store, db, app)
 	app.notifTpls = initNotifTemplates("/email-templates/*.html", fs, app.i18n, app.constants)
 
 	// Initialize the default SMTP (`email`) messenger.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,7 +135,11 @@ func init() {
 	_, queries := initQueries(queryFilePath, db, fs, true)
 
 	// Load settings from DB.
-	initSettings(queries.GetSettings)
+	settings, err := queries.GetSettings()
+	if err != nil {
+		lo.Fatal(err)
+	}
+	initSettings(settings)
 }
 
 func main() {

--- a/cmd/manager_db.go
+++ b/cmd/manager_db.go
@@ -9,19 +9,19 @@ import (
 // runnerDB implements runner.DataSource over the primary
 // database.
 type runnerDB struct {
-	queries *Queries
+	store Store
 }
 
-func newManagerDB(q *Queries) *runnerDB {
+func newManagerDB(s Store) *runnerDB {
 	return &runnerDB{
-		queries: q,
+		store: s,
 	}
 }
 
 // NextCampaigns retrieves active campaigns ready to be processed.
 func (r *runnerDB) NextCampaigns(excludeIDs []int64) ([]*models.Campaign, error) {
 	var out []*models.Campaign
-	err := r.queries.NextCampaigns(&out, pq.Int64Array(excludeIDs))
+	err := r.store.NextCampaigns(&out, pq.Int64Array(excludeIDs))
 	return out, err
 }
 
@@ -31,20 +31,20 @@ func (r *runnerDB) NextCampaigns(excludeIDs []int64) ([]*models.Campaign, error)
 // batch above that.
 func (r *runnerDB) NextSubscribers(campID, limit int) ([]models.Subscriber, error) {
 	var out []models.Subscriber
-	err := r.queries.NextCampaignSubscribers(&out, campID, limit)
+	err := r.store.NextCampaignSubscribers(&out, campID, limit)
 	return out, err
 }
 
 // GetCampaign fetches a campaign from the database.
 func (r *runnerDB) GetCampaign(campID int) (*models.Campaign, error) {
 	var out = &models.Campaign{}
-	err := r.queries.GetCampaign(out, campID, nil)
+	err := r.store.GetCampaign(out, campID, nil)
 	return out, err
 }
 
 // UpdateCampaignStatus updates a campaign's status.
 func (r *runnerDB) UpdateCampaignStatus(campID int, status string) error {
-	_, err := r.queries.UpdateCampaignStatus(campID, status)
+	_, err := r.store.UpdateCampaignStatus(campID, status)
 	return err
 }
 
@@ -58,7 +58,7 @@ func (r *runnerDB) CreateLink(url string) (string, error) {
 	}
 
 	var out string
-	if err := r.queries.CreateLink(&out, uu, url); err != nil {
+	if err := r.store.CreateLink(&out, uu, url); err != nil {
 		return "", err
 	}
 

--- a/cmd/manager_db.go
+++ b/cmd/manager_db.go
@@ -21,7 +21,7 @@ func newManagerDB(q *Queries) *runnerDB {
 // NextCampaigns retrieves active campaigns ready to be processed.
 func (r *runnerDB) NextCampaigns(excludeIDs []int64) ([]*models.Campaign, error) {
 	var out []*models.Campaign
-	err := r.queries.NextCampaigns.Select(&out, pq.Int64Array(excludeIDs))
+	err := r.queries.NextCampaigns(&out, pq.Int64Array(excludeIDs))
 	return out, err
 }
 
@@ -31,20 +31,20 @@ func (r *runnerDB) NextCampaigns(excludeIDs []int64) ([]*models.Campaign, error)
 // batch above that.
 func (r *runnerDB) NextSubscribers(campID, limit int) ([]models.Subscriber, error) {
 	var out []models.Subscriber
-	err := r.queries.NextCampaignSubscribers.Select(&out, campID, limit)
+	err := r.queries.NextCampaignSubscribers(&out, campID, limit)
 	return out, err
 }
 
 // GetCampaign fetches a campaign from the database.
 func (r *runnerDB) GetCampaign(campID int) (*models.Campaign, error) {
 	var out = &models.Campaign{}
-	err := r.queries.GetCampaign.Get(out, campID, nil)
+	err := r.queries.GetCampaign(out, campID, nil)
 	return out, err
 }
 
 // UpdateCampaignStatus updates a campaign's status.
 func (r *runnerDB) UpdateCampaignStatus(campID int, status string) error {
-	_, err := r.queries.UpdateCampaignStatus.Exec(campID, status)
+	_, err := r.queries.UpdateCampaignStatus(campID, status)
 	return err
 }
 
@@ -58,7 +58,7 @@ func (r *runnerDB) CreateLink(url string) (string, error) {
 	}
 
 	var out string
-	if err := r.queries.CreateLink.Get(&out, uu, url); err != nil {
+	if err := r.queries.CreateLink(&out, uu, url); err != nil {
 		return "", err
 	}
 

--- a/cmd/media.go
+++ b/cmd/media.go
@@ -99,7 +99,7 @@ func handleUploadMedia(c echo.Context) error {
 	}
 
 	// Write to the DB.
-	if _, err := app.queries.InsertMedia.Exec(uu, fName, thumbfName, app.constants.MediaProvider); err != nil {
+	if err := app.queries.InsertMedia(uu, fName, thumbfName, app.constants.MediaProvider); err != nil {
 		cleanUp = true
 		app.log.Printf("error inserting uploaded file to db: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -116,7 +116,7 @@ func handleGetMedia(c echo.Context) error {
 		out = []media.Media{}
 	)
 
-	if err := app.queries.GetMedia.Select(&out, app.constants.MediaProvider); err != nil {
+	if err := app.queries.GetMedia(&out, app.constants.MediaProvider); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
 				"name", "{globals.terms.media}", "error", pqErrMsg(err)))
@@ -142,7 +142,7 @@ func handleDeleteMedia(c echo.Context) error {
 	}
 
 	var m media.Media
-	if err := app.queries.DeleteMedia.Get(&m, id); err != nil {
+	if err := app.queries.DeleteMedia(&m, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorDeleting",
 				"name", "{globals.terms.media}", "error", pqErrMsg(err)))

--- a/cmd/media.go
+++ b/cmd/media.go
@@ -99,7 +99,7 @@ func handleUploadMedia(c echo.Context) error {
 	}
 
 	// Write to the DB.
-	if err := app.queries.InsertMedia(uu, fName, thumbfName, app.constants.MediaProvider); err != nil {
+	if err := app.store.InsertMedia(uu, fName, thumbfName, app.constants.MediaProvider); err != nil {
 		cleanUp = true
 		app.log.Printf("error inserting uploaded file to db: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -116,7 +116,7 @@ func handleGetMedia(c echo.Context) error {
 		out = []media.Media{}
 	)
 
-	if err := app.queries.GetMedia(&out, app.constants.MediaProvider); err != nil {
+	if err := app.store.GetMedia(&out, app.constants.MediaProvider); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
 				"name", "{globals.terms.media}", "error", pqErrMsg(err)))
@@ -142,7 +142,7 @@ func handleDeleteMedia(c echo.Context) error {
 	}
 
 	var m media.Media
-	if err := app.queries.DeleteMedia(&m, id); err != nil {
+	if err := app.store.DeleteMedia(&m, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorDeleting",
 				"name", "{globals.terms.media}", "error", pqErrMsg(err)))

--- a/cmd/public.go
+++ b/cmd/public.go
@@ -104,7 +104,7 @@ func handleViewCampaignMessage(c echo.Context) error {
 
 	// Get the campaign.
 	var camp models.Campaign
-	if err := app.queries.GetCampaign(&camp, 0, &campUUID); err != nil {
+	if err := app.store.GetCampaign(&camp, 0, &campUUID); err != nil {
 		if err == sql.ErrNoRows {
 			return c.Render(http.StatusNotFound, tplMessage,
 				makeMsgTpl(app.i18n.T("public.notFoundTitle"), "",
@@ -176,7 +176,7 @@ func handleSubscriptionPage(c echo.Context) error {
 			blocklist = false
 		}
 
-		if err := app.queries.Unsubscribe(campUUID, subUUID, blocklist); err != nil {
+		if err := app.store.Unsubscribe(campUUID, subUUID, blocklist); err != nil {
 			app.log.Printf("error unsubscribing: %v", err)
 			return c.Render(http.StatusInternalServerError, tplMessage,
 				makeMsgTpl(app.i18n.T("public.errorTitle"), "",
@@ -222,7 +222,7 @@ func handleOptinPage(c echo.Context) error {
 	}
 
 	// Get the list of subscription lists where the subscriber hasn't confirmed.
-	if err := app.queries.GetSubscriberLists(&out.Lists, 0, subUUID,
+	if err := app.store.GetSubscriberLists(&out.Lists, 0, subUUID,
 		nil, pq.StringArray(out.ListUUIDs), models.SubscriptionStatusUnconfirmed, ""); err != nil {
 		app.log.Printf("error fetching lists for opt-in: %s", pqErrMsg(err))
 
@@ -240,7 +240,7 @@ func handleOptinPage(c echo.Context) error {
 
 	// Confirm.
 	if confirm {
-		if err := app.queries.ConfirmSubscriptionOptin(subUUID, pq.StringArray(out.ListUUIDs)); err != nil {
+		if err := app.store.ConfirmSubscriptionOptin(subUUID, pq.StringArray(out.ListUUIDs)); err != nil {
 			app.log.Printf("error unsubscribing: %v", err)
 			return c.Render(http.StatusInternalServerError, tplMessage,
 				makeMsgTpl(app.i18n.T("public.errorTitle"), "",
@@ -270,7 +270,7 @@ func handleSubscriptionFormPage(c echo.Context) error {
 
 	// Get all public lists.
 	var lists []models.List
-	if err := app.queries.GetLists(&lists, models.ListTypePublic); err != nil {
+	if err := app.store.GetLists(&lists, models.ListTypePublic); err != nil {
 		app.log.Printf("error fetching public lists for form: %s", pqErrMsg(err))
 		return c.Render(http.StatusInternalServerError, tplMessage,
 			makeMsgTpl(app.i18n.T("public.errorTitle"), "",
@@ -362,7 +362,7 @@ func handleLinkRedirect(c echo.Context) error {
 	}
 
 	var url string
-	if err := app.queries.RegisterLinkClick(&url, linkUUID, campUUID, subUUID); err != nil {
+	if err := app.store.RegisterLinkClick(&url, linkUUID, campUUID, subUUID); err != nil {
 		if pqErr, ok := err.(*pq.Error); ok && pqErr.Column == "link_id" {
 			return c.Render(http.StatusNotFound, tplMessage,
 				makeMsgTpl(app.i18n.T("public.errorTitle"), "",
@@ -396,7 +396,7 @@ func handleRegisterCampaignView(c echo.Context) error {
 
 	// Exclude dummy hits from template previews.
 	if campUUID != dummyUUID && subUUID != dummyUUID {
-		if err := app.queries.RegisterCampaignView(campUUID, subUUID); err != nil {
+		if err := app.store.RegisterCampaignView(campUUID, subUUID); err != nil {
 			app.log.Printf("error registering campaign view: %s", err)
 		}
 	}
@@ -483,7 +483,7 @@ func handleWipeSubscriberData(c echo.Context) error {
 				app.i18n.Ts("public.invalidFeature")))
 	}
 
-	if err := app.queries.DeleteSubscribers(nil, pq.StringArray{subUUID}); err != nil {
+	if err := app.store.DeleteSubscribers(nil, pq.StringArray{subUUID}); err != nil {
 		app.log.Printf("error wiping subscriber data: %s", err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
 			makeMsgTpl(app.i18n.T("public.errorTitle"), "",

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -86,7 +86,7 @@ type Queries struct {
 	createLink        *sqlx.Stmt `query:"create-link"`
 	registerLinkClick *sqlx.Stmt `query:"register-link-click"`
 
-	GetSettings    *sqlx.Stmt `query:"get-settings"`
+	getSettings    *sqlx.Stmt `query:"get-settings"`
 	updateSettings *sqlx.Stmt `query:"update-settings"`
 
 	// GetStats *sqlx.Stmt `query:"get-stats"`
@@ -433,6 +433,14 @@ func (q *Queries) GetCampaignStats(campaignIDs []int) ([]models.CampaignMeta, er
 	}
 
 	return meta, nil
+}
+
+func (q *Queries) GetSettings() (json.RawMessage, error) {
+	var s types.JSONText
+	if err := q.getSettings.Get(&s); err != nil {
+		return nil, fmt.Errorf("error reading settings from DB: %s", pqErrMsg(err))
+	}
+	return json.RawMessage(s), nil
 }
 
 // dbConf contains database config required for connecting to a DB.

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -50,7 +50,7 @@ type Queries struct {
 	UnsubscribeSubscribersFromListsByQuery string `query:"unsubscribe-subscribers-from-lists-by-query"`
 
 	createList      *sqlx.Stmt `query:"create-list"`
-	QueryLists      string     `query:"query-lists"`
+	queryLists      string     `query:"query-lists"`
 	getLists        *sqlx.Stmt `query:"get-lists"`
 	getListsByOptin *sqlx.Stmt `query:"get-lists-by-optin"`
 	updateList      *sqlx.Stmt `query:"update-list"`
@@ -253,7 +253,7 @@ func (q *Queries) CreateCampaign(
 	templateID int,
 	listIDs pq.Int64Array,
 ) error {
-	_, err := q.deleteLists.Exec(id, uuid, campaignType, name, subject, fromEmail, body, altBody, contentType, sendAt, tags, messenger, templateID, listIDs)
+	_, err := q.createCampaign.Exec(id, uuid, campaignType, name, subject, fromEmail, body, altBody, contentType, sendAt, tags, messenger, templateID, listIDs)
 	return err
 }
 
@@ -358,6 +358,17 @@ func (q *Queries) RegisterLinkClick(url *string, linkUUID, campUUID, subUUID str
 func (q *Queries) UpdateSettings(settings []byte) error {
 	_, err := q.updateSettings.Exec(settings)
 	return err
+}
+
+func (q *Queries) QueryLists(listID, offset, limit int, orderBy, order string) ([]models.List, error) {
+	query := fmt.Sprintf(q.queryLists, orderBy, order)
+
+	var results []models.List
+	if err := db.Select(&results, query, listID, offset, limit); err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }
 
 // dbConf contains database config required for connecting to a DB.

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -3,35 +3,41 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/jmoiron/sqlx/types"
+	"github.com/knadh/listmonk/internal/media"
+	"github.com/knadh/listmonk/models"
 	"github.com/lib/pq"
+	null "gopkg.in/volatiletech/null.v6"
 )
 
 // Queries contains all prepared SQL queries.
 type Queries struct {
-	GetDashboardCharts *sqlx.Stmt `query:"get-dashboard-charts"`
-	GetDashboardCounts *sqlx.Stmt `query:"get-dashboard-counts"`
+	getDashboardCharts *sqlx.Stmt `query:"get-dashboard-charts"`
+	getDashboardCounts *sqlx.Stmt `query:"get-dashboard-counts"`
 
-	InsertSubscriber                *sqlx.Stmt `query:"insert-subscriber"`
+	insertSubscriber                *sqlx.Stmt `query:"insert-subscriber"`
 	UpsertSubscriber                *sqlx.Stmt `query:"upsert-subscriber"`
 	UpsertBlocklistSubscriber       *sqlx.Stmt `query:"upsert-blocklist-subscriber"`
-	GetSubscriber                   *sqlx.Stmt `query:"get-subscriber"`
-	GetSubscribersByEmails          *sqlx.Stmt `query:"get-subscribers-by-emails"`
-	GetSubscriberLists              *sqlx.Stmt `query:"get-subscriber-lists"`
+	getSubscriber                   *sqlx.Stmt `query:"get-subscriber"`
+	getSubscribersByEmails          *sqlx.Stmt `query:"get-subscribers-by-emails"`
+	getSubscriberLists              *sqlx.Stmt `query:"get-subscriber-lists"`
 	GetSubscriberListsLazy          *sqlx.Stmt `query:"get-subscriber-lists-lazy"`
-	SubscriberExists                *sqlx.Stmt `query:"subscriber-exists"`
-	UpdateSubscriber                *sqlx.Stmt `query:"update-subscriber"`
-	BlocklistSubscribers            *sqlx.Stmt `query:"blocklist-subscribers"`
-	AddSubscribersToLists           *sqlx.Stmt `query:"add-subscribers-to-lists"`
-	DeleteSubscriptions             *sqlx.Stmt `query:"delete-subscriptions"`
-	ConfirmSubscriptionOptin        *sqlx.Stmt `query:"confirm-subscription-optin"`
-	UnsubscribeSubscribersFromLists *sqlx.Stmt `query:"unsubscribe-subscribers-from-lists"`
-	DeleteSubscribers               *sqlx.Stmt `query:"delete-subscribers"`
-	Unsubscribe                     *sqlx.Stmt `query:"unsubscribe"`
-	ExportSubscriberData            *sqlx.Stmt `query:"export-subscriber-data"`
+	subscriberExists                *sqlx.Stmt `query:"subscriber-exists"`
+	updateSubscriber                *sqlx.Stmt `query:"update-subscriber"`
+	blocklistSubscribers            *sqlx.Stmt `query:"blocklist-subscribers"`
+	addSubscribersToLists           *sqlx.Stmt `query:"add-subscribers-to-lists"`
+	deleteSubscriptions             *sqlx.Stmt `query:"delete-subscriptions"`
+	confirmSubscriptionOptin        *sqlx.Stmt `query:"confirm-subscription-optin"`
+	unsubscribeSubscribersFromLists *sqlx.Stmt `query:"unsubscribe-subscribers-from-lists"`
+	deleteSubscribers               *sqlx.Stmt `query:"delete-subscribers"`
+	unsubscribe                     *sqlx.Stmt `query:"unsubscribe"`
+	exportSubscriberData            *sqlx.Stmt `query:"export-subscriber-data"`
 
 	// Non-prepared arbitrary subscriber queries.
 	QuerySubscribers                       string `query:"query-subscribers"`
@@ -43,46 +49,315 @@ type Queries struct {
 	DeleteSubscriptionsByQuery             string `query:"delete-subscriptions-by-query"`
 	UnsubscribeSubscribersFromListsByQuery string `query:"unsubscribe-subscribers-from-lists-by-query"`
 
-	CreateList      *sqlx.Stmt `query:"create-list"`
+	createList      *sqlx.Stmt `query:"create-list"`
 	QueryLists      string     `query:"query-lists"`
-	GetLists        *sqlx.Stmt `query:"get-lists"`
-	GetListsByOptin *sqlx.Stmt `query:"get-lists-by-optin"`
-	UpdateList      *sqlx.Stmt `query:"update-list"`
+	getLists        *sqlx.Stmt `query:"get-lists"`
+	getListsByOptin *sqlx.Stmt `query:"get-lists-by-optin"`
+	updateList      *sqlx.Stmt `query:"update-list"`
 	UpdateListsDate *sqlx.Stmt `query:"update-lists-date"`
-	DeleteLists     *sqlx.Stmt `query:"delete-lists"`
+	deleteLists     *sqlx.Stmt `query:"delete-lists"`
 
-	CreateCampaign           *sqlx.Stmt `query:"create-campaign"`
+	createCampaign           *sqlx.Stmt `query:"create-campaign"`
 	QueryCampaigns           string     `query:"query-campaigns"`
-	GetCampaign              *sqlx.Stmt `query:"get-campaign"`
-	GetCampaignForPreview    *sqlx.Stmt `query:"get-campaign-for-preview"`
+	getCampaign              *sqlx.Stmt `query:"get-campaign"`
+	getCampaignForPreview    *sqlx.Stmt `query:"get-campaign-for-preview"`
 	GetCampaignStats         *sqlx.Stmt `query:"get-campaign-stats"`
-	GetCampaignStatus        *sqlx.Stmt `query:"get-campaign-status"`
-	NextCampaigns            *sqlx.Stmt `query:"next-campaigns"`
-	NextCampaignSubscribers  *sqlx.Stmt `query:"next-campaign-subscribers"`
-	GetOneCampaignSubscriber *sqlx.Stmt `query:"get-one-campaign-subscriber"`
-	UpdateCampaign           *sqlx.Stmt `query:"update-campaign"`
-	UpdateCampaignStatus     *sqlx.Stmt `query:"update-campaign-status"`
-	UpdateCampaignCounts     *sqlx.Stmt `query:"update-campaign-counts"`
-	RegisterCampaignView     *sqlx.Stmt `query:"register-campaign-view"`
-	DeleteCampaign           *sqlx.Stmt `query:"delete-campaign"`
+	getCampaignStatus        *sqlx.Stmt `query:"get-campaign-status"`
+	nextCampaigns            *sqlx.Stmt `query:"next-campaigns"`
+	nextCampaignSubscribers  *sqlx.Stmt `query:"next-campaign-subscribers"`
+	getOneCampaignSubscriber *sqlx.Stmt `query:"get-one-campaign-subscriber"`
+	updateCampaign           *sqlx.Stmt `query:"update-campaign"`
+	updateCampaignStatus     *sqlx.Stmt `query:"update-campaign-status"`
+	updateCampaignCounts     *sqlx.Stmt `query:"update-campaign-counts"`
+	registerCampaignView     *sqlx.Stmt `query:"register-campaign-view"`
+	deleteCampaign           *sqlx.Stmt `query:"delete-campaign"`
 
-	InsertMedia *sqlx.Stmt `query:"insert-media"`
-	GetMedia    *sqlx.Stmt `query:"get-media"`
-	DeleteMedia *sqlx.Stmt `query:"delete-media"`
+	insertMedia *sqlx.Stmt `query:"insert-media"`
+	getMedia    *sqlx.Stmt `query:"get-media"`
+	deleteMedia *sqlx.Stmt `query:"delete-media"`
 
-	CreateTemplate     *sqlx.Stmt `query:"create-template"`
-	GetTemplates       *sqlx.Stmt `query:"get-templates"`
-	UpdateTemplate     *sqlx.Stmt `query:"update-template"`
-	SetDefaultTemplate *sqlx.Stmt `query:"set-default-template"`
-	DeleteTemplate     *sqlx.Stmt `query:"delete-template"`
+	createTemplate     *sqlx.Stmt `query:"create-template"`
+	getTemplates       *sqlx.Stmt `query:"get-templates"`
+	updateTemplate     *sqlx.Stmt `query:"update-template"`
+	setDefaultTemplate *sqlx.Stmt `query:"set-default-template"`
+	deleteTemplate     *sqlx.Stmt `query:"delete-template"`
 
-	CreateLink        *sqlx.Stmt `query:"create-link"`
-	RegisterLinkClick *sqlx.Stmt `query:"register-link-click"`
+	createLink        *sqlx.Stmt `query:"create-link"`
+	registerLinkClick *sqlx.Stmt `query:"register-link-click"`
 
 	GetSettings    *sqlx.Stmt `query:"get-settings"`
-	UpdateSettings *sqlx.Stmt `query:"update-settings"`
+	updateSettings *sqlx.Stmt `query:"update-settings"`
 
 	// GetStats *sqlx.Stmt `query:"get-stats"`
+}
+
+func (q *Queries) GetDashboardCharts(c *types.JSONText) error {
+	return q.getDashboardCharts.Get(c)
+}
+
+func (q *Queries) GetDashboardCounts(c *types.JSONText) error {
+	return q.getDashboardCounts.Get(c)
+}
+
+func (q *Queries) InsertSubscriber(
+	id *int,
+	uuid, email, name, status string,
+	attribs models.SubscriberAttribs,
+	lists pq.Int64Array,
+	listUUIDs pq.StringArray,
+	subStatus string,
+) error {
+	return q.insertSubscriber.Get(&id, uuid, email, name, status, attribs, lists, listUUIDs, subStatus)
+}
+
+func (q *Queries) GetSubscriber(s *models.Subscribers, id int, uuid, email string) error {
+	return q.getSubscriber.Select(s, id, uuid, email)
+}
+
+func (q *Queries) GetSubscribersByEmails(s *models.Subscribers, emails pq.StringArray) error {
+	return q.getSubscribersByEmails.Select(s, emails)
+}
+
+func (q *Queries) GetSubscriberLists(
+	lists *[]models.List,
+	id int, uuid string,
+	listIDs pq.Int64Array,
+	listUUIDs pq.StringArray,
+	subStatus, optin string,
+) error {
+	return q.getSubscriberLists.Select(lists, id, uuid, listIDs, listUUIDs, subStatus, optin)
+}
+
+func (q *Queries) SubscriberExists(
+	exists *bool,
+	id int, uuid string,
+) error {
+	return q.subscriberExists.Select(exists, id, uuid)
+}
+
+func (q *Queries) UpdateSubscriber(
+	id int64,
+	email, name, status string,
+	attribs json.RawMessage,
+	lists pq.Int64Array,
+) error {
+	_, err := q.updateSubscriber.Exec(id, email, name, status, attribs, lists)
+	return err
+}
+
+func (q *Queries) BlocklistSubscribers(
+	list pq.Int64Array,
+) error {
+	_, err := q.blocklistSubscribers.Exec(list)
+	return err
+}
+
+func (q *Queries) AddSubscribersToLists(
+	subscribers, lists pq.Int64Array,
+) error {
+	_, err := q.blocklistSubscribers.Exec(subscribers, lists)
+	return err
+}
+
+func (q *Queries) DeleteSubscriptions(
+	subscribers, lists pq.Int64Array,
+) error {
+	_, err := q.deleteSubscriptions.Exec(subscribers, lists)
+	return err
+}
+
+func (q *Queries) UnsubscribeSubscribersFromLists(
+	subscribers, lists pq.Int64Array,
+) error {
+	_, err := q.unsubscribeSubscribersFromLists.Exec(subscribers, lists)
+	return err
+}
+
+func (q *Queries) ConfirmSubscriptionOptin(
+	subUUID string, listUUIDs pq.StringArray,
+) error {
+	_, err := q.confirmSubscriptionOptin.Exec(subUUID, listUUIDs)
+	return err
+}
+
+func (q *Queries) DeleteSubscribers(
+	subIDs pq.Int64Array, subUUIDs pq.StringArray,
+) error {
+	_, err := q.deleteSubscribers.Exec(subIDs, subUUIDs)
+	return err
+}
+
+func (q *Queries) Unsubscribe(
+	campaignUUID, subUUID string,
+	blocklist bool,
+) error {
+	_, err := q.unsubscribe.Exec(campaignUUID, subUUID, blocklist)
+	return err
+}
+
+func (q *Queries) ExportSubscriberData(
+	data interface{},
+	id int64,
+	uuidOrNil interface{},
+) error {
+	return q.exportSubscriberData.Get(data, id, uuidOrNil)
+}
+
+func (q *Queries) CreateList(
+	list *int,
+	uuid interface{},
+	name, listType, optin string,
+	tags pq.StringArray,
+) error {
+	return q.exportSubscriberData.Get(list, uuid, name, listType, optin, tags)
+}
+
+func (q *Queries) GetLists(
+	lists *[]models.List,
+	listType string,
+) error {
+	return q.getLists.Select(lists, listType)
+}
+
+func (q *Queries) GetListsByOptin(
+	lists *[]models.List,
+	optin string,
+	listIDs pq.Int64Array,
+	listUUIDs pq.StringArray,
+) error {
+	return q.getListsByOptin.Select(lists, optin, listIDs, listUUIDs)
+}
+
+func (q *Queries) UpdateList(
+	id int,
+	name, listType, optin string,
+	tags pq.StringArray,
+) (sql.Result, error) {
+	return q.updateList.Exec(id, name, listType, optin, tags)
+}
+
+func (q *Queries) DeleteLists(ids pq.Int64Array) error {
+	_, err := q.deleteLists.Exec(ids)
+	return err
+}
+
+func (q *Queries) CreateCampaign(
+	id *int,
+	uuid uuid.UUID,
+	campaignType, name, subject, fromEmail, body string,
+	altBody null.String,
+	contentType string,
+	sendAt null.Time,
+	tags pq.StringArray,
+	messenger string,
+	templateID int,
+	listIDs pq.Int64Array,
+) error {
+	_, err := q.deleteLists.Exec(id, uuid, campaignType, name, subject, fromEmail, body, altBody, contentType, sendAt, tags, messenger, templateID, listIDs)
+	return err
+}
+
+func (q *Queries) GetCampaign(campaign *models.Campaign, id int, uuid *string) error {
+	_, err := q.getCampaign.Exec(campaign, id, uuid)
+	return err
+}
+
+func (q *Queries) GetCampaignForPreview(campaign *models.Campaign, id int) error {
+	_, err := q.getCampaignForPreview.Exec(campaign, id)
+	return err
+}
+
+func (q *Queries) GetCampaignStatus(stats interface{}, status string) error {
+	return q.getCampaignStatus.Select(stats, status)
+}
+
+func (q *Queries) NextCampaigns(c *[]*models.Campaign, excludeIDs pq.Int64Array) error {
+	return q.nextCampaigns.Select(c, excludeIDs)
+}
+
+func (q *Queries) NextCampaignSubscribers(subs *[]models.Subscriber, campID, limit int) error {
+	return q.nextCampaignSubscribers.Select(subs, campID, limit)
+}
+
+func (q *Queries) UpdateCampaign(
+	id int,
+	name, subject, fromEmail, body string,
+	altBody null.String,
+	contentType string,
+	sendAt null.Time,
+	sendLater bool,
+	tags pq.StringArray,
+	messenger string,
+	templateID int,
+	listIDs pq.Int64Array,
+) error {
+	_, err := q.updateCampaign.Exec(id, name, subject, fromEmail, body, altBody, contentType, sendAt, sendLater, tags, messenger, templateID, listIDs)
+	return err
+}
+
+func (q *Queries) UpdateCampaignStatus(
+	id int,
+	status string,
+) (sql.Result, error) {
+	return q.updateCampaignStatus.Exec(id, status)
+}
+
+func (q *Queries) RegisterCampaignView(campUUID, subUUID string) error {
+	_, err := q.registerCampaignView.Exec(campUUID, subUUID)
+	return err
+}
+
+func (q *Queries) DeleteCampaign(id int) error {
+	_, err := q.deleteCampaign.Exec(id)
+	return err
+}
+
+func (q *Queries) InsertMedia(id uuid.UUID, filename, thumbnailFilename, mediaProvider string) error {
+	_, err := q.insertMedia.Exec(id, filename, thumbnailFilename, mediaProvider)
+	return err
+}
+
+func (q *Queries) GetMedia(media *[]media.Media, provider string) error {
+	return q.getMedia.Select(media, provider)
+}
+
+func (q *Queries) DeleteMedia(media *media.Media, id int) error {
+	return q.deleteMedia.Get(media, id)
+}
+
+func (q *Queries) CreateTemplate(id *int, name, body string) error {
+	return q.createTemplate.Get(id, name, body)
+}
+
+func (q *Queries) GetTemplates(out *[]models.Template, id int, noBody bool) error {
+	return q.getTemplates.Select(out, id, noBody)
+}
+
+func (q *Queries) UpdateTemplate(id int, name, body string) (sql.Result, error) {
+	return q.updateTemplate.Exec(id, name, body)
+}
+
+func (q *Queries) SetDefaultTemplate(id int) error {
+	_, err := q.setDefaultTemplate.Exec(id)
+	return err
+}
+
+func (q *Queries) DeleteTemplate(delID *int, id int) error {
+	_, err := q.deleteTemplate.Exec(delID, id)
+	return err
+}
+
+func (q *Queries) CreateLink(out *string, id uuid.UUID, url string) error {
+	return q.createLink.Get(out, id, url)
+}
+
+func (q *Queries) RegisterLinkClick(url *string, linkUUID, campUUID, subUUID string) error {
+	return q.registerLinkClick.Get(url, linkUUID, campUUID, subUUID)
+}
+
+func (q *Queries) UpdateSettings(settings []byte) error {
+	_, err := q.updateSettings.Exec(settings)
+	return err
 }
 
 // dbConf contains database config required for connecting to a DB.

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -21,85 +21,85 @@ import (
 type Queries struct {
 	db *sqlx.DB
 
-	getDashboardCharts *sqlx.Stmt `query:"get-dashboard-charts"`
-	getDashboardCounts *sqlx.Stmt `query:"get-dashboard-counts"`
+	GetDashboardChartsStmt *sqlx.Stmt `query:"get-dashboard-charts"`
+	GetDashboardCountsStmt *sqlx.Stmt `query:"get-dashboard-counts"`
 
-	insertSubscriber                *sqlx.Stmt `query:"insert-subscriber"`
-	upsertSubscriber                *sqlx.Stmt `query:"upsert-subscriber"`
-	upsertBlocklistSubscriber       *sqlx.Stmt `query:"upsert-blocklist-subscriber"`
-	getSubscriber                   *sqlx.Stmt `query:"get-subscriber"`
-	getSubscribersByEmails          *sqlx.Stmt `query:"get-subscribers-by-emails"`
-	getSubscriberLists              *sqlx.Stmt `query:"get-subscriber-lists"`
-	getSubscriberListsLazy          *sqlx.Stmt `query:"get-subscriber-lists-lazy"`
-	subscriberExists                *sqlx.Stmt `query:"subscriber-exists"`
-	updateSubscriber                *sqlx.Stmt `query:"update-subscriber"`
-	blocklistSubscribers            *sqlx.Stmt `query:"blocklist-subscribers"`
-	addSubscribersToLists           *sqlx.Stmt `query:"add-subscribers-to-lists"`
-	deleteSubscriptions             *sqlx.Stmt `query:"delete-subscriptions"`
-	confirmSubscriptionOptin        *sqlx.Stmt `query:"confirm-subscription-optin"`
-	unsubscribeSubscribersFromLists *sqlx.Stmt `query:"unsubscribe-subscribers-from-lists"`
-	deleteSubscribers               *sqlx.Stmt `query:"delete-subscribers"`
-	unsubscribe                     *sqlx.Stmt `query:"unsubscribe"`
-	exportSubscriberData            *sqlx.Stmt `query:"export-subscriber-data"`
+	InsertSubscriberStmt                *sqlx.Stmt `query:"insert-subscriber"`
+	UpsertSubscriberStmt                *sqlx.Stmt `query:"upsert-subscriber"`
+	UpsertBlocklistSubscriberStmt       *sqlx.Stmt `query:"upsert-blocklist-subscriber"`
+	GetSubscriberStmt                   *sqlx.Stmt `query:"get-subscriber"`
+	GetSubscribersByEmailsStmt          *sqlx.Stmt `query:"get-subscribers-by-emails"`
+	GetSubscriberListsStmt              *sqlx.Stmt `query:"get-subscriber-lists"`
+	GetSubscriberListsLazyStmt          *sqlx.Stmt `query:"get-subscriber-lists-lazy"`
+	SubscriberExistsStmt                *sqlx.Stmt `query:"subscriber-exists"`
+	UpdateSubscriberStmt                *sqlx.Stmt `query:"update-subscriber"`
+	BlocklistSubscribersStmt            *sqlx.Stmt `query:"blocklist-subscribers"`
+	AddSubscribersToListsStmt           *sqlx.Stmt `query:"add-subscribers-to-lists"`
+	DeleteSubscriptionsStmt             *sqlx.Stmt `query:"delete-subscriptions"`
+	ConfirmSubscriptionOptinStmt        *sqlx.Stmt `query:"confirm-subscription-optin"`
+	UnsubscribeSubscribersFromListsStmt *sqlx.Stmt `query:"unsubscribe-subscribers-from-lists"`
+	DeleteSubscribersStmt               *sqlx.Stmt `query:"delete-subscribers"`
+	UnsubscribeStmt                     *sqlx.Stmt `query:"unsubscribe"`
+	ExportSubscriberDataStmt            *sqlx.Stmt `query:"export-subscriber-data"`
 
 	// Non-prepared arbitrary subscriber queries.
-	querySubscribers                       string `query:"query-subscribers"`
-	querySubscribersForExport              string `query:"query-subscribers-for-export"`
-	querySubscribersTpl                    string `query:"query-subscribers-template"`
-	deleteSubscribersByQuery               string `query:"delete-subscribers-by-query"`
-	addSubscribersToListsByQuery           string `query:"add-subscribers-to-lists-by-query"`
-	blocklistSubscribersByQuery            string `query:"blocklist-subscribers-by-query"`
-	deleteSubscriptionsByQuery             string `query:"delete-subscriptions-by-query"`
-	unsubscribeSubscribersFromListsByQuery string `query:"unsubscribe-subscribers-from-lists-by-query"`
+	QuerySubscribersStmt                       string `query:"query-subscribers"`
+	QuerySubscribersForExportStmt              string `query:"query-subscribers-for-export"`
+	QuerySubscribersTplStmt                    string `query:"query-subscribers-template"`
+	DeleteSubscribersByQueryStmt               string `query:"delete-subscribers-by-query"`
+	AddSubscribersToListsByQueryStmt           string `query:"add-subscribers-to-lists-by-query"`
+	BlocklistSubscribersByQueryStmt            string `query:"blocklist-subscribers-by-query"`
+	DeleteSubscriptionsByQueryStmt             string `query:"delete-subscriptions-by-query"`
+	UnsubscribeSubscribersFromListsByQueryStmt string `query:"unsubscribe-subscribers-from-lists-by-query"`
 
-	createList      *sqlx.Stmt `query:"create-list"`
-	queryLists      string     `query:"query-lists"`
-	getLists        *sqlx.Stmt `query:"get-lists"`
-	getListsByOptin *sqlx.Stmt `query:"get-lists-by-optin"`
-	updateList      *sqlx.Stmt `query:"update-list"`
-	updateListsDate *sqlx.Stmt `query:"update-lists-date"`
-	deleteLists     *sqlx.Stmt `query:"delete-lists"`
+	CreateListStmt      *sqlx.Stmt `query:"create-list"`
+	QueryListsStmt      string     `query:"query-lists"`
+	GetListsStmt        *sqlx.Stmt `query:"get-lists"`
+	GetListsByOptinStmt *sqlx.Stmt `query:"get-lists-by-optin"`
+	UpdateListStmt      *sqlx.Stmt `query:"update-list"`
+	UpdateListsDateStmt *sqlx.Stmt `query:"update-lists-date"`
+	DeleteListsStmt     *sqlx.Stmt `query:"delete-lists"`
 
-	createCampaign           *sqlx.Stmt `query:"create-campaign"`
-	queryCampaigns           string     `query:"query-campaigns"`
-	getCampaign              *sqlx.Stmt `query:"get-campaign"`
-	getCampaignForPreview    *sqlx.Stmt `query:"get-campaign-for-preview"`
-	getCampaignStats         *sqlx.Stmt `query:"get-campaign-stats"`
-	getCampaignStatus        *sqlx.Stmt `query:"get-campaign-status"`
-	nextCampaigns            *sqlx.Stmt `query:"next-campaigns"`
-	nextCampaignSubscribers  *sqlx.Stmt `query:"next-campaign-subscribers"`
-	getOneCampaignSubscriber *sqlx.Stmt `query:"get-one-campaign-subscriber"`
-	updateCampaign           *sqlx.Stmt `query:"update-campaign"`
-	updateCampaignStatus     *sqlx.Stmt `query:"update-campaign-status"`
-	updateCampaignCounts     *sqlx.Stmt `query:"update-campaign-counts"`
-	registerCampaignView     *sqlx.Stmt `query:"register-campaign-view"`
-	deleteCampaign           *sqlx.Stmt `query:"delete-campaign"`
+	CreateCampaignStmt           *sqlx.Stmt `query:"create-campaign"`
+	QueryCampaignsStmt           string     `query:"query-campaigns"`
+	GetCampaignStmt              *sqlx.Stmt `query:"get-campaign"`
+	GetCampaignForPreviewStmt    *sqlx.Stmt `query:"get-campaign-for-preview"`
+	GetCampaignStatsStmt         *sqlx.Stmt `query:"get-campaign-stats"`
+	GetCampaignStatusStmt        *sqlx.Stmt `query:"get-campaign-status"`
+	NextCampaignsStmt            *sqlx.Stmt `query:"next-campaigns"`
+	NextCampaignSubscribersStmt  *sqlx.Stmt `query:"next-campaign-subscribers"`
+	GetOneCampaignSubscriberStmt *sqlx.Stmt `query:"get-one-campaign-subscriber"`
+	UpdateCampaignStmt           *sqlx.Stmt `query:"update-campaign"`
+	UpdateCampaignStatusStmt     *sqlx.Stmt `query:"update-campaign-status"`
+	UpdateCampaignCountsStmt     *sqlx.Stmt `query:"update-campaign-counts"`
+	RegisterCampaignViewStmt     *sqlx.Stmt `query:"register-campaign-view"`
+	DeleteCampaignStmt           *sqlx.Stmt `query:"delete-campaign"`
 
-	insertMedia *sqlx.Stmt `query:"insert-media"`
-	getMedia    *sqlx.Stmt `query:"get-media"`
-	deleteMedia *sqlx.Stmt `query:"delete-media"`
+	InsertMediaStmt *sqlx.Stmt `query:"insert-media"`
+	GetMediaStmt    *sqlx.Stmt `query:"get-media"`
+	DeleteMediaStmt *sqlx.Stmt `query:"delete-media"`
 
-	createTemplate     *sqlx.Stmt `query:"create-template"`
-	getTemplates       *sqlx.Stmt `query:"get-templates"`
-	updateTemplate     *sqlx.Stmt `query:"update-template"`
-	setDefaultTemplate *sqlx.Stmt `query:"set-default-template"`
-	deleteTemplate     *sqlx.Stmt `query:"delete-template"`
+	CreateTemplateStmt     *sqlx.Stmt `query:"create-template"`
+	GetTemplatesStmt       *sqlx.Stmt `query:"get-templates"`
+	UpdateTemplateStmt     *sqlx.Stmt `query:"update-template"`
+	SetDefaultTemplateStmt *sqlx.Stmt `query:"set-default-template"`
+	DeleteTemplateStmt     *sqlx.Stmt `query:"delete-template"`
 
-	createLink        *sqlx.Stmt `query:"create-link"`
-	registerLinkClick *sqlx.Stmt `query:"register-link-click"`
+	CreateLinkStmt        *sqlx.Stmt `query:"create-link"`
+	RegisterLinkClickStmt *sqlx.Stmt `query:"register-link-click"`
 
-	getSettings    *sqlx.Stmt `query:"get-settings"`
-	updateSettings *sqlx.Stmt `query:"update-settings"`
+	GetSettingsStmt    *sqlx.Stmt `query:"get-settings"`
+	UpdateSettingsStmt *sqlx.Stmt `query:"update-settings"`
 
 	// GetStats *sqlx.Stmt `query:"get-stats"`
 }
 
 func (q *Queries) GetDashboardCharts(c *types.JSONText) error {
-	return q.getDashboardCharts.Get(c)
+	return q.GetDashboardChartsStmt.Get(c)
 }
 
 func (q *Queries) GetDashboardCounts(c *types.JSONText) error {
-	return q.getDashboardCounts.Get(c)
+	return q.GetDashboardCountsStmt.Get(c)
 }
 
 func (q *Queries) InsertSubscriber(
@@ -110,15 +110,15 @@ func (q *Queries) InsertSubscriber(
 	listUUIDs pq.StringArray,
 	subStatus string,
 ) error {
-	return q.insertSubscriber.Get(&id, uuid, email, name, status, attribs, lists, listUUIDs, subStatus)
+	return q.InsertSubscriberStmt.Get(&id, uuid, email, name, status, attribs, lists, listUUIDs, subStatus)
 }
 
 func (q *Queries) GetSubscriber(s *models.Subscribers, id int, uuid, email string) error {
-	return q.getSubscriber.Select(s, id, uuid, email)
+	return q.GetSubscriberStmt.Select(s, id, uuid, email)
 }
 
 func (q *Queries) GetSubscribersByEmails(s *models.Subscribers, emails pq.StringArray) error {
-	return q.getSubscribersByEmails.Select(s, emails)
+	return q.GetSubscribersByEmailsStmt.Select(s, emails)
 }
 
 func (q *Queries) GetSubscriberLists(
@@ -128,14 +128,14 @@ func (q *Queries) GetSubscriberLists(
 	listUUIDs pq.StringArray,
 	subStatus, optin string,
 ) error {
-	return q.getSubscriberLists.Select(lists, id, uuid, listIDs, listUUIDs, subStatus, optin)
+	return q.GetSubscriberListsStmt.Select(lists, id, uuid, listIDs, listUUIDs, subStatus, optin)
 }
 
 func (q *Queries) SubscriberExists(
 	exists *bool,
 	id int, uuid string,
 ) error {
-	return q.subscriberExists.Select(exists, id, uuid)
+	return q.SubscriberExistsStmt.Select(exists, id, uuid)
 }
 
 func (q *Queries) UpdateSubscriber(
@@ -144,49 +144,49 @@ func (q *Queries) UpdateSubscriber(
 	attribs json.RawMessage,
 	lists pq.Int64Array,
 ) error {
-	_, err := q.updateSubscriber.Exec(id, email, name, status, attribs, lists)
+	_, err := q.UpdateSubscriberStmt.Exec(id, email, name, status, attribs, lists)
 	return err
 }
 
 func (q *Queries) BlocklistSubscribers(
 	list pq.Int64Array,
 ) error {
-	_, err := q.blocklistSubscribers.Exec(list)
+	_, err := q.BlocklistSubscribersStmt.Exec(list)
 	return err
 }
 
 func (q *Queries) AddSubscribersToLists(
 	subscribers, lists pq.Int64Array,
 ) error {
-	_, err := q.blocklistSubscribers.Exec(subscribers, lists)
+	_, err := q.BlocklistSubscribersStmt.Exec(subscribers, lists)
 	return err
 }
 
 func (q *Queries) DeleteSubscriptions(
 	subscribers, lists pq.Int64Array,
 ) error {
-	_, err := q.deleteSubscriptions.Exec(subscribers, lists)
+	_, err := q.DeleteSubscriptionsStmt.Exec(subscribers, lists)
 	return err
 }
 
 func (q *Queries) UnsubscribeSubscribersFromLists(
 	subscribers, lists pq.Int64Array,
 ) error {
-	_, err := q.unsubscribeSubscribersFromLists.Exec(subscribers, lists)
+	_, err := q.UnsubscribeSubscribersFromListsStmt.Exec(subscribers, lists)
 	return err
 }
 
 func (q *Queries) ConfirmSubscriptionOptin(
 	subUUID string, listUUIDs pq.StringArray,
 ) error {
-	_, err := q.confirmSubscriptionOptin.Exec(subUUID, listUUIDs)
+	_, err := q.ConfirmSubscriptionOptinStmt.Exec(subUUID, listUUIDs)
 	return err
 }
 
 func (q *Queries) DeleteSubscribers(
 	subIDs pq.Int64Array, subUUIDs pq.StringArray,
 ) error {
-	_, err := q.deleteSubscribers.Exec(subIDs, subUUIDs)
+	_, err := q.DeleteSubscribersStmt.Exec(subIDs, subUUIDs)
 	return err
 }
 
@@ -194,7 +194,7 @@ func (q *Queries) Unsubscribe(
 	campaignUUID, subUUID string,
 	blocklist bool,
 ) error {
-	_, err := q.unsubscribe.Exec(campaignUUID, subUUID, blocklist)
+	_, err := q.UnsubscribeStmt.Exec(campaignUUID, subUUID, blocklist)
 	return err
 }
 
@@ -203,7 +203,7 @@ func (q *Queries) ExportSubscriberData(
 	id int64,
 	uuidOrNil interface{},
 ) error {
-	return q.exportSubscriberData.Get(data, id, uuidOrNil)
+	return q.ExportSubscriberDataStmt.Get(data, id, uuidOrNil)
 }
 
 func (q *Queries) CreateList(
@@ -212,14 +212,14 @@ func (q *Queries) CreateList(
 	name, listType, optin string,
 	tags pq.StringArray,
 ) error {
-	return q.exportSubscriberData.Get(list, uuid, name, listType, optin, tags)
+	return q.CreateListStmt.Get(list, uuid, name, listType, optin, tags)
 }
 
 func (q *Queries) GetLists(
 	lists *[]models.List,
 	listType string,
 ) error {
-	return q.getLists.Select(lists, listType)
+	return q.GetListsStmt.Select(lists, listType)
 }
 
 func (q *Queries) GetListsByOptin(
@@ -228,7 +228,7 @@ func (q *Queries) GetListsByOptin(
 	listIDs pq.Int64Array,
 	listUUIDs pq.StringArray,
 ) error {
-	return q.getListsByOptin.Select(lists, optin, listIDs, listUUIDs)
+	return q.GetListsByOptinStmt.Select(lists, optin, listIDs, listUUIDs)
 }
 
 func (q *Queries) UpdateList(
@@ -236,16 +236,16 @@ func (q *Queries) UpdateList(
 	name, listType, optin string,
 	tags pq.StringArray,
 ) (sql.Result, error) {
-	return q.updateList.Exec(id, name, listType, optin, tags)
+	return q.UpdateListStmt.Exec(id, name, listType, optin, tags)
 }
 
 func (q *Queries) DeleteLists(ids pq.Int64Array) error {
-	_, err := q.deleteLists.Exec(ids)
+	_, err := q.DeleteListsStmt.Exec(ids)
 	return err
 }
 
 func (q *Queries) CreateCampaign(
-	id *int,
+	newID *int,
 	uuid uuid.UUID,
 	campaignType, name, subject, fromEmail, body string,
 	altBody null.String,
@@ -256,30 +256,29 @@ func (q *Queries) CreateCampaign(
 	templateID int,
 	listIDs pq.Int64Array,
 ) error {
-	_, err := q.createCampaign.Exec(id, uuid, campaignType, name, subject, fromEmail, body, altBody, contentType, sendAt, tags, messenger, templateID, listIDs)
-	return err
+	return q.CreateCampaignStmt.Get(newID, uuid, campaignType, name, subject, fromEmail, body, altBody, contentType, sendAt, tags, messenger, templateID, listIDs)
 }
 
 func (q *Queries) GetCampaign(campaign *models.Campaign, id int, uuid *string) error {
-	_, err := q.getCampaign.Exec(campaign, id, uuid)
+	_, err := q.GetCampaignStmt.Exec(campaign, id, uuid)
 	return err
 }
 
 func (q *Queries) GetCampaignForPreview(campaign *models.Campaign, id int) error {
-	_, err := q.getCampaignForPreview.Exec(campaign, id)
+	_, err := q.GetCampaignForPreviewStmt.Exec(campaign, id)
 	return err
 }
 
 func (q *Queries) GetCampaignStatus(stats interface{}, status string) error {
-	return q.getCampaignStatus.Select(stats, status)
+	return q.GetCampaignStatusStmt.Select(stats, status)
 }
 
 func (q *Queries) NextCampaigns(c *[]*models.Campaign, excludeIDs pq.Int64Array) error {
-	return q.nextCampaigns.Select(c, excludeIDs)
+	return q.NextCampaignsStmt.Select(c, excludeIDs)
 }
 
 func (q *Queries) NextCampaignSubscribers(subs *[]models.Subscriber, campID, limit int) error {
-	return q.nextCampaignSubscribers.Select(subs, campID, limit)
+	return q.NextCampaignSubscribersStmt.Select(subs, campID, limit)
 }
 
 func (q *Queries) UpdateCampaign(
@@ -294,7 +293,7 @@ func (q *Queries) UpdateCampaign(
 	templateID int,
 	listIDs pq.Int64Array,
 ) error {
-	_, err := q.updateCampaign.Exec(id, name, subject, fromEmail, body, altBody, contentType, sendAt, sendLater, tags, messenger, templateID, listIDs)
+	_, err := q.UpdateCampaignStmt.Exec(id, name, subject, fromEmail, body, altBody, contentType, sendAt, sendLater, tags, messenger, templateID, listIDs)
 	return err
 }
 
@@ -302,69 +301,69 @@ func (q *Queries) UpdateCampaignStatus(
 	id int,
 	status string,
 ) (sql.Result, error) {
-	return q.updateCampaignStatus.Exec(id, status)
+	return q.UpdateCampaignStatusStmt.Exec(id, status)
 }
 
 func (q *Queries) RegisterCampaignView(campUUID, subUUID string) error {
-	_, err := q.registerCampaignView.Exec(campUUID, subUUID)
+	_, err := q.RegisterCampaignViewStmt.Exec(campUUID, subUUID)
 	return err
 }
 
 func (q *Queries) DeleteCampaign(id int) error {
-	_, err := q.deleteCampaign.Exec(id)
+	_, err := q.DeleteCampaignStmt.Exec(id)
 	return err
 }
 
 func (q *Queries) InsertMedia(id uuid.UUID, filename, thumbnailFilename, mediaProvider string) error {
-	_, err := q.insertMedia.Exec(id, filename, thumbnailFilename, mediaProvider)
+	_, err := q.InsertMediaStmt.Exec(id, filename, thumbnailFilename, mediaProvider)
 	return err
 }
 
 func (q *Queries) GetMedia(media *[]media.Media, provider string) error {
-	return q.getMedia.Select(media, provider)
+	return q.GetMediaStmt.Select(media, provider)
 }
 
 func (q *Queries) DeleteMedia(media *media.Media, id int) error {
-	return q.deleteMedia.Get(media, id)
+	return q.DeleteMediaStmt.Get(media, id)
 }
 
 func (q *Queries) CreateTemplate(id *int, name, body string) error {
-	return q.createTemplate.Get(id, name, body)
+	return q.CreateTemplateStmt.Get(id, name, body)
 }
 
 func (q *Queries) GetTemplates(out *[]models.Template, id int, noBody bool) error {
-	return q.getTemplates.Select(out, id, noBody)
+	return q.GetTemplatesStmt.Select(out, id, noBody)
 }
 
 func (q *Queries) UpdateTemplate(id int, name, body string) (sql.Result, error) {
-	return q.updateTemplate.Exec(id, name, body)
+	return q.UpdateTemplateStmt.Exec(id, name, body)
 }
 
 func (q *Queries) SetDefaultTemplate(id int) error {
-	_, err := q.setDefaultTemplate.Exec(id)
+	_, err := q.SetDefaultTemplateStmt.Exec(id)
 	return err
 }
 
 func (q *Queries) DeleteTemplate(delID *int, id int) error {
-	_, err := q.deleteTemplate.Exec(delID, id)
+	_, err := q.DeleteTemplateStmt.Exec(delID, id)
 	return err
 }
 
 func (q *Queries) CreateLink(out *string, id uuid.UUID, url string) error {
-	return q.createLink.Get(out, id, url)
+	return q.CreateLinkStmt.Get(out, id, url)
 }
 
 func (q *Queries) RegisterLinkClick(url *string, linkUUID, campUUID, subUUID string) error {
-	return q.registerLinkClick.Get(url, linkUUID, campUUID, subUUID)
+	return q.RegisterLinkClickStmt.Get(url, linkUUID, campUUID, subUUID)
 }
 
 func (q *Queries) UpdateSettings(settings []byte) error {
-	_, err := q.updateSettings.Exec(settings)
+	_, err := q.UpdateSettingsStmt.Exec(settings)
 	return err
 }
 
 func (q *Queries) QueryLists(listID, offset, limit int, orderBy, order string) ([]models.List, error) {
-	query := fmt.Sprintf(q.queryLists, orderBy, order)
+	query := fmt.Sprintf(q.QueryListsStmt, orderBy, order)
 
 	var results []models.List
 	if err := db.Select(&results, query, listID, offset, limit); err != nil {
@@ -375,7 +374,7 @@ func (q *Queries) QueryLists(listID, offset, limit int, orderBy, order string) (
 }
 
 func (q *Queries) QueryCampaigns(id, offset, limit int, status []string, query, orderBy, order string) ([]models.Campaign, error) {
-	stmt := fmt.Sprintf(q.queryCampaigns, orderBy, order)
+	stmt := fmt.Sprintf(q.QueryCampaignsStmt, orderBy, order)
 
 	var results []models.Campaign
 	if err := db.Select(&results, stmt, id, pq.StringArray(status), query, offset, limit); err != nil {
@@ -393,11 +392,11 @@ func (q *Queries) UpsertSubscriber(
 	overwrite bool,
 	tx *sql.Tx,
 ) error {
-	stmt := q.upsertSubscriber.Stmt
+	stmt := q.UpsertSubscriberStmt.Stmt
 	if tx != nil {
 		stmt = tx.Stmt(stmt)
 	}
-	_, err := q.upsertSubscriber.Exec(uuid, email, name, attribs, listIDs, overwrite)
+	_, err := q.UpsertSubscriberStmt.Exec(uuid, email, name, attribs, listIDs, overwrite)
 	return err
 }
 
@@ -407,7 +406,7 @@ func (q *Queries) UpsertBlocklistSubscriber(
 	attribs models.SubscriberAttribs,
 	tx *sql.Tx,
 ) error {
-	stmt := q.upsertBlocklistSubscriber.Stmt
+	stmt := q.UpsertBlocklistSubscriberStmt.Stmt
 	if tx != nil {
 		stmt = tx.Stmt(stmt)
 	}
@@ -416,7 +415,7 @@ func (q *Queries) UpsertBlocklistSubscriber(
 }
 
 func (q *Queries) UpdateListsDate(listIDs pq.Int64Array, tx *sql.Tx) error {
-	stmt := q.updateListsDate.Stmt
+	stmt := q.UpdateListsDateStmt.Stmt
 	if tx != nil {
 		stmt = tx.Stmt(stmt)
 	}
@@ -426,7 +425,7 @@ func (q *Queries) UpdateListsDate(listIDs pq.Int64Array, tx *sql.Tx) error {
 
 func (q *Queries) GetCampaignStats(campaignIDs []int) ([]models.CampaignMeta, error) {
 	var meta []models.CampaignMeta
-	if err := q.getCampaignStats.Select(&meta, pq.Array(campaignIDs)); err != nil {
+	if err := q.GetCampaignStatsStmt.Select(&meta, pq.Array(campaignIDs)); err != nil {
 		return meta, err
 	}
 
@@ -439,7 +438,7 @@ func (q *Queries) GetCampaignStats(campaignIDs []int) ([]models.CampaignMeta, er
 
 func (q *Queries) GetSettings() (json.RawMessage, error) {
 	var s types.JSONText
-	if err := q.getSettings.Get(&s); err != nil {
+	if err := q.GetSettingsStmt.Get(&s); err != nil {
 		return nil, fmt.Errorf("error reading settings from DB: %s", pqErrMsg(err))
 	}
 	return json.RawMessage(s), nil
@@ -452,7 +451,7 @@ type SubscriberLists struct {
 
 func (q *Queries) GetSubscriberListsLazy(subscriberIDs []int) ([]SubscriberLists, error) {
 	var sl []SubscriberLists
-	if err := q.getSubscriberListsLazy.Select(&sl, pq.Array(subscriberIDs)); err != nil {
+	if err := q.GetSubscriberListsLazyStmt.Select(&sl, pq.Array(subscriberIDs)); err != nil {
 		return sl, err
 	}
 
@@ -477,7 +476,7 @@ func (q *Queries) QuerySubscribers(listIDs pq.Int64Array, query, orderBy, order 
 		cond = " AND " + query
 	}
 
-	stmt := fmt.Sprintf(q.querySubscribers, cond, orderBy, order)
+	stmt := fmt.Sprintf(q.QuerySubscribersStmt, cond, orderBy, order)
 
 	// Run the query. stmt is the raw SQL query.
 	var results []models.Subscriber
@@ -500,7 +499,7 @@ func (q *Queries) QuerySubscribersForExport(
 		cond = " AND " + query
 	}
 
-	sqlStr := fmt.Sprintf(q.querySubscribersForExport, cond)
+	sqlStr := fmt.Sprintf(q.QuerySubscribersForExportStmt, cond)
 
 	// Verify that the arbitrary SQL search expression is read only.
 	if cond != "" {
@@ -541,23 +540,23 @@ func (q *Queries) QuerySubscribersForExport(
 }
 
 func (q *Queries) DeleteSubscriptionsByQuery(exp string, listIDs pq.Int64Array) error {
-	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.deleteSubscriptionsByQuery, listIDs, q.db)
+	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.DeleteSubscriptionsByQueryStmt, listIDs, q.db)
 }
 
 func (q *Queries) BlocklistSubscribersByQuery(exp string, listIDs pq.Int64Array) error {
-	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.blocklistSubscribersByQuery, listIDs, q.db)
+	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.BlocklistSubscribersByQueryStmt, listIDs, q.db)
 }
 
 func (q *Queries) DeleteSubscribersByQuery(exp string, listIDs pq.Int64Array) error {
-	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.deleteSubscribersByQuery, listIDs, q.db)
+	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.DeleteSubscribersByQueryStmt, listIDs, q.db)
 }
 
 func (q *Queries) UnsubscribeSubscribersFromListsByQuery(exp string, listIDs, targetListIDs pq.Int64Array) error {
-	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.unsubscribeSubscribersFromListsByQuery, listIDs, q.db, targetListIDs)
+	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.UnsubscribeSubscribersFromListsByQueryStmt, listIDs, q.db, targetListIDs)
 }
 
 func (q *Queries) AddSubscribersToListsByQuery(exp string, listIDs, targetListIDs pq.Int64Array) error {
-	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.addSubscribersToListsByQuery, listIDs, q.db, targetListIDs)
+	return q.execSubscriberQueryTpl(sanitizeSQLExp(exp), q.AddSubscribersToListsByQueryStmt, listIDs, q.db, targetListIDs)
 }
 
 // dbConf contains database config required for connecting to a DB.
@@ -603,7 +602,7 @@ func (q *Queries) compileSubscriberQueryTpl(exp string, db *sqlx.DB) (string, er
 	if exp != "" {
 		exp = " AND " + exp
 	}
-	stmt := fmt.Sprintf(q.querySubscribersTpl, exp)
+	stmt := fmt.Sprintf(q.QuerySubscribersTplStmt, exp)
 	if _, err := tx.Exec(stmt, true, pq.Int64Array{}); err != nil {
 		return "", err
 	}

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -58,7 +58,7 @@ type Queries struct {
 	deleteLists     *sqlx.Stmt `query:"delete-lists"`
 
 	createCampaign           *sqlx.Stmt `query:"create-campaign"`
-	QueryCampaigns           string     `query:"query-campaigns"`
+	queryCampaigns           string     `query:"query-campaigns"`
 	getCampaign              *sqlx.Stmt `query:"get-campaign"`
 	getCampaignForPreview    *sqlx.Stmt `query:"get-campaign-for-preview"`
 	GetCampaignStats         *sqlx.Stmt `query:"get-campaign-stats"`
@@ -365,6 +365,17 @@ func (q *Queries) QueryLists(listID, offset, limit int, orderBy, order string) (
 
 	var results []models.List
 	if err := db.Select(&results, query, listID, offset, limit); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func (q *Queries) QueryCampaigns(id, offset, limit int, status []string, query, orderBy, order string) ([]models.Campaign, error) {
+	stmt := fmt.Sprintf(q.queryCampaigns, orderBy, order)
+
+	var results []models.Campaign
+	if err := db.Select(&results, stmt, id, pq.StringArray(status), query, offset, limit); err != nil {
 		return nil, err
 	}
 

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -22,8 +22,8 @@ type Queries struct {
 	getDashboardCounts *sqlx.Stmt `query:"get-dashboard-counts"`
 
 	insertSubscriber                *sqlx.Stmt `query:"insert-subscriber"`
-	UpsertSubscriber                *sqlx.Stmt `query:"upsert-subscriber"`
-	UpsertBlocklistSubscriber       *sqlx.Stmt `query:"upsert-blocklist-subscriber"`
+	upsertSubscriber                *sqlx.Stmt `query:"upsert-subscriber"`
+	upsertBlocklistSubscriber       *sqlx.Stmt `query:"upsert-blocklist-subscriber"`
 	getSubscriber                   *sqlx.Stmt `query:"get-subscriber"`
 	getSubscribersByEmails          *sqlx.Stmt `query:"get-subscribers-by-emails"`
 	getSubscriberLists              *sqlx.Stmt `query:"get-subscriber-lists"`
@@ -54,7 +54,7 @@ type Queries struct {
 	getLists        *sqlx.Stmt `query:"get-lists"`
 	getListsByOptin *sqlx.Stmt `query:"get-lists-by-optin"`
 	updateList      *sqlx.Stmt `query:"update-list"`
-	UpdateListsDate *sqlx.Stmt `query:"update-lists-date"`
+	updateListsDate *sqlx.Stmt `query:"update-lists-date"`
 	deleteLists     *sqlx.Stmt `query:"delete-lists"`
 
 	createCampaign           *sqlx.Stmt `query:"create-campaign"`
@@ -380,6 +380,45 @@ func (q *Queries) QueryCampaigns(id, offset, limit int, status []string, query, 
 	}
 
 	return results, nil
+}
+
+func (q *Queries) UpsertSubscriber(
+	uuid uuid.UUID,
+	email, name string,
+	attribs models.SubscriberAttribs,
+	listIDs pq.Int64Array,
+	overwrite bool,
+	tx *sql.Tx,
+) error {
+	stmt := q.upsertSubscriber.Stmt
+	if tx != nil {
+		stmt = tx.Stmt(stmt)
+	}
+	_, err := q.upsertSubscriber.Exec(uuid, email, name, attribs, listIDs, overwrite)
+	return err
+}
+
+func (q *Queries) UpsertBlocklistSubscriber(
+	uu uuid.UUID,
+	email, name string,
+	attribs models.SubscriberAttribs,
+	tx *sql.Tx,
+) error {
+	stmt := q.upsertBlocklistSubscriber.Stmt
+	if tx != nil {
+		stmt = tx.Stmt(stmt)
+	}
+	_, err := stmt.Exec(uu, email, name, attribs)
+	return err
+}
+
+func (q *Queries) UpdateListsDate(listIDs pq.Int64Array, tx *sql.Tx) error {
+	stmt := q.updateListsDate.Stmt
+	if tx != nil {
+		stmt = tx.Stmt(stmt)
+	}
+	_, err := stmt.Exec(listIDs)
+	return err
 }
 
 // dbConf contains database config required for connecting to a DB.

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -17,6 +17,8 @@ import (
 	null "gopkg.in/volatiletech/null.v6"
 )
 
+var q Store = &Queries{}
+
 // Queries contains all prepared SQL queries.
 type Queries struct {
 	db *sqlx.DB

--- a/cmd/queries.go
+++ b/cmd/queries.go
@@ -262,13 +262,11 @@ func (q *Queries) CreateCampaign(
 }
 
 func (q *Queries) GetCampaign(campaign *models.Campaign, id int, uuid *string) error {
-	_, err := q.GetCampaignStmt.Exec(campaign, id, uuid)
-	return err
+	return q.GetCampaignStmt.Get(campaign, id, uuid)
 }
 
 func (q *Queries) GetCampaignForPreview(campaign *models.Campaign, id int) error {
-	_, err := q.GetCampaignForPreviewStmt.Exec(campaign, id)
-	return err
+	return q.GetCampaignForPreviewStmt.Get(campaign, id)
 }
 
 func (q *Queries) GetCampaignStatus(stats interface{}, status string) error {
@@ -524,7 +522,7 @@ func (q *Queries) QuerySubscribersForExport(
 
 	for id := 0; ; {
 		var out []models.SubscriberExport
-		if err := stmt.Select(&out, listIDs, id, nil, batchSize); err != nil {
+		if err := stmt.Select(&out, listIDs, id, batchSize); err != nil {
 			return err
 		}
 		if len(out) == 0 {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/jmoiron/sqlx/types"
 	"github.com/labstack/echo"
 )
 
@@ -233,18 +232,18 @@ func handleGetLogs(c echo.Context) error {
 
 func getSettings(app *App) (settings, error) {
 	var (
-		b   types.JSONText
 		out settings
 	)
 
-	if err := app.queries.GetSettings.Get(&b); err != nil {
+	settings, err := app.queries.GetSettings()
+	if err != nil {
 		return out, echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
 				"name", "{globals.terms.settings}", "error", pqErrMsg(err)))
 	}
 
 	// Unmarshall the settings and filter out sensitive fields.
-	if err := json.Unmarshal([]byte(b), &out); err != nil {
+	if err := json.Unmarshal(settings, &out); err != nil {
 		return out, echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("settings.errorEncoding", "error", err.Error()))
 	}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -197,7 +197,7 @@ func handleUpdateSettings(c echo.Context) error {
 	}
 
 	// Update the settings in the DB.
-	if err := app.queries.UpdateSettings(b); err != nil {
+	if err := app.store.UpdateSettings(b); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorUpdating",
 				"name", "{globals.terms.settings}", "error", pqErrMsg(err)))
@@ -235,7 +235,7 @@ func getSettings(app *App) (settings, error) {
 		out settings
 	)
 
-	settings, err := app.queries.GetSettings()
+	settings, err := app.store.GetSettings()
 	if err != nil {
 		return out, echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -198,7 +198,7 @@ func handleUpdateSettings(c echo.Context) error {
 	}
 
 	// Update the settings in the DB.
-	if _, err := app.queries.UpdateSettings.Exec(b); err != nil {
+	if err := app.queries.UpdateSettings(b); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorUpdating",
 				"name", "{globals.terms.settings}", "error", pqErrMsg(err)))

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	"github.com/gofrs/uuid"
+	"github.com/jmoiron/sqlx/types"
+	"github.com/knadh/listmonk/internal/media"
+	"github.com/knadh/listmonk/models"
+	"github.com/lib/pq"
+	null "gopkg.in/volatiletech/null.v6"
+)
+
+type Store interface {
+	GetDashboardCharts(c *types.JSONText) error
+	GetDashboardCounts(c *types.JSONText) error
+
+	InsertSubscriber(id *int, uuid, email, name, status string, attribs models.SubscriberAttribs, lists pq.Int64Array, listUUIDs pq.StringArray, subStatus string) error
+	GetSubscriber(s *models.Subscribers, id int, uuid, email string) error
+	GetSubscribersByEmails(s *models.Subscribers, emails pq.StringArray) error
+	GetSubscriberLists(lists *[]models.List, id int, uuid string, listIDs pq.Int64Array, listUUIDs pq.StringArray, subStatus, optin string) error
+	SubscriberExists(exists *bool, id int, uuid string) error
+	UpdateSubscriber(id int64, email, name, status string, attribs json.RawMessage, lists pq.Int64Array) error
+	BlocklistSubscribers(list pq.Int64Array) error
+	AddSubscribersToLists(subscribers, lists pq.Int64Array) error
+	DeleteSubscriptions(subscribers, lists pq.Int64Array) error
+	UnsubscribeSubscribersFromLists(subscribers, lists pq.Int64Array) error
+	ConfirmSubscriptionOptin(subUUID string, listUUIDs pq.StringArray) error
+	DeleteSubscribers(subIDs pq.Int64Array, subUUIDs pq.StringArray) error
+	Unsubscribe(campaignUUID, subUUID string, blocklist bool) error
+	ExportSubscriberData(data interface{}, id int64, uuidOrNil interface{}) error
+	CreateList(list *int, uuid interface{}, name, listType, optin string, tags pq.StringArray) error
+	GetLists(lists *[]models.List, listType string) error
+	GetListsByOptin(lists *[]models.List, optin string, listIDs pq.Int64Array, listUUIDs pq.StringArray) error
+	UpdateList(id int, name, listType, optin string, tags pq.StringArray) (sql.Result, error)
+	DeleteLists(ids pq.Int64Array) error
+	CreateCampaign(id *int, uuid uuid.UUID, campaignType, name, subject, fromEmail, body string, altBody null.String, contentType string, sendAt null.Time, tags pq.StringArray, messenger string, templateID int, listIDs pq.Int64Array) error
+	GetCampaign(campaign *models.Campaign, id int, uuid *string) error
+	GetCampaignForPreview(campaign *models.Campaign, id int) error
+	GetCampaignStatus(stats interface{}, status string) error
+	NextCampaigns(c *[]*models.Campaign, excludeIDs pq.Int64Array) error
+	NextCampaignSubscribers(subs *[]models.Subscriber, campID, limit int) error
+	UpdateCampaign(id int, name, subject, fromEmail, body string, altBody null.String, contentType string, sendAt null.Time, sendLater bool, tags pq.StringArray, messenger string, templateID int, listIDs pq.Int64Array) error
+	UpdateCampaignStatus(id int, status string) (sql.Result, error)
+	RegisterCampaignView(campUUID, subUUID string) error
+	DeleteCampaign(id int) error
+	InsertMedia(id uuid.UUID, filename, thumbnailFilename, mediaProvider string) error
+	GetMedia(media *[]media.Media, provider string) error
+	DeleteMedia(media *media.Media, id int) error
+	CreateTemplate(id *int, name, body string) error
+	GetTemplates(out *[]models.Template, id int, noBody bool) error
+	UpdateTemplate(id int, name, body string) (sql.Result, error)
+	SetDefaultTemplate(id int) error
+	DeleteTemplate(delID *int, id int) error
+	CreateLink(out *string, id uuid.UUID, url string) error
+	RegisterLinkClick(url *string, linkUUID, campUUID, subUUID string) error
+	UpdateSettings(settings []byte) error
+	QueryLists(listID, offset, limit int, orderBy, order string) ([]models.List, error)
+	QueryCampaigns(id, offset, limit int, status []string, query, orderBy, order string) ([]models.Campaign, error)
+	UpsertSubscriber(uuid uuid.UUID, email, name string, attribs models.SubscriberAttribs, listIDs pq.Int64Array, overwrite bool, tx *sql.Tx) error
+	UpsertBlocklistSubscriber(uu uuid.UUID, email, name string, attribs models.SubscriberAttribs, tx *sql.Tx) error
+	UpdateListsDate(listIDs pq.Int64Array, tx *sql.Tx) error
+	GetCampaignStats(campaignIDs []int) ([]models.CampaignMeta, error)
+	GetSettings() (json.RawMessage, error)
+	GetSubscriberListsLazy(subscriberIDs []int) ([]SubscriberLists, error)
+	QuerySubscribers(listIDs pq.Int64Array, query, orderBy, order string, offset, limit int) ([]models.Subscriber, error)
+	QuerySubscribersForExport(query string, listIDs pq.Int64Array, batchSize int, onFetch func([]models.SubscriberExport) error) error
+	DeleteSubscriptionsByQuery(exp string, listIDs pq.Int64Array) error
+	BlocklistSubscribersByQuery(exp string, listIDs pq.Int64Array) error
+	DeleteSubscribersByQuery(exp string, listIDs pq.Int64Array) error
+	UnsubscribeSubscribersFromListsByQuery(exp string, listIDs, targetListIDs pq.Int64Array) error
+	AddSubscribersToListsByQuery(exp string, listIDs, targetListIDs pq.Int64Array) error
+}

--- a/cmd/subscribers.go
+++ b/cmd/subscribers.go
@@ -469,9 +469,7 @@ func handleDeleteSubscribersByQuery(c echo.Context) error {
 		return err
 	}
 
-	err := app.queries.execSubscriberQueryTpl(sanitizeSQLExp(req.Query),
-		app.queries.DeleteSubscribersByQuery,
-		req.ListIDs, app.db)
+	err := app.queries.DeleteSubscribersByQuery(req.Query, req.ListIDs)
 	if err != nil {
 		app.log.Printf("error deleting subscribers: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -494,9 +492,7 @@ func handleBlocklistSubscribersByQuery(c echo.Context) error {
 		return err
 	}
 
-	err := app.queries.execSubscriberQueryTpl(sanitizeSQLExp(req.Query),
-		app.queries.BlocklistSubscribersByQuery,
-		req.ListIDs, app.db)
+	err := app.queries.BlocklistSubscribersByQuery(req.Query, req.ListIDs)
 	if err != nil {
 		app.log.Printf("error blocklisting subscribers: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -523,20 +519,17 @@ func handleManageSubscriberListsByQuery(c echo.Context) error {
 	}
 
 	// Action.
-	var stmt string
+	var err error
 	switch req.Action {
 	case "add":
-		stmt = app.queries.AddSubscribersToListsByQuery
+		err = app.queries.AddSubscribersToListsByQuery(req.Query, req.ListIDs, req.TargetListIDs)
 	case "remove":
-		stmt = app.queries.DeleteSubscriptionsByQuery
+		err = app.queries.DeleteSubscriptionsByQuery(req.Query, req.ListIDs)
 	case "unsubscribe":
-		stmt = app.queries.UnsubscribeSubscribersFromListsByQuery
+		err = app.queries.UnsubscribeSubscribersFromListsByQuery(req.Query, req.ListIDs, req.TargetListIDs)
 	default:
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("subscribers.invalidAction"))
 	}
-
-	err := app.queries.execSubscriberQueryTpl(sanitizeSQLExp(req.Query),
-		stmt, req.ListIDs, app.db, req.TargetListIDs)
 	if err != nil {
 		app.log.Printf("error updating subscriptions: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError,

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -46,7 +46,7 @@ func handleGetTemplates(c echo.Context) error {
 		single = true
 	}
 
-	err := app.queries.GetTemplates.Select(&out, id, noBody)
+	err := app.queries.GetTemplates(&out, id, noBody)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
@@ -86,7 +86,7 @@ func handlePreviewTemplate(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
 		}
 
-		err := app.queries.GetTemplates.Select(&tpls, id, false)
+		err := app.queries.GetTemplates(&tpls, id, false)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError,
 				app.i18n.Ts("globals.messages.errorFetching",
@@ -142,7 +142,7 @@ func handleCreateTemplate(c echo.Context) error {
 
 	// Insert and read ID.
 	var newID int
-	if err := app.queries.CreateTemplate.Get(&newID,
+	if err := app.queries.CreateTemplate(&newID,
 		o.Name,
 		o.Body); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -176,7 +176,7 @@ func handleUpdateTemplate(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	res, err := app.queries.UpdateTemplate.Exec(id, o.Name, o.Body)
+	res, err := app.queries.UpdateTemplate(id, o.Name, o.Body)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorUpdating",
@@ -202,7 +202,7 @@ func handleTemplateSetDefault(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
 	}
 
-	_, err := app.queries.SetDefaultTemplate.Exec(id)
+	err := app.queries.SetDefaultTemplate(id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorUpdating",
@@ -224,7 +224,7 @@ func handleDeleteTemplate(c echo.Context) error {
 	}
 
 	var delID int
-	err := app.queries.DeleteTemplate.Get(&delID, id)
+	err := app.queries.DeleteTemplate(&delID, id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorDeleting",

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -46,7 +46,7 @@ func handleGetTemplates(c echo.Context) error {
 		single = true
 	}
 
-	err := app.queries.GetTemplates(&out, id, noBody)
+	err := app.store.GetTemplates(&out, id, noBody)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorFetching",
@@ -86,7 +86,7 @@ func handlePreviewTemplate(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
 		}
 
-		err := app.queries.GetTemplates(&tpls, id, false)
+		err := app.store.GetTemplates(&tpls, id, false)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError,
 				app.i18n.Ts("globals.messages.errorFetching",
@@ -142,7 +142,7 @@ func handleCreateTemplate(c echo.Context) error {
 
 	// Insert and read ID.
 	var newID int
-	if err := app.queries.CreateTemplate(&newID,
+	if err := app.store.CreateTemplate(&newID,
 		o.Name,
 		o.Body); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
@@ -176,7 +176,7 @@ func handleUpdateTemplate(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	res, err := app.queries.UpdateTemplate(id, o.Name, o.Body)
+	res, err := app.store.UpdateTemplate(id, o.Name, o.Body)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorUpdating",
@@ -202,7 +202,7 @@ func handleTemplateSetDefault(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
 	}
 
-	err := app.queries.SetDefaultTemplate(id)
+	err := app.store.SetDefaultTemplate(id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorUpdating",
@@ -224,7 +224,7 @@ func handleDeleteTemplate(c echo.Context) error {
 	}
 
 	var delID int
-	err := app.queries.DeleteTemplate(&delID, id)
+	err := app.store.DeleteTemplate(&delID, id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			app.i18n.Ts("globals.messages.errorDeleting",

--- a/models/models.go
+++ b/models/models.go
@@ -294,28 +294,6 @@ func (camps Campaigns) GetIDs() []int {
 	return IDs
 }
 
-// LoadStats lazy loads campaign stats onto a list of campaigns.
-func (camps Campaigns) LoadStats(stmt *sqlx.Stmt) error {
-	var meta []CampaignMeta
-	if err := stmt.Select(&meta, pq.Array(camps.GetIDs())); err != nil {
-		return err
-	}
-
-	if len(camps) != len(meta) {
-		return errors.New("campaign stats count does not match")
-	}
-
-	for i, c := range meta {
-		if c.CampaignID == camps[i].ID {
-			camps[i].Lists = c.Lists
-			camps[i].Views = c.Views
-			camps[i].Clicks = c.Clicks
-		}
-	}
-
-	return nil
-}
-
 // CompileTemplate compiles a campaign body template into its base
 // template and sets the resultant template to Campaign.Tpl.
 func (c *Campaign) CompileTemplate(f template.FuncMap) error {

--- a/models/models.go
+++ b/models/models.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/jmoiron/sqlx/types"
 	"github.com/lib/pq"
 	"github.com/yuin/goldmark"
@@ -123,10 +122,6 @@ type Subscriber struct {
 	// Pseudofield for getting the total number of subscribers
 	// in searches and queries.
 	Total int `db:"total" json:"-"`
-}
-type subLists struct {
-	SubscriberID int            `db:"subscriber_id"`
-	Lists        types.JSONText `db:"lists"`
 }
 
 // SubscriberAttribs is the map of key:value attributes of a subscriber.
@@ -247,28 +242,6 @@ func (subs Subscribers) GetIDs() []int {
 	}
 
 	return IDs
-}
-
-// LoadLists lazy loads the lists for all the subscribers
-// in the Subscribers slice and attaches them to their []Lists property.
-func (subs Subscribers) LoadLists(stmt *sqlx.Stmt) error {
-	var sl []subLists
-	err := stmt.Select(&sl, pq.Array(subs.GetIDs()))
-	if err != nil {
-		return err
-	}
-
-	if len(subs) != len(sl) {
-		return errors.New("campaign stats count does not match")
-	}
-
-	for i, s := range sl {
-		if s.SubscriberID == subs[i].ID {
-			subs[i].Lists = s.Lists
-		}
-	}
-
-	return nil
 }
 
 // Value returns the JSON marshalled SubscriberAttribs.


### PR DESCRIPTION
This commit works toward multiple database implementations (#368) by putting all database methods inside of a Go interface.

This is still a work in progress. I am aiming to do the refactor without introducing regressions in the existing codebase by slowly changing the existing implementation and testing after refactoring each method.