### PR TITLE
streamline make configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ LAST_COMMIT := $(shell git rev-parse --short HEAD)
 VERSION := $(shell git describe --tags --abbrev=0)
 BUILDSTR := ${VERSION} (\#${LAST_COMMIT} $(shell date -u +"%Y-%m-%dT%H:%M:%S%z"))
 
+YARN ?= yarn
+
 BIN := listmonk
 STATIC := config.toml.sample \
 	schema.sql queries.sql \
@@ -15,7 +17,7 @@ STATIC := config.toml.sample \
 .PHONY: deps
 deps:
 	go get -u github.com/knadh/stuffbin/...
-	cd frontend && yarn install
+	cd frontend && $(YARN) install
 
 # Build the backend to ./listmonk.
 .PHONY: build
@@ -30,12 +32,12 @@ run: build
 # Build the JS frontend into frontend/dist.
 .PHONY: build-frontend
 build-frontend:
-	export VUE_APP_VERSION="${VERSION}" && cd frontend && yarn build
+	export VUE_APP_VERSION="${VERSION}" && cd frontend && $(YARN) build
 
 # Run the JS frontend server in dev mode.
 .PHONY: run-frontend
 run-frontend:
-	export VUE_APP_VERSION="${VERSION}" && cd frontend && yarn serve
+	export VUE_APP_VERSION="${VERSION}" && cd frontend && $(YARN) serve
 
 # Run Go tests.
 .PHONY: test


### PR DESCRIPTION
Hi,

I’m glad I’ve found this "little" gem and I’ve been working on [a deb package](https://git.hack-hro.de/kmohrf/listmonk-deb) for the past three hours and have encountered a few bumps along the road. It comes down to these two issues:

* Debian installs yarn as `yarnpkg`. This first commit fixes this by simply allowing the caller to override the yarn binary name. This also make it easier to pass options (i.e. for npm caching servers).
* I’ve noticed that the `dist` make target will execute builds each time it’s called and is missing a dependency on the `deps` target. I’ve split up the latter into dedicated targets for `stuffbin` and `node_modules` so that each of them is only executed when necessary. I’ve also defined dependencies for the build targets so that rebuilds should only get triggered if the actual source files changed. I’m not a make-guru, so there’s probably some better way of defining these things, but I’d say it works as a first step in that direction.

Apart from the `pack-bin` and `dist` targets seem to do the same. I’ve kept the `pack-bin` target, but maybe it can be removed?

Feel free to comment on, merge, cherry-pick or gut these changes and thank you for your time!

Cheers,

Konrad