### PR TITLE
Update querying-and-segmentation.md - Querying subscribers who viewed the campaign email

### DIFF
--- a/docs/docs/content/querying-and-segmentation.md
+++ b/docs/docs/content/querying-and-segmentation.md
@@ -66,6 +66,13 @@ subscribers.email LIKE 'John%'
 subscribers.email LIKE 'John%' AND status = 'blocklisted'
 ```
 
+#### Querying subscribers who viewed the campaign email
+
+```sql
+-- Find all subscribers who viewed the campaign email.
+EXISTS(SELECT 1 FROM campaign_views WHERE campaign_views.subscriber_id=subscribers.id AND campaign_views.campaign_id=<put_id_of_campaign>)
+```
+
 #### Querying attributes
 
 ```sql


### PR DESCRIPTION
I'm not sure if this is the correct place for this. Additionally, I wasn't sure if `campaign_views` should be added to the "Database fields" section at the top. 

Additionally, when I go to `/admin/subscribers` -> advanced search, and paste in `subscribers.email LIKE 'John%' AND status = 'blocklisted'`, I get an error notification: `Error fetching Subscribers: pq: column reference "status" is ambiguous`
![status error](https://github.com/user-attachments/assets/7a038309-bfb9-41f6-9228-fcd98d3b2f8b)

Also, that error notification does not get logged, and disappears too fast. I think the time it stays visible should be increased, but I'm not sure how to do that.

I am trying to add these various commands to the docs: https://gist.github.com/MaximilianKohler/e5158fcfe6de80a9069926a67afcae11#postgresql