### PR TITLE
fix: favicon markup

### DIFF
--- a/docs/site/layouts/partials/header.html
+++ b/docs/site/layouts/partials/header.html
@@ -11,7 +11,7 @@
   <link href="{{ .Site.BaseURL }}static/style.css" rel="stylesheet" type="text/css" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-  <link rel="shortcut icon" href="{{ .Site.BaseURL }}static/images/favicon.png" type="image/x-icon" />
+  <link rel="icon" href="{{ .Site.BaseURL }}static/images/favicon.png" type="image/png" />
 
   <meta property="og:title" content="{{ .Title }}" />
   {{ if .Params.thumbnail }}

--- a/static/public/templates/index.html
+++ b/static/public/templates/index.html
@@ -17,9 +17,9 @@
 	<script src="/public/custom.js?v={{ .AssetVersion }}" async defer></script>
 
 	{{ if ne .FaviconURL "" }}
-		<link rel="shortcut icon" href="{{ .FaviconURL }}" type="image/x-icon" />
+		<link rel="icon" href="{{ .FaviconURL }}" type="image/x-icon" />
 	{{ else }}
-		<link rel="shortcut icon" href="/public/static/favicon.png?v={{ .AssetVersion }}" type="image/x-icon" />
+		<link rel="icon" href="/public/static/favicon.png?v={{ .AssetVersion }}" type="image/png" />
 	{{ end }}
 </head>
 <body>


### PR DESCRIPTION
## Changes

- Removed `rel="shortcut"` [because](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#icon)

  > The `shortcut` link type is often seen before `icon`, but this link type is non-conforming, ignored and **web authors must not use it anymore**.

- Corrected media type for PNG favicons.

## Nice to have

For a custom favicon we currently always set `type="image/x-icon"` which is a media type [for ICO files](https://en.wikipedia.org/wiki/ICO_%28file_format%29#MIME_type). 

Instead, I'd like to change the template to infer the media type from the actually provided file's extension, but I think this is impossible with only the [functions built into the html/template package](https://coveooss.github.io/gotemplate/docs/functions_reference/base-go-template-functions/) and we'd have to first define suitable string manipulation functions (like exposing `strings.Split` or just `filepath.Ext`) via [`template.FuncMap`](https://pkg.go.dev/html/template#FuncMap).

If you'd welcome this and provide me some guidance on where exactly I'd need to add this, I'd be happy to extend this PR accordingly or submit another one.