### PR TITLE
Use `Return-Path` header as SMTP envelope sender if set

### DIFF
--- a/frontend/src/views/Campaign.vue
+++ b/frontend/src/views/Campaign.vue
@@ -130,7 +130,7 @@
 
                 <div>
                   <p class="has-text-right">
-                    <a href="#" class="is-size-7" @click.prevent="showHeaders"
+                    <a href="#" @click.prevent="showHeaders"
                       data-cy="btn-headers">
                       <b-icon icon="plus" />{{ $t('settings.smtp.setCustomHeaders') }}
                     </a>

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -11,7 +11,10 @@ import (
 	"github.com/knadh/smtppool"
 )
 
-const emName = "email"
+const (
+	emName        = "email"
+	HdrReturnPath = "Return-Path"
+)
 
 // Server represents an SMTP server's credentials.
 type Server struct {
@@ -125,16 +128,23 @@ func (e *Emailer) Push(m messenger.Message) error {
 	}
 
 	em.Headers = textproto.MIMEHeader{}
-	// Attach e-mail level headers.
-	if len(m.Headers) > 0 {
-		em.Headers = m.Headers
-	}
 
 	// Attach SMTP level headers.
-	if len(srv.EmailHeaders) > 0 {
-		for k, v := range srv.EmailHeaders {
-			em.Headers.Set(k, v)
-		}
+	for k, v := range srv.EmailHeaders {
+		em.Headers.Set(k, v)
+	}
+
+	// Attach e-mail level headers.
+	// Individual headers values override SMTP level headers.
+	for k, v := range m.Headers {
+		em.Headers.Set(k, v[0])
+	}
+
+	// If the `Return-Path` header is set, it should be set as the
+	// the SMTP envelope sender (via the Sender field of the email struct).
+	if sender := em.Headers.Get(HdrReturnPath); sender != "" {
+		em.Sender = sender
+		em.Headers.Del(HdrReturnPath)
 	}
 
 	switch m.ContentType {


### PR DESCRIPTION
Based on the discussion in https://github.com/knadh/listmonk/issues/908.

This is my alternative proposal how to set the SMPT envelope sender based on `Return-Path` header set on the SMTP or per-message level.

Dependent on this PR (+ update of dependency here) https://github.com/knadh/smtppool/pull/7