### PR TITLE
add translation status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ __________________
 
 
 ## Developers
-listmonk is a free and open source software licensed under AGPLv3. If you are interested in contributing, refer to the [developer setup](https://listmonk.app/docs/developer-setup). The backend is written in Go and the frontend is Vue with Buefy for UI. 
+listmonk is a free and open source software licensed under AGPLv3. If you are interested in contributing, refer to the [developer setup](https://listmonk.app/docs/developer-setup). The backend is written in Go and the frontend is Vue with Buefy for UI.
+
+### Translation status
+[![translation badge](https://inlang.com/badge?url=github.com/knadh/listmonk)](https://inlang.com/editor/github.com/knadh/listmonk?ref=badge)
 
 
 ## License


### PR DESCRIPTION
Hey there, we want to get you more contributors to your repository!
Therefore, I added a badge which lets users contribute to your translations.

The badge endpoint allows you to create a dynamic badge that display real-time data on your project. For instance, you can use it to showcase your project's localization progress or the number of errors/warnings on your Github repository. This means that whenever someone views the badge, they will see the most up-to-date information about your project.

For your project, the badge looks like this:
(this image is already auto generated)

[![translation badge](https://inlang.com/badge?url=github.com/knadh/listmonk)](https://inlang.com/editor/github.com/knadh/listmonk?ref=badge)

We would be really happy if you decide to place this into your README to let people contribute to your translations 🥰

– Thank you,
Felix