### PR TITLE
attaching bounces api docs to the docs page

### DIFF
--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - "Media": apis/media.md
     - "Templates": apis/templates.md
     - "Transactional": apis/transactional.md
+    - "Bounces": apis/bounces.md
   - "Maintenance":
     - "Performance": maintenance/performance.md
   - "Contributions":


### PR DESCRIPTION
with reference to this comment(https://github.com/knadh/listmonk/pull/1978#issuecomment-2274611875), missed to attach the newly created bounces docs under API in docs page. This PR fixes that part.