### PR TITLE
Added end of line config for git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 frontend/* linguist-vendored
 VERSION export-subst
+* text=auto eol=lf


### PR DESCRIPTION
Eslint complains on Windows about linebreaks not being LF, because they are the default CRLF on Windows. This change allows git to clone it with the expected EOL