### PR TITLE
Fix RootURL in campaign-status.html

### DIFF
--- a/static/email-templates/campaign-status.html
+++ b/static/email-templates/campaign-status.html
@@ -4,7 +4,7 @@
 <table width="100%">
     <tr>
         <td width="30%"><strong>{{ L.Ts "global.terms.campaign" }}</strong></td>
-        <td><a href="{{ index . "RootURL" }}/campaigns/{{ index . "ID" }}">{{ index . "Name" }}</a></td>
+        <td><a href="{{ RootURL }}/campaigns/{{ index . "ID" }}">{{ index . "Name" }}</a></td>
     </tr>
     <tr>
         <td width="30%"><strong>{{ L.Ts "email.status.status" }}</strong></td>


### PR DESCRIPTION
The campaign status had a broken link:

```
<a href="http:///campaigns/14" target="_blank">Test Newsletter 4</a>
```