### PR TITLE
Documentation Cleanup: Update mkdocs.yml

### DIFF
--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -16,6 +16,7 @@ theme:
     tabs: true
   features:
     - content.code.copy
+    - navigation.expand
 
   palette:
     primary: "white"
@@ -38,24 +39,27 @@ copyright: "Copyright &copy; 2019-2023, Kailash Nadh."
 
 nav:
   - "Introduction": index.md
-  - "Installation": installation.md
-  - "Upgrade": upgrade.md
-  - "Configuration": configuration.md
-  - "Developer setup": developer-setup.md
-  - "Concepts": concepts.md
-  - "Querying and segmenting subscribers": querying-and-segmentation.md
-  - "Templating": templating.md
-  - "Bounce processing": bounces.md
-  - "Messengers": "messengers.md"
-  - "Archives": "archives.md"
-  - "Internationalization": "i18n.md"
-  - "Integrating with external systems": external-integration.md
+  - "Getting Started":
+    - "Installation": installation.md
+    - "Configuration": configuration.md
+    - "Upgrade": upgrade.md
+  - "Using Listmonk":
+    - "Concepts": concepts.md
+    - "Templating": templating.md
+    - "Querying and segmenting subscribers": querying-and-segmentation.md
+    - "Bounce processing": bounces.md
+    - "Messengers": "messengers.md"
+    - "Archives": "archives.md"
+    - "Internationalization": "i18n.md"
+    - "Integrating with external systems": external-integration.md
   - "API": apis/apis.md
-  - "API / Subscribers": apis/subscribers.md
-  - "API / Lists": apis/lists.md
-  - "API / Import": apis/import.md
-  - "API / Campaigns": apis/campaigns.md
-  - "API / Media": apis/media.md
-  - "API / Templates": apis/templates.md
-  - "API / Transactional": apis/transactional.md
+    - "API / Subscribers": apis/subscribers.md
+    - "API / Lists": apis/lists.md
+    - "API / Import": apis/import.md
+    - "API / Campaigns": apis/campaigns.md
+    - "API / Media": apis/media.md
+    - "API / Templates": apis/templates.md
+    - "API / Transactional": apis/transactional.md
+  - "Contribute":
+    - "Developer setup": developer-setup.md
   


### PR DESCRIPTION
Hi @knadh !

I've been revisiting my previous comments ([1](https://github.com/knadh/listmonk/issues/120#issuecomment-1426198275), [2](https://github.com/knadh/listmonk/issues/120#issuecomment-1890851475)) about documentation vs guides vs tutorials, and looking over the docs for this project. I'd like to discuss some suggestions and improvements if you're interested.

# Menu Navigation

My first PR touches on the menu navigation. At the moment, the doc's primary menu looks like one long list:

![image](https://github.com/knadh/listmonk/assets/95003834/c6061f6b-2ce4-46d0-9721-cc65f973c249)

This makes navigating and finding information difficult, especially as the number of pages grows larger. In contrast, here's how [Umami Analytics](https://umami.is/docs) and [NocoDB](https://docs.nocodb.com/) organize their side menu:

![image](https://github.com/knadh/listmonk/assets/95003834/2300284c-5040-4032-b34d-bdc4da349197)

![image](https://github.com/knadh/listmonk/assets/95003834/15648cbe-fd65-470c-9cbf-db0763e86a31)


As such, I've added some indentation to group certain menu items under a common title and [create a second level](https://mkdocs.readthedocs.io/en/0.13.3/user-guide/writing-your-docs/).

I've also added the following to make the [second-level items collapsible](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=collap#navigation-expansion):

```yml
theme:
  features:
    - navigation.expand
```

# Next Steps
Down the road, I would love to assist with a content audit of the docs to make them more user-friendly, and fill in some blanks. Here are some suggestions:

## Proposed Menu Taxonomy (click ▶️ to expand)

<details>

<summary><b>Getting Started</b></summary>

* [Introduction ](https://listmonk.app/docs/)
* [Installation ](https://listmonk.app/docs/installation/)
* [Configuration ](https://listmonk.app/docs/configuration/)
* [Upgrade ](https://listmonk.app/docs/upgrade/)
* Login
* [Concepts ](https://listmonk.app/docs/concepts/)

</details>


<details>

<summary><b>Basics</b></summary>

* Set up SMTP
* Manage Subscription Lists
* Design Campaigns
* Embed Forms
* [Generate Archives](https://listmonk.app/docs/archives/)
* Analyze Reports

</details>


<details>

<summary><b>Advanced</b></summary>

* [Querying and segmenting subscribers ](https://listmonk.app/docs/querying-and-segmentation/)
* [Templating ](https://listmonk.app/docs/templating/)
* [Integrating with external systems ](https://listmonk.app/docs/external-integration/)
* [Bounce processing ](https://listmonk.app/docs/bounces/)
* [Messengers ](https://listmonk.app/docs/messengers/)
* [Internationalization ](https://listmonk.app/docs/i18n/)

</details>


<details>

<summary><b><a href="https://listmonk.app/docs/apis/apis/">API</a></b></summary>

* [API / Subscribers ](https://listmonk.app/docs/apis/subscribers/)
* [API / Lists ](https://listmonk.app/docs/apis/lists/)
* [API / Import ](https://listmonk.app/docs/apis/import/)
* [API / Campaigns ](https://listmonk.app/docs/apis/campaigns/)
* [API / Media ](https://listmonk.app/docs/apis/media/)
* [API / Templates ](https://listmonk.app/docs/apis/templates/)
* [API / Transactional ](https://listmonk.app/docs/apis/transactional/)

</details>


<details>

<summary><b>Guides</b></summary>

* Deploying Listmonk with Railway
* Deploying Listmonk with Pikapods
* Deploying Listmonk with Amazon
* Deploying Listmonk with docker and caddy
* Deploying Listmonk on your PC
* Deploying Listmonk with Linux
* Deploying Listmonk with Fly.io

</details>


<details>

<summary><b>Contribute</b></summary>

* [Developer setup](https://listmonk.app/docs/developer-setup/)
* Report Bugs
* Help with Documentation
* [Translate](https://listmonk.app/docs/i18n/#contributing-a-new-language)
* Donate

</details>


## Content Audit
Looking over the docs to make the content easier to understand for both beginners and power users. This includes deciding:
- where content could be rephrased, moved to another section, or expanded upon on its own page
- what info is missing (ex: explaining that users need to find and provide their own SMTPs)
- where to offer additional guidance, and when to link out (ie: designing campaigns for all platforms and [what to watch out for](https://github.com/knadh/listmonk/issues/1231))

## Guides / Tutorials
There is currently a Tutorials section at the bottom of the [Installation page](https://listmonk.app/docs/installation/#tutorials), but this isn't the most ideal area for this kind of content, neither does it take advantage of [video embedding capabilities](https://github.com/squidfunk/mkdocs-material/issues/492). Some guides may be repetitive and could be grouped by platform.

I'm thinking of two potential ways of managing this, but I'm not sure which way is best:

### Option 1 - Umami Approach
Umami has a section at the end of their docs which contains a page for each platform option.

![image](https://github.com/knadh/listmonk/assets/95003834/35098aec-48c3-40c5-ad5e-73ab25f5a2b9)

A dedicated page is great for detailing all the idiosyncrasies of each platform when it comes to installing, upgrading, additional external tutorials, etc., rather than making the dedicated Installation, Upgrading, etc. pages longer. This is also great for SEO.

_ex: As a Railway user, I want to add additional info for fellow users on how to maintain their Listmonk deployment, and make sure that it doesn't confuse people who use other platforms._

That said, it does create a number of additional pages and menu items.


### Option 2 - NocoDB Approach
Rather than create a page for each platform, NocoDB has opted to cover the details of installation for every platform using tabs and collapsible content:

![https://docs.nocodb.com/getting-started/self-hosted/installation](https://github.com/knadh/listmonk/assets/95003834/9809ce9a-1839-47ba-8cee-9f83b316ee1d)


![https://docs.nocodb.com/getting-started/self-hosted/installation](https://github.com/knadh/listmonk/assets/95003834/11e45b96-2066-4262-a4e6-76895ea466a3)

As such, if you're looking for upgrade instructions, the Upgrade page will have details for every single platform, without having to find the singular page for just that platform.

The downside is that the general purpose Installation / Upgrade / etc. pages may become too long.