### PR TITLE
Fix #1979: syntax error in GetBounce method

### DIFF
--- a/internal/core/bounces.go
+++ b/internal/core/bounces.go
@@ -41,7 +41,7 @@ func (c *Core) QueryBounces(campID, subID int, source, orderBy, order string, of
 // GetBounce retrieves bounce entries based on the given params.
 func (c *Core) GetBounce(id int) (models.Bounce, error) {
 	var out []models.Bounce
-	stmt := fmt.Sprintf(c.q.QueryBounces, "id", SortAsc)
+	stmt := strings.ReplaceAll(c.q.QueryBounces, "%order%", "id "+SortAsc)
 	if err := c.db.Select(&out, stmt, id, 0, 0, "", 0, 1); err != nil {
 		c.log.Printf("error fetching bounces: %v", err)
 		return models.Bounce{}, echo.NewHTTPError(http.StatusInternalServerError,


### PR DESCRIPTION
Issue - https://github.com/knadh/listmonk/issues/1979

Issue:
When making a GET request to the /api/bounces/{id} endpoint, the API was returning an error response:

`{"message":"Error fetching Bounce: pq: syntax error at or near "rder""}`
This error was caused by an incorrect placeholder replacement in the SQL query within the GetBounce function.

Fix:
- Updated the `GetBounce` function to use strings.ReplaceAll for replacing the `%order%` placeholder in the SQL query, similar to how it is done in the `QueryBounces` function.
- This ensures the placeholder is correctly substituted with the order clause "`id ASC`", resolving the syntax error.

Testing:
- Verified that the API now correctly fetches the bounce entry when making a GET request to `http://localhost:9000/api/bounces/{id}`, for tis case, i used same id mentioned in issue.