### PR TITLE
Use POSIX standard -c flag for "touch"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(STUFFBIN):
 
 $(FRONTEND_YARN_MODULES): frontend/package.json frontend/yarn.lock
 	cd frontend && $(YARN) install
-	touch --no-create $(FRONTEND_YARN_MODULES)
+	touch -c $(FRONTEND_YARN_MODULES)
 
 # Build the backend to ./listmonk.
 $(BIN): $(shell find . -type f -name "*.go")
@@ -48,7 +48,7 @@ run:
 # Build the JS frontend into frontend/dist.
 $(FRONTEND_DIST): $(FRONTEND_DEPS)
 	export VUE_APP_VERSION="${VERSION}" && cd frontend && $(YARN) build
-	touch --no-create $(FRONTEND_DIST)
+	touch -c $(FRONTEND_DIST)
 
 
 .PHONY: build-frontend


### PR DESCRIPTION
non-GNU systems like FreeBSD and illumos do not understand the long
"--no-create" flag to touch. POSIX defines that conforming implementations
must understand "-c" for this, so use the flag that is widely understood
(including by GNU touch).

<https://pubs.opengroup.org/onlinepubs/9699919799/utilities/touch.html>