### PR TITLE
import warning and setting overwrite default off

### DIFF
--- a/docs/swagger/collections.yaml
+++ b/docs/swagger/collections.yaml
@@ -2487,6 +2487,8 @@ components:
               type: string
             import.subscribe:
               type: string
+            import.subscribeWarning:
+              type: string
             import.title:
               type: string
             import.upload:

--- a/frontend/src/views/Import.vue
+++ b/frontend/src/views/Import.vue
@@ -6,7 +6,7 @@
     <b-loading :active="isLoading" />
 
     <section v-if="isFree()" class="wrap">
-      <form @submit.prevent="onSubmit" class="box">
+      <form @submit.prevent="onUploadClick" class="box">
         <div>
           <div class="columns">
             <div class="column">
@@ -175,7 +175,7 @@ export default Vue.extend({
         subStatus: 'unconfirmed',
         delim: ',',
         lists: [],
-        overwrite: true,
+        overwrite: false,
         file: null,
       },
 
@@ -293,6 +293,31 @@ export default Vue.extend({
         this.pollStatus();
         this.form.file = null;
       });
+    },
+
+    resetForm() {
+      this.form.mode = 'subscribe';
+      this.form.overwrite = false;
+      this.form.file = null;
+      this.form.lists = [];
+      this.form.subStatus = 'unconfirmed';
+      this.form.delim = ',';
+    },
+
+    onUploadClick() {
+      if (this.form.mode === 'subscribe' && this.form.overwrite === true) {
+        this.$utils.confirm(
+          this.$t('import.subscribeWarning'),
+          () => {
+            this.onSubmit(); // Only run onSubmit after the user confirms
+          },
+          () => {
+            this.resetForm(); // Reset form to default on cancel
+          },
+        );
+      } else {
+        this.onSubmit();
+      }
     },
 
     onSubmit() {

--- a/frontend/src/views/Import.vue
+++ b/frontend/src/views/Import.vue
@@ -93,12 +93,8 @@
         </h5>
         <p>{{ $t('import.instructionsHelp') }}</p>
         <br />
-        <blockquote className="csv-example">
-          <code className="csv-headers">
-              <span>email,</span>
-              <span>name,</span>
-              <span>attributes</span>
-            </code>
+        <blockquote class="csv-example">
+          <code class="csv-headers"> <span>email,</span> <span>name,</span> <span>attributes</span></code>
         </blockquote>
 
         <hr />
@@ -106,23 +102,8 @@
         <h5 class="title is-size-6">
           {{ $t('import.csvExample') }}
         </h5>
-        <blockquote className="csv-example">
-          <code className="csv-headers">
-              <span>email,</span>
-              <span>name,</span>
-              <span>attributes</span>
-            </code><br />
-          <code className="csv-row">
-              <span>user1@mail.com,</span>
-              <span>"User One",</span>
-              <span>"{""age"": 42, ""planet"": ""Mars""}"</span>
-            </code><br />
-          <code className="csv-row">
-              <span>user2@mail.com,</span>
-              <span>"User Two",</span>
-              <span>"{""age"": 24, ""job"": ""Time Traveller""}"</span>
-            </code>
-        </blockquote>
+
+        <pre class="csv-example" v-text="example" />
       </div>
     </section><!-- upload //-->
 
@@ -177,6 +158,7 @@ export default Vue.extend({
         lists: [],
         overwrite: false,
         file: null,
+        example: '',
       },
 
       // Initial page load still has to wait for the status API to return
@@ -295,6 +277,14 @@ export default Vue.extend({
       });
     },
 
+    renderExample() {
+      const h = 'email, name, attributes\n'
+        + 'user1 @mail.com, "User One", "{""age"": 42, ""planet"": ""Mars""}"\n'
+        + 'user2 @mail.com, "User Two", "{""age"": 24, ""job"": ""Time Traveller""}"';
+
+      this.example = h;
+    },
+
     resetForm() {
       this.form.mode = 'subscribe';
       this.form.overwrite = false;
@@ -361,6 +351,7 @@ export default Vue.extend({
   },
 
   mounted() {
+    this.renderExample();
     this.pollStatus();
 
     const ids = this.$utils.parseQueryIDs(this.$route.query.list_id);

--- a/frontend/src/views/Import.vue
+++ b/frontend/src/views/Import.vue
@@ -6,7 +6,7 @@
     <b-loading :active="isLoading" />
 
     <section v-if="isFree()" class="wrap">
-      <form @submit.prevent="onUploadClick" class="box">
+      <form @submit.prevent="onUpload" class="box">
         <div>
           <div class="columns">
             <div class="column">
@@ -294,20 +294,13 @@ export default Vue.extend({
       this.form.delim = ',';
     },
 
-    onUploadClick() {
-      if (this.form.mode === 'subscribe' && this.form.overwrite === true) {
-        this.$utils.confirm(
-          this.$t('import.subscribeWarning'),
-          () => {
-            this.onSubmit(); // Only run onSubmit after the user confirms
-          },
-          () => {
-            this.resetForm(); // Reset form to default on cancel
-          },
-        );
-      } else {
-        this.onSubmit();
+    onUpload() {
+      if (this.form.mode === 'subscribe' && this.form.overwrite) {
+        this.$utils.confirm(this.$t('import.subscribeWarning'), this.onSubmit, this.resetForm);
+        return;
       }
+
+      this.onSubmit();
     },
 
     onSubmit() {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -259,6 +259,7 @@
     "import.recordsCount": "{num} / {total} records",
     "import.stopImport": "Stop import",
     "import.subscribe": "Subscribe",
+    "import.subscribeWarning":"Overwriting could lead to import unsubscribed emails as subscribed.",
     "import.title": "Import subscribers",
     "import.upload": "Upload",
     "lists.confirmDelete": "Are you sure? This does not delete subscribers.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -259,7 +259,7 @@
     "import.recordsCount": "{num} / {total} records",
     "import.stopImport": "Stop import",
     "import.subscribe": "Subscribe",
-    "import.subscribeWarning":"Overwriting could lead to import unsubscribed emails as subscribed.",
+    "import.subscribeWarning":"Overwriting will re-subscribe unusbscribed e-mails. Continue?",
     "import.title": "Import subscribers",
     "import.upload": "Upload",
     "lists.confirmDelete": "Are you sure? This does not delete subscribers.",


### PR DESCRIPTION
related: #2057 
closes: #2057

I added a fix that sets the overwrite switch as off by default and shows a warning message when trying to import after switch on the overwrite option. I have added the i18n string in en.json file and when testing locally, I could see the i18n key alone. I am not sure if it involves any additional steps to get the translation working. If anyone could guide me on that part, it would be useful.