### PR TITLE
Issue 1017: Connection to Serverless Database Clusters

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -248,6 +248,7 @@ func initDB() *sqlx.DB {
 		MaxOpen     int           `koanf:"max_open"`
 		MaxIdle     int           `koanf:"max_idle"`
 		MaxLifetime time.Duration `koanf:"max_lifetime"`
+		Options     string        `koanf:"options"`
 	}
 	if err := ko.Unmarshal("db", &c); err != nil {
 		lo.Fatalf("error loading db config: %v", err)
@@ -255,7 +256,7 @@ func initDB() *sqlx.DB {
 
 	lo.Printf("connecting to db: %s:%d/%s", c.Host, c.Port, c.DBName)
 	db, err := sqlx.Connect("postgres",
-		fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", c.Host, c.Port, c.User, c.Password, c.DBName, c.SSLMode))
+		fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s options=%s", c.Host, c.Port, c.User, c.Password, c.DBName, c.SSLMode, c.Options))
 	if err != nil {
 		lo.Fatalf("error connecting to DB: %v", err)
 	}


### PR DESCRIPTION
[See Issue : Issue-1016](https://github.com/knadh/listmonk/issues/1016#issue-1440776166) 
# Summary 
This pull request , attempts to fix the issue while connecting to serverless PostgreSQL instances like cockroachdb, etc. It does so by passing an extra argument `options` which is supported by `sqlX` and subsequently `databases/sql` of Golang . 

# Issue
Migrations cannot be run as cockroachdb doesn't support DROP TYPE CASCADE . Which inturn is making everything miserable.
# Attempted Fixes:
- Running migrations from the schema.sql on Cockroachdb's online migration manager - Didn't Work ❌
- Running migrations from cockroach CLI from schema.sql - Didn't Work ❌
- Running migrations from cockroach CLI from shema.sql while removing CASCADE from all DROPs - Partially Worked ✅


Upon this if we try to run it runs into a migration issue , and migration then causes a bunch of other issues while trying to apply them! 