### PR TITLE
#2114 - Fix issue of wrong platform used during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:latest
+FROM alpine:latest
 
 # Install dependencies
 RUN apk --no-cache add ca-certificates tzdata shadow su-exec


### PR DESCRIPTION
## Context

Removed `--platform=$BUILDPLATFORM` from the `Dockerfile` this was overriding the buildx configuration set by goreleaser.yaml .

## Testing

Assuming that a new release was created, and published to DockerHub and the following commands are run on a Arm64 machine:

```shell
$ docker run -ti --rm --entrypoint /bin/sh knadh/listmonk:latest
```

```shell
$ apk add file
```

```shell
$ file /bin/busybox
/bin/busybox: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, BuildID[sha1]=0473dd0398a4d4c4f29ebed5a94f63d78096563e, stripped
```

The output of the `file /bin/busybox` should include `ARM aarch64` meaning that the base image is Arm64.
