### PR TITLE
Fix #1657 - Prevent adding attachments multiple times in campaign test messages

### DIFF
--- a/cmd/campaigns.go
+++ b/cmd/campaigns.go
@@ -453,7 +453,8 @@ func handleTestCampaign(c echo.Context) error {
 	// Send the test messages.
 	for _, s := range subs {
 		sub := s
-		if err := sendTestMessage(sub, &camp, app); err != nil {
+		c := camp
+		if err := sendTestMessage(sub, &c, app); err != nil {
 			app.log.Printf("error sending test message: %v", err)
 			return echo.NewHTTPError(http.StatusInternalServerError,
 				app.i18n.Ts("campaigns.errorSendTest", "error", err.Error()))


### PR DESCRIPTION
Create a copy of the campaign object before sending test message to each subscriber. This way the attachments are not shared between subscribers.

Fixes #1657 