### PR TITLE
Optimize Update Check Mechanism in cmd/updates.go

### DIFF
--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -27,52 +27,55 @@ type AppUpdate struct {
 var reSemver = regexp.MustCompile(`-(.*)`)
 
 // checkUpdates is a blocking function that checks for updates to the app
-// at the given intervals. On detecting a new update (new semver), it
-// sets the global update status that renders a prompt on the UI.
+// at the given intervals. It uses a HEAD request to check the latest release
+// on GitHub without downloading the entire payload. On detecting a new update
+// (new semver), it sets the global update status that renders a prompt on the UI.
+
+// checkUpdates checks for updates every 24 hours.
+// curVersion (the current version of the listmonk)
 func checkUpdates(curVersion string, interval time.Duration, app *App) {
+	app.log.Printf("checkUpdates started with current version: %s", curVersion)
+
 	// Strip -* suffix.
 	curVersion = reSemver.ReplaceAllString(curVersion, "")
-	time.Sleep(time.Second * 1)
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		resp, err := http.Get(updateCheckURL)
+		app.log.Println("checking for remote update")
+
+		resp, err := http.Head(updateCheckURL)
 		if err != nil {
 			app.log.Printf("error checking for remote update: %v", err)
 			continue
 		}
+
+		app.log.Printf("response status code: %d", resp.StatusCode)
 
 		if resp.StatusCode != 200 {
 			app.log.Printf("non 200 response on remote update check: %d", resp.StatusCode)
 			continue
 		}
 
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			app.log.Printf("error reading remote update payload: %v", err)
-			continue
-		}
-		resp.Body.Close()
-
-		var up remoteUpdateResp
-		if err := json.Unmarshal(b, &up); err != nil {
-			app.log.Printf("error unmarshalling remote update payload: %v", err)
+		etag := resp.Header.Get("Etag")
+		if etag == "" {
+			app.log.Println("no Etag header in remote update response")
 			continue
 		}
 
 		// There is an update. Set it on the global app state.
-		if semver.IsValid(up.Version) {
-			v := reSemver.ReplaceAllString(up.Version, "")
+		if semver.IsValid(etag) {
+			v := reSemver.ReplaceAllString(etag, "")
 			if semver.Compare(v, curVersion) > 0 {
 				app.Lock()
 				app.update = &AppUpdate{
-					Version: up.Version,
-					URL:     up.URL,
+					Version: etag,
+					URL:     fmt.Sprintf("%s/releases/latest", updateCheckURL[:len(updateCheckURL)-1]),
 				}
 				app.Unlock()
 
-				app.log.Printf("new update %s found", up.Version)
+				app.log.Printf("new update %s found", etag)
 			}
 		}
 	}


### PR DESCRIPTION
Any advice and changes would be welcome as it is my first PR to listmonk and I am new to learning and writing Go. 
Thank You

## Basic Desc: ##

This pull request introduces several optimizations to the **checkUpdates** function to enhance efficiency and reduce bandwidth usage. The changes transition the update check from using a GET request to a HEAD request, eliminate an unnecessary initial delay, and streamline the process of checking for new updates. These modifications ensure that the application checks for updates in a more efficient manner, focusing on the headers rather than retrieving the entire response body.

## Explanation ##

- Switch from GET to HEAD for Update Checks: The update check now uses a http. Head request instead of http.Get. This optimizes network usage by requesting only the headers, which is sufficient for checking the Etag to determine the latest version available.
- Remove Initial Delay: Eliminated the 1-second delay (time.Sleep(time.Second * 1)) at the start of the update check loop. This change ensures that the update check starts immediately upon invocation of the function, reducing unnecessary wait time.
- Streamline Version Check: Instead of fetching and unmarshalling the response body to check the latest version, the updated code directly uses the Etag header from the HEAD request's response. This simplifies the logic and reduces the amount of code executed for each update check.
- Update URL Construction: The URL for the new update is constructed dynamically using the updateCheckURL, ensuring that it always points to the latest release without needing to read this information from the response body.
- Code Cleanup: Removed the code related to reading and unmarshalling the response body, as it is no longer necessary. This cleanup helps in maintaining the focus on the headers, making the function more straightforward and easier to understand.