### PR TITLE
Spiffy up containerized dev stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,4 +112,4 @@ rm-dev-docker: build ## Delete the docker containers including DB volumes.
 .PHONY: init-dev-docker
 init-dev-docker: build-dev-docker ## Delete the docker containers including DB volumes.
 	cd dev; \
-	docker-compose run --rm backend sh -c "make dist && yes | ./listmonk --install --config dev/config.toml"
+	docker-compose run --rm backend sh -c "make dist && ./listmonk --install --idempotent --yes --config dev/config.toml"

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,1 @@
+!config.toml

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,27 +1,43 @@
 # Docker suite for development
 
-**NOTE**: This exists only for local development. If you're interested in using Docker for a production setup, visit the [docs](https://listmonk.app/docs/installation/#docker) instead.
+**NOTE**: This exists only for local development. If you're interested in using
+Docker for a production setup, visit the
+[docs](https://listmonk.app/docs/installation/#docker) instead.
 
 ### Objective
 
-The purpose of this docker suite for local development is to isolate all the dev dependencies in a docker environment. The containers have a host volume mounted inside for the entire app directory. This helps us to not do a full `docker build` for every single local change, only restarting the docker environment is enough.
+The purpose of this Docker suite for local development is to isolate all the dev
+dependencies in a Docker environment. The containers have a host volume mounted
+inside for the entire app directory. This helps us to not do a full
+`docker build` for every single local change, only restarting the Docker
+environment is enough.
 
 ## Setting up a dev suite
 
-To spin up a local suite of
+To spin up a local suite of:
 
 - PostgreSQL
 - Mailhog
 - Node.js frontend app
 - Golang backend app
 
+### Verify your config file
+
+The config file provided at `dev/config.toml` will be used when running the
+containerized development stack. Make sure the values set within are suitable
+for the feature you're trying to develop.
+
 ### Setup DB
+
+Running this will build the appropriate images and initialize the database.
 
 ```bash
 make init-dev-docker
 ```
 
 ### Start frontend and backend apps
+
+Running this start your local development stack.
 
 ```bash
 make dev-docker
@@ -39,5 +55,8 @@ make rm-dev-docker
 
 ### See local changes in action
 
-- Backend: Anytime you do a change to the Go app, it needs to be compiled. Just run `make dev-docker` again and that should automatically handle it for you.
-- Frontend: Anytime you change the frontend code, you don't need to do anything. Since `yarn` is watching for all the changes and we have mounted the code inside the docker container, `yarn` server automatically restarts.
+- Backend: Anytime you do a change to the Go app, it needs to be compiled. Just
+  run `make dev-docker` again and that should automatically handle it for you.
+- Frontend: Anytime you change the frontend code, you don't need to do anything.
+  Since `yarn` is watching for all the changes and we have mounted the code
+  inside the docker container, `yarn` server automatically restarts.

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -1,0 +1,28 @@
+# IMPORTANT: This configuration is meant for development only
+### DO NOT USE IN PRODUCTION ###
+
+[app]
+# Interface and port where the app will run its webserver.  The default value
+# of localhost will only listen to connections from the current machine. To
+# listen on all interfaces use '0.0.0.0'. To listen on the default web address
+# port, use port 80 (this will require running with elevated permissions).
+address = "0.0.0.0:9000"
+
+# BasicAuth authentication for the admin dashboard. This will eventually
+# be replaced with a better multi-user, role-based authentication system.
+# IMPORTANT: Leave both values empty to disable authentication on admin
+# only where an external authentication is already setup.
+admin_username = "listmonk"
+admin_password = "listmonk"
+
+# Database.
+[db]
+host = "db"
+port = 5432
+user = "listmonk-dev"
+password = "listmonk-dev"
+database = "listmonk-dev"
+ssl_mode = "disable"
+max_open = 25
+max_idle = 25
+max_lifetime = "300s"


### PR DESCRIPTION
This PR suggests a few minor changes that should make the containerized dev stack a bit easier to start.

In it's current state the stack will error out on the `config.toml` file being absent, and that message easily gets buried under the rather verbose logs produced by the frontend stack. Likewise, initializing the database did not reliably work.