### PR TITLE
docs: suggest an FQDN in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
   app:
     <<: *app-defaults
     container_name: listmonk_app
+    hostname: listmonk.example.com # Recommend using FQDN for hostname
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
The 'hostname' field in the docker-compose file is later used in Listmonk to generate the 'Message-Id' of each mail. The hostname is used as the id-right section of 'Message-Id'.

According to RFC 2822 3.6.4, id-right = dot-atom-text / no-fold-literal / obs-id-right

Also, Rspamd has a spam filtering field 'MID_RHS_NOT_FQDN' which defaults to a 1.0 score.
https://github.com/rspamd/rspamd/blob/8b8211ac701e76a1ad474da5c6976769ba310f6c/rules/mid.lua#L29

This commit suggests an FQDN in the docker-compose file, which is guaranteed to meet the requirement.