### PR TITLE
make RootURL available in email templates

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -472,6 +472,7 @@ func initCampaignManager(q *models.Queries, cs *constants, app *App) *manager.Ma
 		ViewTrackURL:          cs.ViewTrackURL,
 		MessageURL:            cs.MessageURL,
 		ArchiveURL:            cs.ArchiveURL,
+		RootURL:               cs.RootURL,
 		UnsubHeader:           ko.Bool("privacy.unsubscribe_header"),
 		SlidingWindow:         ko.Bool("app.message_sliding_window"),
 		SlidingWindowDuration: ko.Duration("app.message_sliding_window_duration"),

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -124,6 +124,7 @@ type Config struct {
 	MessageURL            string
 	ViewTrackURL          string
 	ArchiveURL            string
+	RootURL	              string
 	UnsubHeader           bool
 
 	// Interval to scan the DB for active campaign checkpoints.
@@ -353,6 +354,9 @@ func (m *Manager) TemplateFuncs(c *models.Campaign) template.FuncMap {
 		"ArchiveURL": func() string {
 			return m.cfg.ArchiveURL
 		},
+		"RootURL": func() string {
+			return m.cfg.RootURL
+		}
 	}
 
 	for k, v := range m.tplFuncs {


### PR DESCRIPTION
This is an attempt at implementing what is needed to make the RootURL variabe available in email templates.
addresses #1483