### PR TITLE
Enable extra system calls in systemd service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: goreleaser
 
-on:
-  push:
-    tags:
-      - "v*" # Will trigger only if tag is pushed matching pattern `v*` (Eg: `v0.1.0`)
+on: workflow_dispatch
+
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: goreleaser
 
-on: workflow_dispatch
-
+on:
+  push:
+    tags:
+      - "v*" # Will trigger only if tag is pushed matching pattern `v*` (Eg: `v0.1.0`)
 
 jobs:
   goreleaser:

--- a/listmonk@.service
+++ b/listmonk@.service
@@ -35,7 +35,7 @@ SystemCallArchitectures=native
 # Only enable a reasonable set of system calls.
 # see: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#SystemCallFilter=
 SystemCallFilter=@system-service
-SystemCallFilter=~@privileged @resources
+SystemCallFilter=~@privileged
 # ProtectSystem=strict, which is implied by DynamicUser=True, already disabled write calls
 # to the entire filesystem hierarchy, leaving only /dev/, /proc/, and /sys/ writable.
 # listmonk doesn’t need access to those so might as well disable them.


### PR DESCRIPTION
Proposed fix for #1310. 

Since v2.4.0, it looks like Listmonk is making system calls for changing resource limits, memory or scheduling parameters. This PR allows those system calls in the systemd service configuration. This allows Listmonk to run as a systemd service.

The downside of this change is that it weakens the sandbox around the Listmonk process when run as a systemd service. I don't fully understand how systemd works, but I don't expect any serious consequence.