### PR TITLE
fix(analytics): add to and from dates to campaign analytics URL

### DIFF
--- a/frontend/src/views/CampaignAnalytics.vue
+++ b/frontend/src/views/CampaignAnalytics.vue
@@ -247,7 +247,7 @@ export default Vue.extend({
     },
 
     onSubmit() {
-      this.$router.push({ query: { id: this.form.campaigns.map((c) => c.id) } });
+      this.$router.push({ query: { id: this.form.campaigns.map((c) => c.id), from: dayjs(this.form.from).unix(), to: dayjs(this.form.to).unix() } });
     },
 
     queryCampaigns(q) {
@@ -300,8 +300,11 @@ export default Vue.extend({
 
   created() {
     const now = dayjs().set('hour', 23).set('minute', 59).set('seconds', 0);
-    this.form.to = now.toDate();
-    this.form.from = now.subtract(7, 'day').set('hour', 0).set('minute', 0).toDate();
+    const weekAgo = now.subtract(7, 'day').set('hour', 0).set('minute', 0);
+    const from = this.$route.query.from ? dayjs.unix(this.$route.query.from) : weekAgo;
+    const to = this.$route.query.to ? dayjs.unix(this.$route.query.to) : now;
+    this.form.from = from.toDate();
+    this.form.to = to.toDate();
   },
 
   mounted() {


### PR DESCRIPTION
First off, thanks for maintaining this great project! We use three separate instances in production and love it.

This fixes https://github.com/knadh/listmonk/issues/1821, which occurs when clicking the Search button on the Analytics page because `this.$router.push` is called with the same URL as the current page. So, this simple fix just puts the `to` and `from` date in the URL when searching, and reads them from query params in the `created` function. It maintains the same defaults when there are no dates in the query params. 

Happy to make changes if the query param approach is not what you had in mind.