### PR TITLE
feat: Add timezone config in app container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /listmonk
 COPY listmonk .
 COPY config.toml.sample config.toml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ x-app-defaults: &app-defaults
     - "9000:9000"
   networks:
     - listmonk
+  environment:
+    - TZ=Etc/UTC
 
 x-db-defaults: &db-defaults
   image: postgres:13


### PR DESCRIPTION
Adds `tzdata` in the `Dockerfile` of the app so that
user can pass a `TZ` env variable to the container to configure
their timezone information.

Fixes https://github.com/knadh/listmonk/issues/637 