### PR TITLE
Add optional CORS header middleware

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -3,13 +3,12 @@ package main
 import (
 	"bytes"
 	"crypto/subtle"
-	"net/http"
-	"path"
-	"regexp"
-
 	"github.com/knadh/paginator"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"net/http"
+	"path"
+	"regexp"
 )
 
 const (
@@ -63,6 +62,23 @@ func initHTTPHandlers(e *echo.Echo, app *App) {
 			app.log.Println(err.Error())
 		}
 		e.DefaultHTTPErrorHandler(err, c)
+	}
+
+	// CORS middleware
+	if ko.Bool("cors.enabled") {
+		var allowedOrigins = ko.Strings("cors.allowed_origins")
+		// If the allowed origins are not set, the middleware will not be used.
+		if len(allowedOrigins) > 0 {
+			e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+				AllowOrigins: ko.Strings("cors.allowed_origins"),
+				AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
+			}))
+			app.log.Println("CORS middleware enabled")
+			app.log.Printf("Allowed origins: %v", allowedOrigins)
+		} else {
+			app.log.Println("CORS middleware not enabled as allowed origins are not set properly")
+		}
+
 	}
 
 	// Admin JS app views.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -12,6 +12,10 @@ address = "localhost:9000"
 admin_username = "listmonk"
 admin_password = "listmonk"
 
+[cors]
+enabled = false
+allowed_origins = ["*", "localhost:3000"]
+
 # Database.
 [db]
 host = "localhost"

--- a/docs/docs/content/configuration.md
+++ b/docs/docs/content/configuration.md
@@ -10,17 +10,20 @@ Variables in config.toml can also be provided as environment variables prefixed 
 
 Example:
 
-| **Environment variable**       | Example value  |
-| ------------------------------ | -------------- |
-| `LISTMONK_app__address`        | "0.0.0.0:9000" |
-| `LISTMONK_app__admin_username` | listmonk       |
-| `LISTMONK_app__admin_password` | listmonk       |
-| `LISTMONK_db__host`            | db             |
-| `LISTMONK_db__port`            | 9432           |
-| `LISTMONK_db__user`            | listmonk       |
-| `LISTMONK_db__password`        | listmonk       |
-| `LISTMONK_db__database`        | listmonk       |
-| `LISTMONK_db__ssl_mode`        | disable        |
+| **Environment variable**            | Example value  |
+|-------------------------------------|----------------|
+| `LISTMONK_app__address`             | "0.0.0.0:9000" |
+| `LISTMONK_app__admin_username`      | listmonk       |
+| `LISTMONK_app__admin_password`      | listmonk       |
+| `LISTMONK_db__host`                 | db             |
+| `LISTMONK_db__port`                 | 9432           |
+| `LISTMONK_db__user`                 | listmonk       |
+| `LISTMONK_db__password`             | listmonk       |
+| `LISTMONK_db__database`             | listmonk       |
+| `LISTMONK_db__ssl_mode`             | disable        |
+| `LISTMONK_cors__enabled`            | false          |
+| `LISTMONK_cors__allowed_origins__0` | example.com    |
+| `LISTMONK_cors__allowed_origins__1` | another.com    |
 
 
 ### Customizing system templates


### PR DESCRIPTION
Optional CORS header middleware with configs like:

[cors]
enabled = true
allowed_origins = ["example.com"]

or with environment variable like (in docker compose for example):

```
  app:
    <<: *app-defaults
    container_name: listmonk_app
    command: [ sh, -c, "yes | ./listmonk --config config.toml" ]
    depends_on:
      - db
    volumes:
      - ./config.toml:/listmonk/config.toml
    environment:
      - LISTMONK_cors__enabled=true
      - LISTMONK_cors__allowed_origins__0=*
      - LISTMONK_cors__allowed_origins__1=http://localhost:3000
      - LISTMONK_cors__allowed_origins__2=google.com
      - LISTMONK_cors__allowed_origins__2=another.com
```
 Note: the google.com is overriden with another.com in this example.
 
 With enabled false, everything works as before, so it doesn't break backward the compatibility. Without array of origins, it shows a warning, but works like cors disabled. 
 
 Inspiration for this PR: https://github.com/knadh/listmonk/issues/1521
