### PR TITLE
fix [docs]: correct invalid example request of basic auth in docs

### DIFF
--- a/docs/docs/content/apis/import.md
+++ b/docs/docs/content/apis/import.md
@@ -16,7 +16,7 @@ Retrieve the status of an import.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/import/subscribers'
+curl -u "username:password" -X GET 'http://localhost:9000/api/import/subscribers'
 ```
 
 ##### Example Response
@@ -41,7 +41,7 @@ Retrieve logs related to imports.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/import/subscribers/logs'
+curl -u "username:password" -X GET 'http://localhost:9000/api/import/subscribers/logs'
 ```
 
 ##### Example Response
@@ -85,7 +85,7 @@ Stop and delete an ongoing import.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X DELETE 'http://localhost:9000/api/import/subscribers' 
+curl -u "username:password" -X DELETE 'http://localhost:9000/api/import/subscribers' 
 ```
 
 ##### Example Response

--- a/docs/docs/content/apis/lists.md
+++ b/docs/docs/content/apis/lists.md
@@ -29,7 +29,7 @@ Retrieve lists.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/lists?page=1&per_page=100'
+curl -u "username:password" -X GET 'http://localhost:9000/api/lists?page=1&per_page=100'
 ```
 
 ##### Example Response
@@ -85,7 +85,7 @@ Retrieve a specific list.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/lists/5'
+curl -u "username:password" -X GET 'http://localhost:9000/api/lists/5'
 ```
 
 ##### Example Response
@@ -124,7 +124,7 @@ Create a new list.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X POST 'http://localhost:9000/api/lists'
+curl -u "username:password" -X POST 'http://localhost:9000/api/lists'
 ```
 
 ##### Example Response
@@ -164,7 +164,7 @@ Update a list.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X PUT 'http://localhost:9000/api/lists/5' \
+curl -u "username:password" -X PUT 'http://localhost:9000/api/lists/5' \
 --form 'name=modified test list' \
 --form 'type=private'
 ```

--- a/docs/docs/content/apis/media.md
+++ b/docs/docs/content/apis/media.md
@@ -15,7 +15,7 @@ Get an uploaded media file.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/media' \
+curl -u "username:password" -X GET 'http://localhost:9000/api/media' \
 --header 'Content-Type: multipart/form-data; boundary=--------------------------093715978792575906250298'
 ```
 
@@ -51,7 +51,7 @@ Upload a media file.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X POST 'http://localhost:9000/api/media' \
+curl -u "username:password" -X POST 'http://localhost:9000/api/media' \
 --header 'Content-Type: multipart/form-data; boundary=--------------------------183679989870526937212428' \
 --form 'file=@/path/to/image.jpg'
 ```
@@ -86,7 +86,7 @@ Delete an uploaded media file.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X DELETE 'http://localhost:9000/api/media/1'
+curl -u "username:password" -X DELETE 'http://localhost:9000/api/media/1'
 ```
 
 ##### Example Response

--- a/docs/docs/content/apis/templates.md
+++ b/docs/docs/content/apis/templates.md
@@ -20,7 +20,7 @@ Retrieve all templates.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/templates'
+curl -u "username:password" -X GET 'http://localhost:9000/api/templates'
 ```
 
 ##### Example Response
@@ -56,7 +56,7 @@ Retrieve a specific template.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/templates/1'
+curl -u "username:password" -X GET 'http://localhost:9000/api/templates/1'
 ```
 
 ##### Example Response
@@ -90,7 +90,7 @@ Retrieve the HTML preview of a template.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X GET 'http://localhost:9000/api/templates/1/preview'
+curl -u "username:password" -X GET 'http://localhost:9000/api/templates/1/preview'
 ```
 
 ##### Example Response
@@ -179,7 +179,7 @@ Set a template as the default.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X PUT 'http://localhost:9000/api/templates/1/default'
+curl -u "username:password" -X PUT 'http://localhost:9000/api/templates/1/default'
 ```
 
 ##### Example Response
@@ -213,7 +213,7 @@ Delete a template.
 ##### Example Request
 
 ```shell
-curl -u "username:username" -X DELETE 'http://localhost:9000/api/templates/35'
+curl -u "username:password" -X DELETE 'http://localhost:9000/api/templates/35'
 ```
 
 ##### Example Response


### PR DESCRIPTION
This PR includes the correction of invalid example requests specified in issue #1939 
Made corrections in lists, import, media, and templates doc files.