### PR TITLE
feat: add multiarch docker build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
           make dist
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: --parallelism 1 --rm-dist --skip-validate
+          args: release --parallelism 1 --clean --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.19
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - 6
       - 7
     ldflags:
-      - -s -w -X "main.buildString={{ .Tag }} ({{ .ShortCommit }} {{ .Date }})" -X "main.versionString={{ .Tag }}"
+      - -s -w -X "main.buildString={{ .Tag }} {{ .Release.Goos }}/{{ .Release.Goarch }} ({{ .ShortCommit }} {{ .Date }})" -X "main.versionString={{ .Tag }}"
 
     hooks:
       # stuff executables with static assets.
@@ -37,15 +37,16 @@ archives:
       - LICENSE
 
 dockers:
-  - goos: linux
+  - use: buildx
+    goos: linux
     goarch: amd64
     ids:
     - listmonk
     image_templates:
-    - "listmonk/listmonk:latest"
-    - "listmonk/listmonk:{{ .Tag }}"
-    - "ghcr.io/knadh/{{ .ProjectName }}:latest"
-    - "ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}"
+    - "listmonk/{{ .ProjectName }}:latest-amd64"
+    - "listmonk/{{ .ProjectName }}:{{ .Tag }}-amd64"
+    - "ghcr.io/knadh/{{ .ProjectName }}:latest-amd64"
+    - "ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-amd64"
     build_flag_templates:
     - --platform=linux/amd64
     - --label=org.opencontainers.image.title={{ .ProjectName }}
@@ -60,3 +61,103 @@ dockers:
     extra_files:
     - config.toml.sample
     - config-demo.toml
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - listmonk
+    image_templates:
+    - "listmonk/{{ .ProjectName }}:latest-arm64v8"
+    - "listmonk/{{ .ProjectName }}:{{ .Tag }}-arm64v8"
+    - "ghcr.io/knadh/{{ .ProjectName }}:latest-arm64v8"
+    - "ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-arm64v8"
+    build_flag_templates:
+    - --platform=linux/arm64/v8
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.description={{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=AGPL-3.0
+    dockerfile: Dockerfile
+    extra_files:
+    - config.toml.sample
+    - config-demo.toml
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    ids:
+    - listmonk
+    image_templates:
+    - "listmonk/{{ .ProjectName }}:latest-armv6"
+    - "listmonk/{{ .ProjectName }}:{{ .Tag }}-armv6"
+    - "ghcr.io/knadh/{{ .ProjectName }}:latest-armv6"
+    - "ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-armv6"
+    build_flag_templates:
+    - --platform=linux/arm/v6
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.description={{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=AGPL-3.0
+    dockerfile: Dockerfile
+    extra_files:
+    - config.toml.sample
+    - config-demo.toml
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    ids:
+    - listmonk
+    image_templates:
+    - "listmonk/{{ .ProjectName }}:latest-armv7"
+    - "listmonk/{{ .ProjectName }}:{{ .Tag }}-armv7"
+    - "ghcr.io/knadh/{{ .ProjectName }}:latest-armv7"
+    - "ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-armv7"
+    build_flag_templates:
+    - --platform=linux/arm/v7
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.description={{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/knadh/{{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=AGPL-3.0
+    dockerfile: Dockerfile
+    extra_files:
+    - config.toml.sample
+    - config-demo.toml
+
+docker_manifests:
+  - name_template: listmonk/{{ .ProjectName }}:latest
+    image_templates:
+      - listmonk/{{ .ProjectName }}:latest-amd64
+      - listmonk/{{ .ProjectName }}:latest-arm64v8
+      - listmonk/{{ .ProjectName }}:latest-armv6
+      - listmonk/{{ .ProjectName }}:latest-armv7
+  - name_template: listmonk/{{ .ProjectName }}:{{ .Tag }}
+    image_templates:
+      - listmonk/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - listmonk/{{ .ProjectName }}:{{ .Tag }}-arm64v8
+      - listmonk/{{ .ProjectName }}:{{ .Tag }}-armv6
+      - listmonk/{{ .ProjectName }}:{{ .Tag }}-armv7
+  - name_template: ghcr.io/knadh/{{ .ProjectName }}:latest
+    image_templates:
+      - ghcr.io/knadh/{{ .ProjectName }}:latest-amd64
+      - ghcr.io/knadh/{{ .ProjectName }}:latest-arm64v8
+      - ghcr.io/knadh/{{ .ProjectName }}:latest-armv6
+      - ghcr.io/knadh/{{ .ProjectName }}:latest-armv7
+  - name_template: ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}
+    image_templates:
+      - ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-arm64v8
+      - ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-armv6
+      - ghcr.io/knadh/{{ .ProjectName }}:{{ .Tag }}-armv7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - 6
       - 7
     ldflags:
-      - -s -w -X "main.buildString={{ .Tag }} {{ .Release.Goos }}/{{ .Release.Goarch }} ({{ .ShortCommit }} {{ .Date }})" -X "main.versionString={{ .Tag }}"
+      - -s -w -X "main.buildString={{ .Tag }} ({{ .ShortCommit }} {{ .Date }}, {{ .Os }}/{{ .Arch }})" -X "main.versionString={{ .Tag }}"
 
     hooks:
       # stuff executables with static assets.


### PR DESCRIPTION
- Added docker build support for the following platforms:
  - amd64 (default)
  - arm64v8
  - armv6
  - armv7
- Added `GOOS` and `GOARCH` information to the `buildString`
- Added docker manifest details to store image architecture metadata
- Updated `docker/login-action` from `v1` to `v2`
- Updated `goreleaser/goreleaser-action` from `v2` to `v4`

Tested the images locally, built with `goreleaser` and seems to be working fine. Screenshots:

#### Build Images
![image](https://github.com/knadh/listmonk/assets/11243138/96b0a149-d135-4741-ba81-e80da50a5863)

#### Running Containers
![image](https://github.com/knadh/listmonk/assets/11243138/a9984e14-3313-4722-8f66-dce8eff23026)

#### Container Binary Build Info
![image](https://github.com/knadh/listmonk/assets/11243138/9fe7acc1-1cee-4e26-a958-3432ebeee226)
