### PR TITLE
Add support for running Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,27 @@
+# Use the latest alpine image as the base image
 FROM alpine:latest
+
+# Install dependencies
 RUN apk --no-cache add ca-certificates tzdata
+
+# Default values for UID and GID
+ARG UID=1001
+ARG GID=1001
+
+# Create and set a non-root user
+RUN addgroup -g ${GID} app && adduser -u ${UID} -G app -h /home/app -s /sbin/nologin -D app
+USER app
+
+# Set the working directory
 WORKDIR /listmonk
-COPY listmonk .
-COPY config.toml.sample config.toml
-COPY config-demo.toml .
-CMD ["./listmonk"]
+
+# Copy only the necessary files
+COPY --chown=app:app listmonk .
+COPY --chown=app:app config.toml.sample config.toml
+COPY --chown=app:app config-demo.toml .
+
+# Expose the application port
 EXPOSE 9000
+
+# Define the command to run the application
+CMD ["./listmonk"]


### PR DESCRIPTION
This pull request introduces the capability to run the listmonk Docker container as non-root user by specifying the `UID` and `GID` through environment variables. 

The following changes have been made:

- Updated the `Dockerfile` to create a non-root user (`app`) and group (`app`) using the specified  `UID=1001` and `GID=1001`.
- Introduced default values for `UID` and `GID`, with the option to override them using build arguments:
    ```shell
     docker build --build-arg UID=2001 --build-arg GID=2001 -t listmonk .
    ```

## Advantages:

- Improved Security: Running containers as non-root users reduces the potential impact of security vulnerabilities. It limits the access permissions of the container, minimizing the risk of privilege escalation attacks.
- Compliance: Many security guidelines, best practices and bigger organizations don't allow running applications as the root user. This change helps in complying with such security standards.

## Breaking changes

Impacts for people running previous versions (using root, before non root user `UID` and `GID`)

- Existing Files: Accessing files with another user that is not the root (now `UID` and `GID`)  may result in permission errors when the non-root user tries to access these files.
- Configuration files: Configuration files that need to be read or written by the application may not be accessible if their ownership is not updated to match the new `UID` and `GID`.

## Testing

Built the project using

```shell
make dist
goreleaser --parallelism 1 --snapshot --clean 
```

Tested running the docker `arm64` locally without issues.

## Future work

- I'm going to open a pull-request to "[recommended](https://github.com/th0th/helm-charts/tree/main/charts/listmonk/templates)" Helm chart author to  introduce the `spec.securityContext.runAsUser` ,  `spec.securityContext.runAsGroup` including `spec.containers[*].securityContext.allowPrivilegeEscalation=false` in his deployment to close the loop once this pull-request gets accepted.
