### PR TITLE
Making Dockerfile more flexible for builds in different CPU arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,28 @@
+FROM node:19-alpine as front-builder
+
+RUN apk add --no-cache alpine-sdk
+
+WORKDIR /app
+ADD . /app
+
+RUN make build-frontend
+
+FROM golang:alpine as builder
+
+RUN apk add --no-cache alpine-sdk
+
+WORKDIR /app
+ADD . /app
+COPY --from=front-builder /app/frontend /app/frontend
+
+RUN make dist
+
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /listmonk
-COPY listmonk .
+
+COPY --from=builder /app/listmonk .
+
 COPY config.toml.sample config.toml
 COPY config-demo.toml .
 CMD ["./listmonk"]


### PR DESCRIPTION
Using Listmonk on Arm64 from Docker is quite complex unless you build a binary and copy it to the container, which is a lot more work than just running the `docker build` command.
This PR makes Dockerfile more flexible to just run Docker Build with all of the build processes that Listmonk has, which comes with a benefit that if you need to build for Arm64, then use the Docker cross arch builder command.