### PR TITLE
Corrected loading of messengers from serverConfig on line 629

### DIFF
--- a/frontend/src/views/Campaign.vue
+++ b/frontend/src/views/Campaign.vue
@@ -626,7 +626,7 @@ export default Vue.extend({
     },
 
     messengers() {
-      return ['email', ...this.serverConfig.messengers.map((m) => m.name)];
+      return [...this.serverConfig.messengers.map((m) => m.name)];
     },
   },
 

--- a/frontend/src/views/Campaign.vue
+++ b/frontend/src/views/Campaign.vue
@@ -626,7 +626,7 @@ export default Vue.extend({
     },
 
     messengers() {
-      return [...this.serverConfig.messengers.map((m) => m.name)];
+      return [...this.serverConfig.messengers];
     },
   },
 


### PR DESCRIPTION
Starting with v4.0, it was impossible to select any messenger besides email for a campaign due to an issue loading the messenger list from the API on line 629 of Campaign.vue.

The change was making m.name be just m since the messengers are listed as an array of strings on /api/config