### PR TITLE
Add subscription created_at, updated_at when listing subscribers list

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -220,7 +220,9 @@ type List struct {
 	SubscriberID     int            `db:"subscriber_id" json:"-"`
 
 	// This is only relevant when querying the lists of a subscriber.
-	SubscriptionStatus string `db:"subscription_status" json:"subscription_status,omitempty"`
+	SubscriptionStatus    string    `db:"subscription_status" json:"subscription_status,omitempty"`
+	SubscriptionCreatedAt null.Time `db:"subscription_created_at" json:"subscription_created_at,omitempty"`
+	SubscriptionUpdatedAt null.Time `db:"subscription_updated_at" json:"subscription_updated_at,omitempty"`
 
 	// Pseudofield for getting the total number of subscribers
 	// in searches and queries.

--- a/queries.sql
+++ b/queries.sql
@@ -38,7 +38,13 @@ SELECT * FROM lists
 WITH subs AS (
     SELECT subscriber_id, JSON_AGG(
         ROW_TO_JSON(
-            (SELECT l FROM (SELECT subscriber_lists.status AS subscription_status, lists.*) l)
+            (SELECT l FROM (
+                SELECT
+                    subscriber_lists.status AS subscription_status,
+                    subscriber_lists.created_at AS subscription_created_at,
+                    subscriber_lists.updated_at AS subscription_updated_at,
+                    lists.*
+            ) l)
         )
     ) AS lists FROM lists
     LEFT JOIN subscriber_lists ON (subscriber_lists.list_id = lists.id)


### PR DESCRIPTION
Right now the api returns subscribers list subscription with 'updated_at', 'created_at' values from the list itself.

When trying to synchronise subscription status with an external system, accessing subscription 'updated_at', 'created_at' values might be useful as well. 

This commit is adding subscription_created_at, subscription_updated_at attributes to list information:

```json
{
	"id": 1,
	"created_at": "2022-11-08T23:02:38.187513Z",
	"updated_at": "2022-11-08T23:02:38.187513Z",
	"uuid": "0e4106c8-707d-4f34-b719-d28114ccd49f",
	"email": "john@example.com",
	"name": "John Doe",
	"attribs": {
		"city": "Bengaluru",
		"good": true,
		"type": "known"
	},
	"status": "enabled",
	"lists": [
            {
		"subscription_status": "unsubscribed",
		"subscription_created_at": "2022-11-08T23:02:38.187513+00:00",  /* NEW */
		"subscription_updated_at": "2022-11-08T23:27:01.351319+00:00",  /* NEW */
		"id": 1,
		"uuid": "db41ca4e-a460-49b6-9b82-517bce96c378",
		"name": "Default list",
		"type": "private",
		"optin": "single",
		"tags": [
			"test"
		],
		"description": "",
		"created_at": "2022-11-08T23:02:38.183927+00:00",
		"updated_at": "2022-11-08T23:02:38.183927+00:00"
	    }
        ]
}
```