### PR TITLE
Fix outdated docker local dev suite

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "listmonk",
+  "dockerComposeFile": "../dev/docker-compose.yml",
+  "service": "backend",
+  "workspaceFolder": "/app",
+  "forwardPorts": [9000],
+  "postStartCommand": "make dist && ./listmonk --install --idempotent --yes --config dev/config.toml"
+}

--- a/dev/app.Dockerfile
+++ b/dev/app.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS go
+FROM golang:1.20 AS go
 
 FROM node:16 AS node
 

--- a/dev/app.Dockerfile
+++ b/dev/app.Dockerfile
@@ -8,4 +8,4 @@ ENV CGO_ENABLED=0
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /app
-ENTRYPOINT [ "" ]
+CMD [ "sleep infinity" ]

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -3,17 +3,17 @@
 # of localhost will only listen to connections from the current machine. To
 # listen on all interfaces use '0.0.0.0'. To listen on the default web address
 # port, use port 80 (this will require running with elevated permissions).
-address = "localhost:9000"
+address = "0.0.0.0:9000"
 
 # Database.
 [db]
-host = "localhost"
+host = "db"
 port = 5432
-user = "listmonk"
-password = "listmonk"
+user = "listmonk-dev"
+password = "listmonk-dev"
 
 # Ensure that this database has been created in Postgres.
-database = "listmonk"
+database = "listmonk-dev"
 
 ssl_mode = "disable"
 max_open = 25

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -1,28 +1,24 @@
-# IMPORTANT: This configuration is meant for development only
-### DO NOT USE IN PRODUCTION ###
-
 [app]
 # Interface and port where the app will run its webserver.  The default value
 # of localhost will only listen to connections from the current machine. To
 # listen on all interfaces use '0.0.0.0'. To listen on the default web address
 # port, use port 80 (this will require running with elevated permissions).
-address = "0.0.0.0:9000"
-
-# BasicAuth authentication for the admin dashboard. This will eventually
-# be replaced with a better multi-user, role-based authentication system.
-# IMPORTANT: Leave both values empty to disable authentication on admin
-# only where an external authentication is already setup.
-admin_username = "listmonk"
-admin_password = "listmonk"
+address = "localhost:9000"
 
 # Database.
 [db]
-host = "db"
+host = "localhost"
 port = 5432
-user = "listmonk-dev"
-password = "listmonk-dev"
-database = "listmonk-dev"
+user = "listmonk"
+password = "listmonk"
+
+# Ensure that this database has been created in Postgres.
+database = "listmonk"
+
 ssl_mode = "disable"
 max_open = 25
 max_idle = 25
 max_lifetime = "300s"
+
+# Optional space separated Postgres DSN params. eg: "application_name=listmonk gssencmode=disable"
+params = ""

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,11 +1,21 @@
 version: "3"
 
 services:
+  adminer:
+    image: adminer:4.8.1-standalone
+    restart: always
+    ports:
+      - 8070:8080
+    networks:
+      - listmonk-dev
+
   mailhog:
     image: mailhog/mailhog:v1.0.1
     ports:
       - "1025:1025" # SMTP
       - "8025:8025" # UI
+    networks:
+      - listmonk-dev
 
   db:
     image: postgres:13

--- a/docs/docs/content/developer-setup.md
+++ b/docs/docs/content/developer-setup.md
@@ -18,9 +18,24 @@ The app has two distinct components, the Go backend and the VueJS frontend. In t
 
 
 ### Running the dev environment
-1. Run `make run` to start the listmonk dev server on `:9000`.
-2. Run `make run-frontend` to start the Vue frontend in dev mode using yarn on `:8080`. All `/api/*` calls are proxied to the app running on `:9000`. Refer to the [frontend README](https://github.com/knadh/listmonk/blob/master/frontend/README.md) for an overview on how the frontend is structured.
-3. Visit `http://localhost:8080`
+You can run your dev environment locally or inside containers.
+
+After setting up the dev environment, you can visit `http://localhost:8080`.
+
+
+1. Locally
+- Run `make run` to start the listmonk dev server on `:9000`.
+- Run `make run-frontend` to start the Vue frontend in dev mode using yarn on `:8080`. All `/api/*` calls are proxied to the app running on `:9000`. Refer to the [frontend README](https://github.com/knadh/listmonk/blob/master/frontend/README.md) for an overview on how the frontend is structured.
+
+2. Inside containers (Using Makefile)
+- Run `make init-dev-docker` to setup container for db.
+- Run `make dev-docker` to setup docker container suite.
+- Run `make rm-dev-docker` to clean up docker container suite.
+
+3. Inside containers (Using devcontainer)
+- Open repo in vscode, open command palette, and select "Dev Containers: Rebuild and Reopen in Container".
+
+It will set up db, and start frontend/backend for you.
 
 
 # Production build


### PR DESCRIPTION
**Changes**:
- Upgrade golang to 1.20
- Modify dev's config (conform to prod's, and fix dev db credential)
- Add support for devcontainers
- Update docs for dev environment setup

Fix #2199 