### PR TITLE
Added deploy template for RepoCloud.io

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -148,7 +148,9 @@ The `master` branch with bleeding edge changes is periodically built and publish
 <a href="https://railway.app/new/template/listmonk"><img src="https://camo.githubusercontent.com/081df3dd8cff37aab35044727b02b94a8e948052487a8c6253e190f5940d776d/68747470733a2f2f7261696c7761792e6170702f627574746f6e2e737667" alt="One-click deploy on Raleway" style="max-height: 32px;" /></a>
 <br />
 <a href="https://www.pikapods.com/pods?run=listmonk"><img src="https://www.pikapods.com/static/run-button.svg" alt="Deploy on PikaPod" /></a>
-
+<br />
+<a href="https://repocloud.io/details/?app_id=217"><img src="https://d16t0pc4846x52.cloudfront.net/deploy.png" alt="Deploy at RepoCloud"/></a>
+<br />
 
 ## Tutorials
 


### PR DESCRIPTION
Integration with one-click deploy template for RepoCloud. This addition simplifies the process for users to quickly deploy and scale ListMonk using RepoCloud's efficient cloud hosting services.