### PR TITLE
add error message for filename with non-ascii chars

### DIFF
--- a/cmd/media.go
+++ b/cmd/media.go
@@ -48,6 +48,10 @@ func handleUploadMedia(c echo.Context) error {
 		ext         = strings.TrimPrefix(strings.ToLower(filepath.Ext(file.Filename)), ".")
 		contentType = file.Header.Get("Content-Type")
 	)
+	if !isASCII(file.Filename) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity,
+			app.i18n.Ts("media.invalidFileName", "name", file.Filename))
+	}
 
 	// Validate file extension.
 	if !inArray("*", app.constants.MediaUpload.Extensions) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 var (
@@ -112,4 +113,13 @@ func titleCase(input string) string {
 	}
 
 	return strings.Join(parts, " ")
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if c > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
 }

--- a/docs/docs/content/apis/apis.md
+++ b/docs/docs/content/apis/apis.md
@@ -44,15 +44,16 @@ All timestamp fields are in the format `2019-01-01T09:00:00.000000+05:30`. The s
 
 ### Common HTTP error codes
 
-| Code  |                                                                          |
-| ----- | ------------------------------------------------------------------------ |
-|  400  | Missing or bad request parameters or values                              |
-|  403  | Session expired or invalidate. Must relogin                              |
-|  404  | Request resource was not found                                           |
-|  405  | Request method (GET, POST etc.) is not allowed on the requested endpoint |
-|  410  | The requested resource is gone permanently                               |
-|  429  | Too many requests to the API (rate limiting)                             |
-|  500  | Something unexpected went wrong                                          |
-|  502  | The backend OMS is down and the API is unable to communicate with it     |
-|  503  | Service unavailable; the API is down                                     |
-|  504  | Gateway timeout; the API is unreachable                                  |
+| Code  |                                                                             |
+| ----- | ----------------------------------------------------------------------------|
+|  400  | Missing or bad request parameters or values                                 |
+|  403  | Session expired or invalidate. Must relogin                                 |
+|  404  | Request resource was not found                                              |
+|  405  | Request method (GET, POST etc.) is not allowed on the requested endpoint    |
+|  410  | The requested resource is gone permanently                                  |
+|  422  | Unprocessable entity. Unable to process request as it contains invalid data |
+|  429  | Too many requests to the API (rate limiting)                                |
+|  500  | Something unexpected went wrong                                             |
+|  502  | The backend OMS is down and the API is unable to communicate with it        |
+|  503  | Service unavailable; the API is down                                        |
+|  504  | Gateway timeout; the API is unreachable                                     |

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -288,6 +288,7 @@
     "media.errorSavingThumbnail": "Error saving thumbnail: {error}",
     "media.errorUploading": "Error uploading file: {error}",
     "media.invalidFile": "Invalid file: {error}",
+    "media.invalidFileName": "Invalid filename {name}. Use only ASCII characters",
     "media.title": "Media",
     "media.unsupportedFileType": "Unsupported file type ({type})",
     "media.upload": "Upload",


### PR DESCRIPTION
fixes: #1955 

This PR prevents uploading files with non-ascii characters. It returns an error message saying "Invalid filename 汉语.txt. Use only ASCII characters" with error code "422"

