### PR TITLE
Update templating.md to include link to GO template expression documentation

### DIFF
--- a/docs/docs/content/templating.md
+++ b/docs/docs/content/templating.md
@@ -2,7 +2,7 @@
 
 A template is a re-usable HTML design that can be used across campaigns and transactional messages. Most commonly, templates have standard header and footer areas with logos and branding elements, where campaign content is inserted in the middle. listmonk supports Go template expressions that lets you create powerful, dynamic HTML templates.
 
-listmonk supports [Go template](https://gowebexamples.com/templates/) expressions that lets you create powerful, dynamic HTML templates. It also integrates 100+ useful [Sprig template functions](https://masterminds.github.io/sprig/).
+listmonk supports [Go template](https://pkg.go.dev/text/template) expressions that lets you create powerful, dynamic HTML templates. It also integrates 100+ useful [Sprig template functions](https://masterminds.github.io/sprig/).
 
 ## Campaign templates
 Campaign templates are used in an e-mail campaigns. These template are created and managed on the UI under `Campaigns -> Templates`, and are selected when creating new campaigns.


### PR DESCRIPTION
Pointing "Go template" hyperlink to actual Go template expression documentation.