### PR TITLE
Fix tag query param in lists.md

### DIFF
--- a/docs/docs/content/apis/lists.md
+++ b/docs/docs/content/apis/lists.md
@@ -21,7 +21,7 @@ Retrieve lists.
 |:---------|:---------|:---------|:-----------------------------------------------------------------|
 | query    | string   |          | string for list name search.                                     |
 | status   | []string |          | Status to filter lists. Repeat in the query for multiple values. |
-| tags     | []string |          | Tags to filter lists. Repeat in the query for multiple values.   |
+| tag      | []string |          | Tags to filter lists. Repeat in the query for multiple values.   |
 | order_by | string   |          | Sort field. Options: name, status, created_at, updated_at.       |
 | order    | string   |          | Sorting order. Options: ASC, DESC.                               |
 | page     | number   |          | Page number for pagination.                                      |


### PR DESCRIPTION
The docs say that `tags` is a query param, but it's actually `tag`, as seen here:

https://github.com/knadh/listmonk/blob/51e3f1789bade0c416e8bea8b3b1eccef39399b7/cmd/lists.go#L19