### PR TITLE
add support for arm binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,11 @@ builds:
       - netbsd
     goarch:
       - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
     ldflags:
       - -s -w -X "main.buildString={{ .Tag }} ({{ .ShortCommit }} {{ .Date }})" -X "main.versionString={{ .Tag }}"
 


### PR DESCRIPTION
Related to #544 

Updates `.goreleaser.yml` to compile binaries for aarch64, armhf and armv7. 

Tested on my fork of this repository.