### PR TITLE
Add AutoHeadingID option to Markdown parser

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmoiron/sqlx/types"
 	"github.com/lib/pq"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
 	null "gopkg.in/volatiletech/null.v6"
@@ -261,6 +262,9 @@ type Bounce struct {
 
 // markdown is a global instance of Markdown parser and renderer.
 var markdown = goldmark.New(
+	goldmark.WithParserOptions(
+		parser.WithAutoHeadingID(),
+	),
 	goldmark.WithRendererOptions(
 		html.WithXHTML(),
 		html.WithUnsafe(),


### PR DESCRIPTION
Having anchors created by the markdown parser allows to link directly to some part of the message.

This can be useful, for ex. if you want to create a table of contents within the message or when linking to the web version of the message.

(I didn’t sent a proposal before posting my PR since I read the contributing guidelines after coding and since it’s a really small PR, I hope you won’t mind)