### PR TITLE
Enable TxMessage attachments through API 

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/knadh/listmonk/internal/manager"
+	"github.com/knadh/listmonk/internal/messenger"
 	"github.com/knadh/listmonk/models"
 	"github.com/labstack/echo/v4"
 )
@@ -85,6 +86,13 @@ func handleSendTxMessage(c echo.Context) error {
 		msg.ContentType = m.ContentType
 		msg.Messenger = m.Messenger
 		msg.Body = m.Body
+		for _, attch := range m.Attachments {
+			msg.Attachments = append(msg.Attachments, messenger.Attachment{
+				Name:    attch.Name,
+				Content: attch.Content,
+				Header:  messenger.MakeAttachmentHeader(attch.Name, "base64"),
+			})
+		}
 
 		// Optional headers.
 		if len(m.Headers) != 0 {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -411,16 +411,7 @@ func (m *Manager) worker() {
 				return
 			}
 
-			err := m.messengers[msg.Messenger].Push(messenger.Message{
-				From:        msg.From,
-				To:          msg.To,
-				Subject:     msg.Subject,
-				ContentType: msg.ContentType,
-				Body:        msg.Body,
-				AltBody:     msg.AltBody,
-				Subscriber:  msg.Subscriber,
-				Campaign:    msg.Campaign,
-			})
+			err := m.messengers[msg.Messenger].Push(msg.Message)
 			if err != nil {
 				m.logger.Printf("error sending message '%s': %v", msg.Subject, err)
 			}

--- a/models/models.go
+++ b/models/models.go
@@ -361,10 +361,18 @@ type TxMessage struct {
 	ContentType string                 `json:"content_type"`
 	Messenger   string                 `json:"messenger"`
 
+	Attachments []Attachment `json:"attachments"`
+
 	Subject    string             `json:"-"`
 	Body       []byte             `json:"-"`
 	Tpl        *template.Template `json:"-"`
 	SubjectTpl *txttpl.Template   `json:"-"`
+}
+
+// Attachment is used by TxMessage, consists of FileName and file Content in bytes
+type Attachment struct {
+	Name    string `json:"name"`
+	Content []byte `json:"content"`
 }
 
 // markdown is a global instance of Markdown parser and renderer.


### PR DESCRIPTION
This implementation allows for attachments in transactional messages.  
Tested with Email messenger.  
No additional validation, since file/name should be checked by API client.  

Helpful for sending invoices, tickets etc.

Semi fixes issue #241