### PR TITLE
Clear placeholder on focus

### DIFF
--- a/static/public/static/style.css
+++ b/static/public/static/style.css
@@ -46,6 +46,10 @@ input[type="text"], input[type="email"], select {
     border-color: #0055d4;
   }
 
+input:focus::placeholder {
+  color: transparent;
+}
+
 .center {
   text-align: center;
 }


### PR DESCRIPTION
Because it could be disturbing for people who are not confident with forms not being able to delete words before writing.