### PR TITLE
doLogout re-defined in App.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -81,7 +81,6 @@ export default Vue.extend({
     return {
       activeItem: {},
       activeGroup: {},
-      showLogout: Boolean,
       windowWidth: window.innerWidth,
     };
   },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,7 +11,8 @@
         </template>
         <template slot="end">
           <navigation v-if="isMobile" :isMobile="isMobile"
-            :activeItem="activeItem" :activeGroup="activeGroup" @toggleGroup="toggleGroup" />
+            :activeItem="activeItem" :activeGroup="activeGroup" @toggleGroup="toggleGroup"
+            @doLogout="doLogout" />
           <b-navbar-item v-else tag="div">
             <a href="#" @click.prevent="doLogout">{{ $t('users.logout') }}</a>
           </b-navbar-item>
@@ -65,6 +66,7 @@
 <script>
 import Vue from 'vue';
 import { mapState } from 'vuex';
+import { uris } from './constants';
 
 import Navigation from './components/Navigation.vue';
 
@@ -117,6 +119,20 @@ export default Vue.extend({
           });
         }, 500);
       });
+    },
+
+    doLogout() {
+      const http = new XMLHttpRequest();
+
+      const u = uris.root.substr(-1) === '/' ? uris.root : `${uris.root}/`;
+      http.open('get', `${u}api/logout`, false, 'logout_non_user', 'logout_non_user');
+      http.onload = () => {
+        document.location.href = uris.root;
+      };
+      http.onerror = () => {
+        document.location.href = uris.root;
+      };
+      http.send();
     },
   },
 

--- a/frontend/src/components/Navigation.vue
+++ b/frontend/src/components/Navigation.vue
@@ -82,8 +82,6 @@
 
 
 <script>
-import { uris } from '../constants';
-
 export default {
   name: 'navigation',
 
@@ -99,17 +97,7 @@ export default {
     },
 
     doLogout() {
-      const http = new XMLHttpRequest();
-
-      const u = uris.root.substr(-1) === '/' ? uris.root : `${uris.root}/`;
-      http.open('get', `${u}api/logout`, false, 'logout_non_user', 'logout_non_user');
-      http.onload = () => {
-        document.location.href = uris.root;
-      };
-      http.onerror = () => {
-        document.location.href = uris.root;
-      };
-      http.send();
+      this.$emit('doLogout');
     },
   },
 };


### PR DESCRIPTION
I missed that the navbar logout button was moved back into App.vue in the previous commit.