### PR TITLE
fix(install-prod.sh): Make `tr` work with macOS

### DIFF
--- a/install-prod.sh
+++ b/install-prod.sh
@@ -77,7 +77,7 @@ is_running() {
 }
 
 generate_password(){
-	echo $(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+	echo $(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
 }
 
 get_config() {


### PR DESCRIPTION
Fixes https://github.com/knadh/listmonk/issues/624

Source https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string#comment393964_230684