### PR TITLE
Better Feedback when trying SMTP Test with existing creds

### DIFF
--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -262,6 +262,17 @@ func handleTestSMTPSettings(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.missingFields", "name", "email"))
 	}
 
+	password := ko.String("password")
+	// now we have to check if the password only contains •••••••••••••••• chars because
+	// then we want to load the stored password instead.
+	// but currently this is not yet supported so at least we need to inform the user to avoid
+	// confusion:
+	if password == strings.Repeat(pwdMask, utf8.RuneCountInString(password)) {
+		errStr := "Doing a Test connection with a pre-existing/saved password is currently not supported. You can only test the connection for a new password (without saving it before)"
+		app.log.Printf(errStr)
+		return echo.NewHTTPError(http.StatusInternalServerError, errStr)
+	}
+
 	// Initialize a new SMTP pool.
 	req.MaxConns = 1
 	req.IdleTimeout = time.Second * 2


### PR DESCRIPTION
Since the SMTP Test is only working for unsaved passwords (as otherwise the password is just ******) I would at least love to give that feedback to the user.

If you feel this is the wrong approach and we rather should then read it from the database and run the Test Mail, fine by me as well HOWEVER I think we need a better UX either way to make it clear what's happening.

So if you think this solution is good in the meantime providing proper Error message, please merge :)
