### PR TITLE
Add more functions to notification template parsing

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/jmoiron/sqlx"
 	"github.com/jmoiron/sqlx/types"
 	"github.com/knadh/goyesql/v2"
@@ -602,12 +603,22 @@ func initNotifTemplates(path string, fs stuffbin.FileSystem, i *i18n.I18n, cs *c
 		"LogoURL": func() string {
 			return cs.LogoURL
 		},
+		"Date": func(layout string) string {
+			if layout == "" {
+				layout = time.ANSIC
+			}
+			return time.Now().Format(layout)
+		},
 		"L": func() *i18n.I18n {
 			return i
 		},
 		"Safe": func(safeHTML string) template.HTML {
 			return template.HTML(safeHTML)
 		},
+	}
+
+	for k, v := range sprig.GenericFuncMap() {
+		funcs[k] = v
 	}
 
 	tpls, err := stuffbin.ParseTemplatesGlob(funcs, fs, "/static/email-templates/*.html")


### PR DESCRIPTION
I wanted to add a copyright notification in the footer of my newsletters. I can use the `Date` function in the campaign body, but not in any of the `static/email-templates/*.html` files.

```diff
 {{ define "footer" }}
     </div>
     
     <div class="footer">
         <p>{{ L.T "public.poweredBy" }} <a href="https://listmonk.app" target="_blank">listmonk</a></p>
+        <small>&copy; {{ Date "2006" }}</small>
     </div>
     <div class="gutter">&nbsp;</div>
 </body>
 </html>
 {{ end }}
```

Try to add the above modification, and:

```console
$ ./listmonk --static-dir=static
2023/03/25 15:30:13 main.go:99: v2.4.0 (c668523 2023-03-20T13:50:31Z)
2023/03/25 15:30:13 init.go:138: reading config: config.toml
2023/03/25 15:30:13 init.go:266: connecting to db: /var/run/postgresql/:5432/listmonk
2023/03/25 15:30:14 init.go:225: loading static files from: static
2023/03/25 15:30:14 init.go:585: media upload provider: filesystem
2023/03/25 15:30:14 init.go:615: error parsing e-mail notif templates: template: base.html:94: function "Date" not defined
```

This PR adds in the `Date` function, as well as sprig functions.