### PR TITLE
updating the api docs of media with missing api

### DIFF
--- a/docs/docs/content/apis/media.md
+++ b/docs/docs/content/apis/media.md
@@ -1,10 +1,11 @@
 # API / Media
 
-Method | Endpoint                                       | Description
--------|------------------------------------------------|------------------------------
-GET    | [/api/media](#get-apimedia)                                     | Get uploaded media file
-POST   | [/api/media](#post-apimedia)                                     | Upload media file
-DELETE | [/api/media/{media_id}](#delete-apimediamedia_id)                          | Delete uploaded media file
+Method | Endpoint                                             | Description
+-------|------------------------------------------------------|---------------------------------
+GET    | [/api/media](#get-apimedia)                          | Get uploaded media file
+GET    | [/api/media/{media_id}](#get-apimediamedia_id)       | Get specific uploaded media file
+POST   | [/api/media](#post-apimedia)                         | Upload media file
+DELETE | [/api/media/{media_id}](#delete-apimediamedia_id)    | Delete uploaded media file
 
 ______________________________________________________________________
 
@@ -35,7 +36,42 @@ curl -u "username:password" -X GET 'http://localhost:9000/api/media' \
     ]
 }
 ```
+______________________________________________________________________
 
+#### GET /api/media/{media_id}
+
+Retrieve a specific media.
+
+##### Parameters
+
+| Name          | Type      | Required | Description      |
+|:--------------|:----------|:---------|:-----------------|
+| media_id      | Number    | Yes      | Media ID.        |
+
+##### Example Request
+
+```shell
+curl -u 'username:password' 'http://localhost:9000/api/media/7' 
+```
+
+##### Example Response
+
+```json
+{
+  "data": 
+    {
+        "id": 7,
+        "uuid": "62e32e97-d6ca-4441-923f-b62607000dd1",
+        "filename": "ResumeB.pdf",
+        "content_type": "application/pdf",
+        "created_at": "2024-08-06T11:28:53.888257+05:30",
+        "thumb_url": null,
+        "provider": "filesystem",
+        "meta": {},
+        "url": "http://localhost:9000/uploads/ResumeB.pdf"
+    }
+}
+```
 ______________________________________________________________________
 
 #### POST /api/media


### PR DESCRIPTION
updating the api docs of media with missing API.

For media apis, retrieving a specific media using its id is missing. Updated that part in this PR.