### PR TITLE
fix dummy detection for OIDC client secret

### DIFF
--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -160,9 +160,9 @@ export default Vue.extend({
         hasDummy = 'captcha';
       }
 
-      if (this.isDummy(form['security.oidc.client_secret'])) {
-        form['security.oidc.client_secret'] = '';
-      } else if (this.hasDummy(form['security.oidc.client_secret'])) {
+      if (this.isDummy(form['security.oidc'].client_secret)) {
+        form['security.oidc'].client_secret = '';
+      } else if (this.hasDummy(form['security.oidc'].client_secret)) {
         hasDummy = 'oidc';
       }
 


### PR DESCRIPTION
Dummy detection for OIDC client secret does not work because wrong symbol is referenced. This causes that the OIDC client secret is overridden by a dummy secret when user saves application settings. This change fixes this issue.