### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # on how you can achieve the same. It is not intented to run out of the box
 # and you must edit the below configurations to suit your needs.
 
-version: "3.7"
+version: "3.6"
 
 x-app-defaults: &app-defaults
   restart: unless-stopped


### PR DESCRIPTION
why is my server telling me this


ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
[root@dmxtest listmonk]#