### PR TITLE
issue fix for clone campaign with empty list

### DIFF
--- a/queries.sql
+++ b/queries.sql
@@ -505,10 +505,12 @@ camp AS (
 med AS (
     INSERT INTO campaign_media (campaign_id, media_id, filename)
         (SELECT (SELECT id FROM camp), id, filename FROM media WHERE id=ANY($19::INT[]))
+),
+camp_list AS (
+    INSERT INTO campaign_lists (campaign_id, list_id, list_name)
+        SELECT (SELECT id FROM camp), id, name FROM lists WHERE id=ANY($14::INT[])
 )
-INSERT INTO campaign_lists (campaign_id, list_id, list_name)
-    (SELECT (SELECT id FROM camp), id, name FROM lists WHERE id=ANY($14::INT[]))
-    RETURNING (SELECT id FROM camp);
+SELECT id FROM camp;
 
 -- name: query-campaigns
 -- Here, 'lists' is returned as an aggregated JSON array from campaign_lists because

--- a/queries.sql
+++ b/queries.sql
@@ -506,7 +506,7 @@ med AS (
     INSERT INTO campaign_media (campaign_id, media_id, filename)
         (SELECT (SELECT id FROM camp), id, filename FROM media WHERE id=ANY($19::INT[]))
 ),
-camp_list AS (
+insLists AS (
     INSERT INTO campaign_lists (campaign_id, list_id, list_name)
         SELECT (SELECT id FROM camp), id, name FROM lists WHERE id=ANY($14::INT[])
 )


### PR DESCRIPTION
fixes: #1879

This issue occurred as the CTE query returned the id from campaign after inserting entry into campaign_lists table. But in this case, there is no insert happening and the result set returned was empty. Fixed the query to return id irrespective of insert happening in the campaign_lists table. 

Thanks,
Bowrna