### PR TITLE
Fix bug in template cache that stored only references of the last template

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -443,7 +443,8 @@ func initTxTemplates(m *manager.Manager, app *App) {
 			lo.Printf("error compiling transactional template %d: %v", t.ID, err)
 			continue
 		}
-		m.CacheTpl(t.ID, &t)
+		var copy models.Template = t
+		m.CacheTpl(t.ID, &copy)
 	}
 }
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/textproto"
@@ -38,7 +39,12 @@ func handleSendTxMessage(c echo.Context) error {
 	// Get the subscriber.
 	sub, err := app.core.GetSubscriber(m.SubscriberID, "", m.SubscriberEmail)
 	if err != nil {
-		return err
+		var httpErr *echo.HTTPError
+		// If subscriber email is defined but unknown (StatusBadRequest), we can continue
+		if (errors.As(err, &httpErr) && httpErr.Code != http.StatusBadRequest) || m.SubscriberEmail == "" {
+			return err
+		}
+		sub.Email = m.SubscriberEmail
 	}
 
 	// Render the message.


### PR DESCRIPTION
The template cache `tpls` stores pointers to templates and is initially loaded with the existing templates using a reference to a for-loop variable. As the variable is the same and just the value changes, the reference stays the same, so that all entries in `tpls` are identical with the consequence that the whole cache stores just the last loaded template.

I fixed it by creating a copying of the loop-variable and store the reference to that one. Ideally, you could consider storing the templates by-value instead of by-reference in `tpls` to prevent these little issues 😊 

Another thing I'm worried about: The in-memory template cache prevents Listmonk from being horizontally scaled, what you would typically do in production in k8s. Mutliple Listmonk replicas in a cluster may start with identical caches, but get out of sync the moment a template is created/updated as that is processed. Only the one replica processing the request has the lattest cache entry.

My proposal is to either:
1. completely remove the cache
2. allow to disable the cache via config
3. give the cache entries a short TTL

What do you think?