### PR TITLE
Added support to run list monk within IIS

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -707,18 +707,25 @@ func initHTTPServer(app *App) *echo.Echo {
 	}
 
 	// Register all HTTP handlers.
-	initHTTPHandlers(srv, app)
-
-	// Start the server.
-	go func() {
-		if err := srv.Start(ko.String("app.address")); err != nil {
-			if strings.Contains(err.Error(), "Server closed") {
-				lo.Println("HTTP server shut down")
-			} else {
-				lo.Fatalf("error starting HTTP server: %v", err)
-			}
-		}
-	}()
+    initHTTPHandlers(srv, app)
+    port := ko.String("app.port")
+    if os.Getenv("ASPNETCORE_PORT") != "" { // get enviroment variable that set by ACNM
+        port = os.Getenv("ASPNETCORE_PORT")
+        lo.Println("port retrieved from aspnetcore")
+    } else {
+        lo.Println("Could not find aspnet core port via IIS")
+    }
+    // Start the server.
+    lo.Println("HTTP starting on: " + "app.address" + ":" + port)
+    go func() {
+        if err := srv.Start(ko.String("app.address") + ":" + port); err != nil {
+            if strings.Contains(err.Error(), "Server closed") {
+                lo.Println("HTTP server shut down")
+            } else {
+                lo.Fatalf("error starting HTTP server: %v", err)
+            }
+        }
+    }()
 
 	return srv
 }

--- a/web.config
+++ b/web.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <system.webServer>
+        <handlers>
+            <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+        </handlers>
+        <aspNetCore processPath=".\listmonk.exe" />
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
This is a modification to allow listmonk to run within IIS. 
**Problem:**
By default IIS assumes your app will be able to be told what random port to run on at each IIS/webapp startup. Listmonk had no way of knowing what port it should launch on (IIS sets it and it's up to the web app to find and use it).
**Solution:**
This change allows listmonk to check for the ASPNETCORE_PORT as set by ACNM, and then use this value for the listening port, and if no value is found, use the config.toml value as per usual.
There's also the addition of a web.config file that allows IIS to run listmonk as an aspnetcore web app. It's generic and simply tells IIS what to launch.
**Notes:**
These settings changes are specific to windows builds (.exe)
Hopefully these help someone run under IIS and don't break anything else.