### PR TITLE
Implements feature #1578 - CC and BCC on custom headers

### DIFF
--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/smtp"
 	"net/textproto"
+	"strings"
 
 	"github.com/knadh/listmonk/models"
 	"github.com/knadh/smtppool"
@@ -14,6 +15,8 @@ import (
 const (
 	emName        = "email"
 	hdrReturnPath = "Return-Path"
+	hdrBcc        = "Bcc"
+	hdrCc         = "Cc"
 )
 
 // Server represents an SMTP server's credentials.
@@ -145,6 +148,22 @@ func (e *Emailer) Push(m models.Message) error {
 		em.Sender = sender
 		em.Headers.Del(hdrReturnPath)
 	}
+
+	// If the `Bcc` header is set, it should be set on the Envelope
+	if bcc := em.Headers.Get(hdrBcc); bcc != "" {
+		for _, part := range strings.Split(bcc, ",") {
+			em.Bcc = append(em.Bcc, strings.TrimSpace(part))
+		}
+		em.Headers.Del(hdrBcc)
+	}	
+
+	// If the `Cc` header is set, it should be set on the Envelope
+	if cc := em.Headers.Get(hdrCc); cc != "" {
+		for _, part := range strings.Split(cc, ",") {
+			em.Cc = append(em.Cc, strings.TrimSpace(part))
+		}
+		em.Headers.Del(hdrCc)
+	}	
 
 	switch m.ContentType {
 	case "plain":


### PR DESCRIPTION
A trivial solution to implement exactly what is suggested on #1578, second option. In a lot of cases companies are required to keep a track record of all emails sent to clients. This is often achieved simply by bcc all emails to an archived mailbox. Of course, a perfect solution would be to implement archival at SMTP server side, but not all senders have this functionality. As an example discussed before in #1578, Amazon SES does not.
This feature addresses this. You can add a Bcc header at SMTP server configuration so that all emails sent by listmonk are copied.