### PR TITLE
fix: query campaign does not search numbers

### DIFF
--- a/queries.sql
+++ b/queries.sql
@@ -534,7 +534,7 @@ FROM campaigns c
 WHERE ($1 = 0 OR id = $1)
     AND (CARDINALITY($2::campaign_status[]) = 0 OR status = ANY($2))
     AND (CARDINALITY($3::VARCHAR(100)[]) = 0 OR $3 <@ tags)
-    AND ($4 = '' OR TO_TSVECTOR(CONCAT(name, ' ', subject)) @@ TO_TSQUERY($4))
+    AND ($4 = '' OR TO_TSVECTOR(CONCAT(name, ' ', subject)) @@ TO_TSQUERY($4) OR CONCAT(c.name, ' ', c.subject) ILIKE $4)
 ORDER BY %order% OFFSET $5 LIMIT (CASE WHEN $6 < 1 THEN NULL ELSE $6 END);
 
 -- name: get-campaign


### PR DESCRIPTION
This PR fix a problem with the, where previously it couldn't handle alphanumeric strings effectively, for instance "Testing1234". 

## The problem

The problem arises becuase of the limitations encountered with PostgreSQL's full-text search when dealing with alphanumeric strings. The core of the issue lies in the process of tokenization and indexing is optimized for natural language text and not for patterns that include numbers.

Full-text search breaks down text into tokens based on spaces and punctuation, then converts these tokens into lexemes. Alphanumeric strings might not be broken down or analyzed in a way that's useful for matching partial strings, especially when numbers are involved.

This can be easily demostrated with the following statements 

```sql
$ SELECT to_tsvector('Testing') @@ to_tsquery('Testing123');
FALSE
```
For the above instance the `tsvectors` for `Testing` is `'test':1`, however the tsquery is `'testing123'`, which is a bad match

```sql
$ SELECT to_tsvector('123') @@ to_tsquery('Testing123');
FALSE
```
Similarly, the vectors for `123` is `'123':1` and the tsquery is `testing123`

## The solution

To fix this, we can add a fallback, which does substring matching using the `ILIKE` operator to ensure accurate results for alphanumeric queries.

Fixes #1713 