### PR TITLE
build: push docker image to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Prepare Dependencies
         run: |
           make dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,14 +32,25 @@ archives:
       - LICENSE
 
 dockers:
-  -
-    goos: linux
+  - goos: linux
     goarch: amd64
     ids:
     - listmonk
     image_templates:
     - "listmonk/listmonk:latest"
     - "listmonk/listmonk:{{ .Tag }}"
+    - "ghcr.io/knadh/{{ .ProjectName }}:latest"
+    - "ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}"
+    build_flag_templates:
+    - --platform=linux/amd64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.description={{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=AGPL-3.0
     dockerfile: Dockerfile
     extra_files:
     - config.toml.sample


### PR DESCRIPTION
With the new recent changes in dockerhub[1], we should start pushing images to ghcr, and eventually phase out the existing dockerhub setup.

This PR adds a few configuration steps required to push images to ghcr alongside dockerhub.

[1]: https://blog.alexellis.io/docker-is-deleting-open-source-images/