### PR TITLE
fix: easy install docker script for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The latest image is available on DockerHub at [`listmonk/listmonk:latest`](https
 
 ```bash
 mkdir listmonk-demo && cd listmonk-demo
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-demo.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-demo.sh)"
 ```
 
 DO NOT use this demo setup in production.
@@ -27,7 +27,7 @@ DO NOT use this demo setup in production.
 
 ```bash
 mkdir listmonk && cd listmonk
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-prod.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-prod.sh)"
 ```
 Visit `http://localhost:9000`.
 

--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -26,7 +26,7 @@ Use the sample [docker-compose.yml](https://github.com/knadh/listmonk/blob/maste
 
 ```bash
 mkdir listmonk-demo && cd listmonk-demo
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-demo.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-demo.sh)"
 ```
 
 #### Manual Docker install
@@ -47,7 +47,7 @@ This setup is recommended if you want to _quickly_ setup `listmonk` in productio
 
 ```bash
 mkdir listmonk && cd listmonk
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-prod.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/install-prod.sh)"
 ```
 
 The above shell script performs the following actions:

--- a/install-demo.sh
+++ b/install-demo.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu
 
 # Listmonk demo setup using `docker compose`.

--- a/install-prod.sh
+++ b/install-prod.sh
@@ -10,7 +10,6 @@ RED="$(tput setaf 1 2>/dev/null || printf '')"
 BLUE="$(tput setaf 4 2>/dev/null || printf '')"
 GREEN="$(tput setaf 2 2>/dev/null || printf '')"
 NO_COLOR="$(tput sgr0 2>/dev/null || printf '')"
-SED_INPLACE=$(if [[ "$(uname)" == "Darwin" ]]; then echo "-i ''"; else echo "-i"; fi)
 
 info() {
   printf '%s\n' "${BLUE}> ${NO_COLOR} $*"
@@ -25,7 +24,18 @@ completed() {
 }
 
 exists() {
-  command -v "$1" 1>/dev/null 2>&1
+  command -v "$1" >/dev/null 2>&1
+}
+
+sed_inplace() {
+    local search_pattern="$1"
+    local replacement="$2"
+    local file="$3"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "s/${search_pattern}/${replacement}/g" "$file"
+    else
+        sed -i "s/${search_pattern}/${replacement}/g" "$file"
+    fi
 }
 
 check_dependencies() {
@@ -40,7 +50,7 @@ check_dependencies() {
 	fi
 
 	# Check for "docker compose" functionality.
-	if ! docker compose version > /dev/null 2>&1; then
+	if ! docker compose version >/dev/null 2>&1; then
 		echo "'docker compose' functionality is not available. Please update to a newer version of Docker. See https://docs.docker.com/engine/install/ for more details."
 		exit 1
 	fi
@@ -69,7 +79,7 @@ is_healthy() {
 }
 
 is_running() {
-	info "checking if "$1" is running"
+	info "checking if $1 is running"
 	status="$(docker inspect -f "{{.State.Status}}" "$1")"
 	if [ "$status" = "running" ]; then
 		return 0
@@ -97,16 +107,12 @@ modify_config(){
 	db_password=$(generate_password)
 
 	info "modifying config.toml"
-	# Replace `db.host=localhost` with `db.host=db` in config file.
-	sed $SED_INPLACE "s/host = \"localhost\"/host = \"listmonk_db\"/g" config.toml
-	# Replace `db.password=listmonk` with `db.password={{db_password}}` in config file.
-	# Note that `password` is wrapped with `\b`. This ensures that `admin_password` doesn't match this pattern instead.
-	sed $SED_INPLACE "s/\bpassword\b = \"listmonk\"/password = \"$db_password\"/g" config.toml
-	# Replace `app.address=localhost:9000` with `app.address=0.0.0.0:9000` in config file.
-	sed $SED_INPLACE "s/address = \"localhost:9000\"/address = \"0.0.0.0:9000\"/g" config.toml
+	sed_inplace 'host = "localhost"' 'host = "listmonk_db"' config.toml
+	sed_inplace 'password = "listmonk"' "password = \"${db_password}\"" config.toml
+	sed_inplace 'address = "localhost:9000"' 'address = "0.0.0.0:9000"' config.toml
 
 	info "modifying docker-compose.yml"
-	sed $SED_INPLACE "s/POSTGRES_PASSWORD=listmonk/POSTGRES_PASSWORD=$db_password/g" docker-compose.yml
+	sed_inplace 'POSTGRES_PASSWORD=listmonk' "POSTGRES_PASSWORD=$db_password" docker-compose.yml
 }
 
 run_migrations(){

--- a/install-prod.sh
+++ b/install-prod.sh
@@ -89,7 +89,7 @@ is_running() {
 }
 
 generate_password(){
-	echo $(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+	echo "$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')"
 }
 
 get_config() {

--- a/install-prod.sh
+++ b/install-prod.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu
 
 # Listmonk production setup using `docker compose`.


### PR DESCRIPTION
Closes https://github.com/knadh/listmonk/issues/1740

Log on my macOS machine:

```
➜ ./install-prod.sh

>  checking for an existing docker db volume
>  fetching config.toml from listmonk repo
>  fetching docker-compose.yml from listmonk repo
>  generating a random password
>  modifying config.toml
>  modifying docker-compose.yml
>  running migrations
[+] Running 3/3
 ✔ Network test-listmonk_listmonk        Created                                                                                                                                      0.0s
 ✔ Volume "test-listmonk_listmonk-data"  Created                                                                                                                                      0.0s
 ✔ Container listmonk_db                 Started                                                                                                                                      0.0s
>  waiting for db container to be up. retrying in 3s
>  waiting for db container to be up. retrying in 3s
>  waiting for db container to be up. retrying in 3s
>  waiting for db container to be up. retrying in 3s
>  waiting for db container to be up. retrying in 3s
[+] Creating 1/0
 ✔ Container listmonk_db  Running                                                                                                                                                     0.0s
2024/02/20 13:17:20 main.go:102: v3.0.0 (f9120d9 2024-02-04T11:20:27Z, linux/arm64)
2024/02/20 13:17:20 init.go:150: reading config: config.toml
2024/02/20 13:17:20 init.go:289: connecting to db: listmonk_db:5432/listmonk

** first time installation **
** IMPORTANT: This will wipe existing listmonk tables and types in the DB 'listmonk' **
continue (y/N)?  y
2024/02/20 13:17:24 install.go:179: setup complete
2024/02/20 13:17:24 install.go:180: run the program and access the dashboard at 0.0.0.0:9000
>  starting app
[+] Running 2/0
 ✔ Container listmonk_db   Running                                                                                                                                                    0.0s
 ✔ Container listmonk_app  Started                                                                                                                                                    0.0s
>  finishing setup
>  checking if listmonk_db is running
>  checking if listmonk_app is running
✓  Listmonk is now up and running. Visit http://localhost:9000 in your browser.
```

