### PR TITLE
Add external transactional endpoint (#1108)

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -163,6 +163,7 @@ func initHTTPHandlers(e *echo.Echo, app *App) {
 	g.DELETE("/api/maintenance/subscriptions/unconfirmed", handleGCSubscriptions)
 
 	g.POST("/api/tx", handleSendTxMessage)
+	g.POST("/api/tx/external", handleSendExternalTxMessage)
 
 	g.GET("/api/events", handleEventStream)
 

--- a/docs/docs/content/apis/transactional.md
+++ b/docs/docs/content/apis/transactional.md
@@ -2,7 +2,8 @@
 
 | Method | Endpoint | Description                    |
 |:-------|:---------|:-------------------------------|
-| POST   | /api/tx  | Send transactional messages    |
+| POST   | /api/tx  | Send transactional messages to subscribers    |
+| POST   | /api/tx/external  | Send transactional messages to anyone    |
 
 ______________________________________________________________________
 
@@ -48,6 +49,49 @@ EOF
 }
 ```
 
+______________________________________________________________________
+
+#### POST /api/tx/external
+
+Allows sending transactional messages to one or more external recipients via a preconfigured transactional template.
+The recipients don't have to be subscribers.
+This means that the template will not have access to subscriber metadata.
+
+##### Parameters
+
+| Name              | Type      | Required | Description                                                                |
+|:------------------|:----------|:---------|:---------------------------------------------------------------------------|
+| recipient_email  | string    |          | Email of the recipient.              |
+| recipient_emails | string\[\]  |          | Multiple recipient emails as alternative to `recipient_email`.           |
+| template_id       | number    | Yes      | ID of the transactional template to be used for the message.               |
+| from_email        | string    |          | Optional sender email.                                                     |
+| data              | JSON      |          | Optional nested JSON map. Available in the template as `{{ .Tx.Data.* }}`. |
+| headers           | JSON\[\]    |          | Optional array of email headers.                                           |
+| messenger         | string    |          | Messenger to send the message. Default is `email`.                         |
+| content_type      | string    |          | Email format options include `html`, `markdown`, and `plain`.              |
+
+##### Example
+
+```shell
+curl -u "username:password" "http://localhost:9000/api/tx/external" -X POST \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     --data-binary @- << EOF
+    {
+        "recipient_email": "user@test.com",
+        "template_id": 2,
+        "data": {"order_id": "1234", "date": "2022-07-30", "items": [1, 2, 3]},
+        "content_type": "html"
+    }
+EOF
+```
+
+##### Example response
+
+```json
+{
+    "data": true
+}
+```
 ______________________________________________________________________
 
 #### File Attachments

--- a/docs/site/layouts/index.html
+++ b/docs/site/layouts/index.html
@@ -108,7 +108,7 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/knadh/listmonk/master/inst
       <img class="box" src="static/images/tx.png" alt="Screenshot of transactional API" />
     </div>
     <p>
-      Simple API to send arbitrary transactional messages to subscribers
+      Simple API to send arbitrary transactional messages to subscribers and external recipients
       using pre-defined templates. Send messages as e-mail, SMS, Whatsapp messages or any medium via Messenger interfaces.
     </p>
   </section>

--- a/docs/swagger/collections.yaml
+++ b/docs/swagger/collections.yaml
@@ -1846,6 +1846,29 @@ paths:
                   data:
                     type: boolean
 
+  /tx/external:
+    post:
+      tags:
+        - Transactional
+      description: send message to anyone
+      operationId: transactWithAnyone
+      requestBody:
+        description: email message to recipient
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransactionalMessage"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: boolean
+
   "/maintenance/subscribers/{type}":
     delete:
       description: garbage collects (deletes) orphaned or blocklisted subscribers.


### PR DESCRIPTION
Hello @knadh,
I am tagging you because you were also involved in the linked issue.

I decided to create a proposal implementation that allows external mails to be sent.
I implemented it as a separate endpoint in order not to interfere with the existing transactional endpoint.
I tested it locally and it seems to work for me.

Prior to this PR I have not written a single line of go, so please go easy on me :).
Looking forward to your feedback and I am happy to make changes, as I really would like to see this feature added to listmonk.