### PR TITLE
Add MJML Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates nodejs npm
+RUN npm install -g mjml
 WORKDIR /listmonk
 COPY listmonk .
 COPY config.toml.sample config.toml

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -12,12 +12,13 @@ import (
 )
 
 type serverConfig struct {
-	Messengers   []string   `json:"messengers"`
-	Langs        []i18nLang `json:"langs"`
-	Lang         string     `json:"lang"`
-	Update       *AppUpdate `json:"update"`
-	NeedsRestart bool       `json:"needs_restart"`
-	Version      string     `json:"version"`
+	Messengers    []string   `json:"messengers"`
+	Langs         []i18nLang `json:"langs"`
+	Lang          string     `json:"lang"`
+	Update        *AppUpdate `json:"update"`
+	NeedsRestart  bool       `json:"needs_restart"`
+	Version       string     `json:"version"`
+	MJMLSupported bool       `json:"mjml_supported"`
 }
 
 // handleGetServerConfig returns general server config.
@@ -53,6 +54,8 @@ func handleGetServerConfig(c echo.Context) error {
 	out.Update = app.update
 	app.Unlock()
 	out.Version = versionString
+
+	out.MJMLSupported = mjmlSupported
 
 	return c.JSON(http.StatusOK, okResp{out})
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,8 @@ var (
 	// overridden by build flags, are relative to the CWD at runtime.
 	appDir      string = "."
 	frontendDir string = "frontend"
+
+	mjmlSupported bool
 )
 
 func init() {
@@ -197,6 +199,8 @@ func main() {
 	if ko.Bool("app.check_updates") {
 		go checkUpdates(versionString, time.Hour*24, app)
 	}
+
+	checkMJMLSupported()
 
 	// Wait for the reload signal with a callback to gracefully shut down resources.
 	// The `wait` channel is passed to awaitReload to wait for the callback to finish

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -31,6 +31,7 @@ var migList = []migFunc{
 	{"v0.9.0", migrations.V0_9_0},
 	{"v1.0.0", migrations.V1_0_0},
 	{"v2.0.0", migrations.V2_0_0},
+	{"v2.1.0", migrations.V2_1_0},
 }
 
 // upgrade upgrades the database to the current version by running SQL migration files

--- a/frontend/src/components/Editor.vue
+++ b/frontend/src/components/Editor.vue
@@ -15,6 +15,11 @@
               native-value="html"
               data-cy="check-html">{{ $t('campaigns.rawHTML') }}</b-radio>
 
+            <b-radio v-if="serverConfig.mjml_supported" v-model="form.radioFormat"
+              @input="onFormatChange" :disabled="disabled || mjmlDisallowed" name="format"
+              native-value="mjml"
+              data-cy="check-mjml">{{ $t('campaigns.rawMJML') }}</b-radio>
+
             <b-radio v-model="form.radioFormat"
               @input="onFormatChange" :disabled="disabled" name="format"
               native-value="markdown"
@@ -62,8 +67,8 @@
       </b-modal>
     </template>
 
-    <!-- raw html editor //-->
-    <html-editor v-if="form.format === 'html'" v-model="form.body" />
+    <!-- raw html / mjml editor //-->
+    <html-editor v-if="form.format === 'html' || form.format === 'mjml'" v-model="form.body" />
 
     <!-- plain text / markdown editor //-->
     <b-input v-if="form.format === 'plain' || form.format === 'markdown'"
@@ -166,6 +171,7 @@ export default {
 
   data() {
     return {
+      mjmlDisallowed: true,
       isPreviewing: false,
       isMediaVisible: false,
       isEditorFullscreen: false,
@@ -388,6 +394,16 @@ export default {
 
       return out.join('\n').replace(/\n\s*\n\s*\n/g, '\n\n');
     },
+
+    getTemplate(id) {
+      return this.$api.getTemplates().then((data) => {
+        const only = data.filter((t) => t.id === id);
+        if (only.length === 1) {
+          return only[0];
+        }
+        return null;
+      });
+    },
   },
 
   mounted() {
@@ -460,6 +476,14 @@ export default {
       }
 
       this.onEditorChange();
+    },
+
+    templateId(id) {
+      this.getTemplate(id).then((template) => {
+        if (template) {
+          this.mjmlDisallowed = template.type !== 'mjml';
+        }
+      });
     },
   },
 };

--- a/frontend/src/views/TemplateForm.vue
+++ b/frontend/src/views/TemplateForm.vue
@@ -16,8 +16,16 @@
                   :placeholder="$t('globals.fields.name')" required />
             </b-field>
 
+            <b-field :label="$t('globals.fields.type')" label-position="on-border">
+              <b-select v-model="form.type" name="type" required>
+                <option value="html">HTML</option>
+                <option value="mjml" v-if="serverConfig.mjml_supported">MJML</option>
+              </b-select>
+            </b-field>
+
             <b-field v-if="form.body !== null"
-              :label="$t('templates.rawHTML')" label-position="on-border">
+              :label="form.type.toUpperCase()"
+              label-position="on-border">
               <html-editor v-model="form.body" name="body" />
             </b-field>
 
@@ -39,6 +47,7 @@
       type='template'
       :title="previewItem.name"
       :body="form.body"
+      :contentType="form.type"
       @close="closePreview"></campaign-preview>
   </section>
 </template>
@@ -65,6 +74,7 @@ export default Vue.extend({
       // Binds form input values.
       form: {
         name: '',
+        // html | mjml
         type: '',
         optin: '',
         body: null,
@@ -97,6 +107,7 @@ export default Vue.extend({
         id: this.data.id,
         name: this.form.name,
         body: this.form.body,
+        type: this.form.type,
       };
 
       this.$api.createTemplate(data).then((d) => {
@@ -111,6 +122,7 @@ export default Vue.extend({
         id: this.data.id,
         name: this.form.name,
         body: this.form.body,
+        type: this.form.type,
       };
 
       this.$api.updateTemplate(data).then((d) => {
@@ -122,7 +134,7 @@ export default Vue.extend({
   },
 
   computed: {
-    ...mapState(['loading']),
+    ...mapState(['loading', 'serverConfig']),
   },
 
   mounted() {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -54,6 +54,7 @@
     "campaigns.progress": "Progress",
     "campaigns.queryPlaceholder": "Name or subject",
     "campaigns.rawHTML": "Raw HTML",
+    "campaigns.rawMJML": "MJML",
     "campaigns.removeAltText": "Remove alternate plain text message",
     "campaigns.richText": "Rich text",
     "campaigns.schedule": "Schedule campaign",

--- a/internal/migrations/v2.1.0.go
+++ b/internal/migrations/v2.1.0.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/koanf"
+	"github.com/knadh/stuffbin"
+)
+
+// V0_2_1 performs the DB migrations for v.2.1.0.
+func V2_1_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
+	_, err := db.Exec(`
+	DO $$
+	BEGIN
+		IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'template_type') THEN
+			CREATE TYPE template_type AS ENUM ('html', 'mjml');
+		END IF;
+	END$$;
+
+	ALTER TYPE content_type ADD VALUE IF NOT EXISTS 'mjml';
+
+	ALTER TABLE templates ADD COLUMN IF NOT EXISTS type template_type NOT NULL DEFAULT 'html';
+	`)
+	return err
+}

--- a/models/models.go
+++ b/models/models.go
@@ -43,6 +43,7 @@ const (
 	CampaignTypeOptin           = "optin"
 	CampaignContentTypeRichtext = "richtext"
 	CampaignContentTypeHTML     = "html"
+	CampaignContentTypeMJML     = "mjml"
 	CampaignContentTypeMarkdown = "markdown"
 	CampaignContentTypePlain    = "plain"
 
@@ -70,6 +71,9 @@ const (
 
 	BounceTypeHard = "hard"
 	BounceTypeSoft = "soft"
+
+	TemplateTypeHTML = "html"
+	TemplateTypeMJML = "mjml"
 )
 
 // regTplFunc represents contains a regular expression for wrapping and
@@ -196,8 +200,9 @@ type Campaign struct {
 	TemplateID  int            `db:"template_id" json:"template_id"`
 	Messenger   string         `db:"messenger" json:"messenger"`
 
-	// TemplateBody is joined in from templates by the next-campaigns query.
+	// TemplateBody and TemplateType are joined in from templates by the next-campaigns query.
 	TemplateBody string             `db:"template_body" json:"-"`
+	TemplateType string             `db:"template_type" json:"-"`
 	Tpl          *template.Template `json:"-"`
 	SubjectTpl   *template.Template `json:"-"`
 	AltBodyTpl   *template.Template `json:"-"`
@@ -235,6 +240,7 @@ type Template struct {
 
 	Name      string `db:"name" json:"name"`
 	Body      string `db:"body" json:"body,omitempty"`
+	Type      string `db:"type" json:"type"`
 	IsDefault bool   `db:"is_default" json:"is_default"`
 }
 

--- a/schema.sql
+++ b/schema.sql
@@ -4,8 +4,9 @@ DROP TYPE IF EXISTS subscriber_status CASCADE; CREATE TYPE subscriber_status AS 
 DROP TYPE IF EXISTS subscription_status CASCADE; CREATE TYPE subscription_status AS ENUM ('unconfirmed', 'confirmed', 'unsubscribed');
 DROP TYPE IF EXISTS campaign_status CASCADE; CREATE TYPE campaign_status AS ENUM ('draft', 'running', 'scheduled', 'paused', 'cancelled', 'finished');
 DROP TYPE IF EXISTS campaign_type CASCADE; CREATE TYPE campaign_type AS ENUM ('regular', 'optin');
-DROP TYPE IF EXISTS content_type CASCADE; CREATE TYPE content_type AS ENUM ('richtext', 'html', 'plain', 'markdown');
+DROP TYPE IF EXISTS content_type CASCADE; CREATE TYPE content_type AS ENUM ('richtext', 'html', 'plain', 'markdown', 'mjml');
 DROP TYPE IF EXISTS bounce_type CASCADE; CREATE TYPE bounce_type AS ENUM ('soft', 'hard', 'complaint');
+DROP TYPE IF EXISTS template_type CASCADE; CREATE TYPE template_type AS ENUM ('html', 'mjml');
 
 -- subscribers
 DROP TABLE IF EXISTS subscribers CASCADE;
@@ -58,6 +59,7 @@ CREATE TABLE templates (
     id              SERIAL PRIMARY KEY,
     name            TEXT NOT NULL,
     body            TEXT NOT NULL,
+    type            template_type NOT NULL DEFAULT 'html',
     is_default      BOOLEAN NOT NULL DEFAULT false,
 
     created_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/static/email-templates/default.mjml.tpl
+++ b/static/email-templates/default.mjml.tpl
@@ -1,0 +1,42 @@
+<mjml>
+  <mj-head>
+  	<mj-attributes>
+      <mj-text font-family="Helvetica Neue, Segoe UI, Helvetica, sans-serif" color="#444" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#F0F1F3">
+    
+    <mj-section>
+      <mj-column>
+        <mj-spacer height="50px" />
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#fff" border-radius="5px">
+      <mj-column>
+        <mj-text font-size="15px" line-height="26px">
+          {{ template "content" . }} 
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section>
+      <mj-column>
+        <mj-text font-size="12px" color="#888" align="center">
+          {{ L.T "email.unsubHelp" }}
+          <a href="{{ UnsubscribeURL }}" style="color: #888;">{{ L.T "email.unsub" }}</a>
+        </mj-text>
+        <mj-text font-size="12px" color="#888" align="center">
+          Powered by <a href="https://listmonk.app" target="_blank" style="color: #888;">listmonk</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section>
+      <mj-column>
+        <mj-raw>{{ TrackView }}</mj-raw>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>


### PR DESCRIPTION
This adds support for [MJML](https://mjml.io/). Somewhat addresses #521

As this does require the MJML CLI to be installed globally on the system (or docker container), this does somewhat break the "Single binary app" idea of listmonk. However, if the MJML CLI is not installed globally, it will simply log it in the console, and all MJML options will be hidden from the admin ui.

No worries if you feel this change is out of scope for this project due to the above.


Changes:
- Templates now have a type, which can either be HTML or MJML
- Campaign bodies have the new content type MJML. This can only be selected if the template for the campaign is also MJML
- MJML templates compile to HTML, including comment breakpoints for Outlook support
-  Added `static/email-templates/default.mjml.tpl`. While not currently used in the source code, this replicates ` static/email-templates/default.tpl` but using MJML, for reference.