### PR TITLE
feat: add new link to no-code editor in the i18n docs

### DIFF
--- a/docs/docs/content/i18n.md
+++ b/docs/docs/content/i18n.md
@@ -14,12 +14,11 @@ These additional language packs can be downloaded and passed to listmonk with th
 
 To customize an existing language or to load a new language, put one or more `.json` language files in a directory, and pass the directory path to listmonk with the<br />`--i18n-dir=/path/to/dir` flag.
 
+## Language contributions
 
-## Contributing a new language
+- Go to https://inlang.com/editor/github.com/knadh/listmonk
+- To make changes and push them, you need to log in to GitHub using OAuth and fork the project from the UI.
+- Translate the text in the input fields on the UI. You can use the filters to see only the necessary translations.
+- Once you're done, push the changes from the UI and click on "Open a pull request." This will take you to GitHub, where you can write a PR message.
 
-- Visit [https://listmonk.app/i18n](https://listmonk.app/i18n)
-- To make changes to an existing language, use the "Load language" option on the top right.
-- To create a new language, use the "Load language" option on the top right and select "Default".
-- Translate the text in the input fields on the UI.
-- Once done, use the `Switch to raw JSON` and copy the JSON data and save it to a file named `xx.json`, where `xx` is the two letter code of the language.
-- Send a pull request to add the file to the [i18n directory on the GitHub repo](https://github.com/knadh/listmonk/tree/master/i18n). If you are not familiar with pull requests, share the file by creating a new "issue"  (comment) on the [GitHub issues page](https://github.com/knadh/listmonk/issues)
+Creating new languages from the editor will be possible soon.


### PR DESCRIPTION
Hey folks ☕️,

added the link of i18n no-code editor inlang to the docs. 

![image](https://user-images.githubusercontent.com/58360188/227892285-c91007db-abc0-4e81-8ab7-26cc51eb1acd.png)
