### PR TITLE
feat: docker compose with alpine for postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ x-app-defaults: &app-defaults
     - TZ=Etc/UTC
 
 x-db-defaults: &db-defaults
-  image: postgres:13
+  image: postgres:13-alpine
   ports:
     - "9432:5432"
   networks:


### PR DESCRIPTION
listmonk is using alpine already, so why not use alpine for postgres too and save a few MB of network traffic and storage space.