### PR TITLE
feat: added Forward Email to SMTP providers list

### DIFF
--- a/frontend/src/views/settings/smtp.vue
+++ b/frontend/src/views/settings/smtp.vue
@@ -70,6 +70,7 @@
               </div>
             </div><!-- auth -->
             <div class="smtp-shortcuts is-size-7">
+              <a href="" @click.prevent="() => fillSettings(n, 'fe')">Forward Email</a>
               <a href="" @click.prevent="() => fillSettings(n, 'gmail')">Gmail</a>
               <a href="" @click.prevent="() => fillSettings(n, 'ses')">Amazon SES</a>
               <a href="" @click.prevent="() => fillSettings(n, 'mailgun')">Mailgun</a>
@@ -215,6 +216,9 @@ import { mapState } from 'vuex';
 import { regDuration } from '../../constants';
 
 const smtpTemplates = {
+  fe: {
+    host: 'smtp.forwardemail.net', port: 465, auth_protocol: 'login', tls_type: 'TLS',
+  },
   gmail: {
     host: 'smtp.gmail.com', port: 465, auth_protocol: 'login', tls_type: 'TLS',
   },


### PR DESCRIPTION
Hi there @knadh 👋 

We're the team at [Forward Email](https://forwardemail.net) (100% open-source email service) &ndash; and this PR is simply to add us to the built-in list for listmonk alongside other closed-source solutions like Postmark, Sendgrid, et all.

**Why use us as your email provider?**

- Send & receive email as `you@yourdomain.com`
- Unlimited addresses and domains for just $3/mo
- Developer-friendly API for your website and apps
- Enterprise-grade SOC 2 Type 2 security standards
- Automatic spam, phishing, and malware protection
- Supports Apple, Windows, iOS, Android, Linux, ...

**What makes us different than others?**

- We’re the only 100% open-source provider
- We don’t rely on any third parties (no [SPOF](https://en.wikipedia.org/wiki/Single_point_of_failure))
- Our pricing allows you to scale cost effectively
- Unlike others, your email with us [is not](https://forwardemail.net/encrypted-email) stored in a shared database alongside everyone else

> P.S. Our full timeline is at https://forwardemail.net/about and our GitHub is at https://github.com/forwardemail