### PR TITLE
fix: Add a check for existing docker db volume

### DIFF
--- a/install-prod.sh
+++ b/install-prod.sh
@@ -44,6 +44,14 @@ check_dependencies() {
 	fi
 }
 
+check_existing_db_volume() {
+	info "checking for an existing docker db volume"
+	if docker volume inspect listmonk_listmonk-data >/dev/null 2>&1; then
+		error "listmonk-data volume already exists. Please use docker-compose down -v to remove old volumes for a fresh setup of PostgreSQL."
+		exit 1
+	fi
+}
+
 download() {
 	curl --fail --silent --location --output "$2" "$1"
 }
@@ -124,6 +132,7 @@ show_output(){
 
 
 check_dependencies
+check_existing_db_volume
 get_config
 get_containers
 modify_config


### PR DESCRIPTION
Fixes https://github.com/knadh/listmonk/issues/517

PostgreSQL DB container uses [initdb](https://www.postgresql.org/docs/14/app-initdb.html) to initialize the DB data directory. The password/username/DB name is set during this time. If any of these values change, these don't get updated _automagically_ since `initdb` runs only once on an absence of data directory.

So, if the `install-prod.sh` script is cancelled midway, the `listmonk-data` docker DB volume is already created. If the script is run again, it will generate a new password and set this in `docker-compose` and `config.toml`. However, this password is wrong, since the `listmonk-data` DB directory was initialized with the script's previous run's password.

This script simply checks for an existence of `listmonk_listmonk-data` volume and if it exists, errors out immediately. It is upto the user to continue (by manually changing password in `config.toml`/`docker-compose.yml`) or remove the volume (by `docker-compose down -v`

```
➜ ./install-prod.sh

>  checking for an existing docker db volume
x listmonk-data volume already exists. Please use docker-compose down -v to remove old volumes for a fresh setup of PostgreSQL.
```

