### PR TITLE
fix: check errors.Is instead of strings.Contains for http: Server closed error

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -792,7 +794,7 @@ func initHTTPServer(app *App) *echo.Echo {
 	// Start the server.
 	go func() {
 		if err := srv.Start(ko.String("app.address")); err != nil {
-			if strings.Contains(err.Error(), "Server closed") {
+			if errors.Is(err, http.ErrServerClosed) {
 				lo.Println("HTTP server shut down")
 			} else {
 				lo.Fatalf("error starting HTTP server: %v", err)


### PR DESCRIPTION
A very small addition to check http: Server closed error with proper errors.Is check, instead of strings.Contains
This is not a bugfix, or doesn't fix anything. Only makes the code a tiny bit more reliable and readable.