### PR TITLE
Fix maintenance settings title

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -110,7 +110,7 @@ const routes = [
   {
     path: '/settings/maintenance',
     name: 'maintenance',
-    meta: { title: 'logs.title', group: 'settings' },
+    meta: { title: 'maintenance.title', group: 'settings' },
     component: () => import(/* webpackChunkName: "main" */ '../views/Maintenance.vue'),
   },
 ];


### PR DESCRIPTION
It showed "Logs" instead of "Maintenance" in the tab title