### PR TITLE
📝🐛 — Fix /api/subscribers/lists doc

### DIFF
--- a/docs/docs/content/apis/subscribers.md
+++ b/docs/docs/content/apis/subscribers.md
@@ -291,6 +291,7 @@ Modify subscriber list memberships.
 
 ```shell
 curl -u 'username:password' -X PUT 'http://localhost:9000/api/subscribers/lists' \
+-H 'Content-Type: application/json' \
 --data-raw '{"ids": [1, 2, 3], "action": "add", "target_list_ids": [4, 5, 6], "status": "confirmed"}'
 ```
 


### PR DESCRIPTION
The doc was missing the `Content-Type: application/json` header, making it unusable.