### PR TITLE
Clarify default option in prompt

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -32,7 +32,7 @@ func install(lastVer string, db *sqlx.DB, fs stuffbin.FileSystem, prompt, idempo
 
 	if prompt {
 		var ok string
-		fmt.Print("continue (y/n)?  ")
+		fmt.Print("continue (y/N)?  ")
 		if _, err := fmt.Scanf("%s", &ok); err != nil {
 			lo.Fatalf("error reading value from terminal: %v", err)
 		}


### PR DESCRIPTION
Pressing enter without specifying a letter in the continue prompt cancells installation. So, the script should show as such.