### PR TITLE
fix(docker): support multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM --platform=$BUILDPLATFORM alpine:latest
 RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /listmonk
 COPY listmonk .


### PR DESCRIPTION
- Updated Dockerfile to use `--platform=$BUILDPLATFORM` for compatibility with multiple architectures