### PR TITLE
Allow also non-subscribers to receive transactional emails

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/textproto"
@@ -38,7 +39,12 @@ func handleSendTxMessage(c echo.Context) error {
 	// Get the subscriber.
 	sub, err := app.core.GetSubscriber(m.SubscriberID, "", m.SubscriberEmail)
 	if err != nil {
-		return err
+		var httpErr *echo.HTTPError
+		// If subscriber email is defined but unknown (StatusBadRequest), we can continue
+		if (errors.As(err, &httpErr) && httpErr.Code != http.StatusBadRequest) || m.SubscriberEmail == "" {
+			return err
+		}
+		sub.Email = m.SubscriberEmail
 	}
 
 	// Render the message.


### PR DESCRIPTION
Currently transactional emails are rejected for subscriber_emails that are not already stored in the subscribers table. However, the point of transaction emails is to for example send a verification email at account creation before an email is confirmed. In these cases we don't subscribe a user to mailing list but might send that email exactly once.

Long story short, that PR allows api/tx to accept subscriber_emails that are not known already. I've successfully tested it locally.