### PR TITLE
fix: expose healthcheck API as public endpoint

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -151,6 +151,8 @@ func registerHTTPHandlers(e *echo.Echo, app *App) {
 		"campUUID", "subUUID"))
 	e.GET("/campaign/:campUUID/:subUUID/px.png", validateUUID(handleRegisterCampaignView,
 		"campUUID", "subUUID"))
+	// Public health API endpoint.
+	e.GET("/health", handleHealthCheck)
 }
 
 // handleIndex is the root handler that renders the Javascript frontend.


### PR DESCRIPTION
Fixes https://github.com/knadh/listmonk/issues/380

If basic auth is enabled, the endpoint will still respond with 200.

```sh
curl -i localhost:9000/api/health
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Date: Wed, 02 Jun 2021 14:38:47 GMT
Content-Length: 14

{"data":true}
```