### PR TITLE
Fix #1155. Empty output subscribers query, who finish campaign

### DIFF
--- a/queries.sql
+++ b/queries.sql
@@ -688,33 +688,28 @@ campLists AS (
     LEFT JOIN campaign_lists ON (campaign_lists.list_id = lists.id)
     WHERE campaign_lists.campaign_id = $1
 ),
-subIDs AS (
-    SELECT DISTINCT ON (sl.subscriber_id) sl.subscriber_id, sl.list_id, sl.status FROM subscriber_lists sl
-    INNER JOIN subscribers ON (subscribers.id = sl.subscriber_id AND subscribers.status!='blocklisted')
+subs AS (
+    select subscribers.* from subscribers
+    INNER JOIN subscriber_lists sl ON (subscribers.id = sl.subscriber_id)
+    LEFT JOIN campLists ON (campLists.list_id = sl.list_id)
     WHERE
         -- ARRAY_AGG is 20x faster instead of a simple SELECT because the query planner
         -- understands the CTE's cardinality after the scalar array conversion. Huh.
         sl.list_id = ANY((SELECT ARRAY_AGG(list_id) FROM campLists)::INT[]) AND
         sl.status != 'unsubscribed' AND
         sl.subscriber_id > (SELECT last_subscriber_id FROM camps) AND
-        sl.subscriber_id <= (SELECT max_subscriber_id FROM camps)
-    ORDER BY sl.subscriber_id LIMIT $2
-),
-subs AS (
-    SELECT subscribers.* FROM subIDs
-    LEFT JOIN campLists ON (campLists.list_id = subIDs.list_id)
-    INNER JOIN subscribers ON (
-        subscribers.id = subIDs.subscriber_id AND
+        sl.subscriber_id <= (SELECT max_subscriber_id FROM camps) and
+        subscribers.status!='blocklisted' and 
         (CASE
             -- For optin campaigns, only e-mail 'unconfirmed' subscribers.
-            WHEN (SELECT type FROM camps) = 'optin' THEN subIDs.status = 'unconfirmed' AND campLists.optin = 'double'
+            WHEN (SELECT type FROM camps) = 'optin' THEN sl.status = 'unconfirmed'
             -- For regular campaigns with double optin lists, only e-mail 'confirmed' subscribers.
-            WHEN campLists.optin = 'double' THEN subIDs.status = 'confirmed'
+            WHEN campLists.optin = 'double' THEN sl.status = 'confirmed'
             -- For regular campaigns with non-double optin lists, e-mail everyone
             -- except unsubscribed subscribers.
-            ELSE subIDs.status != 'unsubscribed'
+            ELSE sl.status != 'unsubscribed'
         END)
-    )
+    ORDER BY sl.subscriber_id LIMIT $2
 ),
 u AS (
     UPDATE campaigns


### PR DESCRIPTION
Fix problem Campaign goes to finished status without reaching all subscribers #1155. 

It was in us, when we import big blacklisted base at start work with listmonk, and future lists have blocklisted subscribers but they wasn't unsubscribed. It was problem, because at first sample in query, find only unsubscribed emails, but in finish all unsubscribed finish transform in empty, because all of them is blacklisted. This element stop campaign, despite the remaining large number of emails on the mailing list, despite the remaining large number of emails on the mailing list.