### PR TITLE
pack-bin is missing dependency on build-frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dist: $(STUFFBIN) build build-frontend pack-bin
 # pack-releases runns stuffbin packing on the given binary. This is used
 # in the .goreleaser post-build hook.
 .PHONY: pack-bin
-pack-bin: $(STUFFBIN)
+pack-bin: build-frontend $(BIN) $(STUFFBIN)
 	$(STUFFBIN) -a stuff -in ${BIN} -out ${BIN} ${STATIC}
 
 # Use goreleaser to do a dry run producing local builds.


### PR DESCRIPTION
When building on a system with enough cores, there is a race condition where
make runs pack-bin before build-frontend is complete.

Running: /usr/bin/gmake -j 60 dist
go install github.com/knadh/stuffbin/...
CGO_ENABLED=0 go build -o listmonk -ldflags="-s -w -X 'main.buildString=v2.0.0 (#05585b7 2021-09-29T08:59:00+0000)' -X 'main.versionString=v2.0.0'" cmd/*.go
cd frontend && /data/omnios-build/omniosorg/r151038/_extra/listmonk-2.0.0/listmonk-2.0.0/listmonk/_deps/node_modules/yarn/bin/yarn install
yarn install v1.22.11
[1/4] Resolving packages...
[2/4] Fetching packages...
/data/omnios-build/omniosorg/r151038/_extra/listmonk-2.0.0/listmonk-2.0.0/listmonk/_deps/bin/stuffbin -a stuff -in listmonk -out listmonk config.toml.sample schema.sql queries.sql static/public:/public static/email-templates frontend/dist:/admin i18n:/i18n
stuffing failed: stat frontend/dist: no such file or directory
gmake: *** [Makefile:76: pack-bin] Error 1
gmake: *** Waiting for unfinished jobs....