### PR TITLE
accessibility fix for subscription form

### DIFF
--- a/static/public/templates/subscription-form.html
+++ b/static/public/templates/subscription-form.html
@@ -6,14 +6,14 @@
     <form method="post" action="" class="form">
         <div>
             <p>
-                <label>{{ L.T "subscribers.email" }}</label>
-                <input name="email" required="true" type="email" placeholder="{{ L.T "subscribers.email" }}" autofocus="true" >
+                <label for="email">{{ L.T "subscribers.email" }}</label>
+                <input id="email" name="email" required="true" type="email" placeholder="{{ L.T "subscribers.email" }}" autofocus="true" >
 
                 <input name="nonce" class="nonce" value="" />
             </p>
             <p>
-                <label>{{ L.T "public.subName" }}</label>
-                <input name="name" type="text" placeholder="{{ L.T "public.subName" }}" >
+                <label for="name">{{ L.T "public.subName" }}</label>
+                <input id="name" name="name" type="text" placeholder="{{ L.T "public.subName" }}" >
             </p>
             <br />
             <ul class="lists">


### PR DESCRIPTION
**What's the issue :**
Currently, there are no ids or aria-labels in the public subscription forms. These are helpful for accessibility.

[Link to issue](https://github.com/knadh/listmonk/issues/697)

**What's the solution:**

Add _for_ attribute to label tag and _id_ attribute to input tag. 

Label tag with _for_ attribute takes care of handling accessibility for input tag. Refer this document for more info [doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#accessibility_concerns)

**Screenshot of proof:**
![image](https://user-images.githubusercontent.com/29778698/210934074-2f93f3e3-4723-47bd-9648-9484f163b055.png)


