### PR TITLE
Refactor backend

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -48,5 +48,4 @@ func handleEventStream(c echo.Context) error {
 		}
 	}
 
-	return nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -9,6 +9,9 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
@@ -116,7 +119,7 @@ func trimNullBytes(b []byte) string {
 func titleCase(input string) string {
 	parts := strings.Fields(input)
 	for n, p := range parts {
-		parts[n] = strings.Title(p)
+		parts[n] = cases.Title(language.Und).String(p)
 	}
 
 	return strings.Join(parts, " ")

--- a/internal/captcha/captcha.go
+++ b/internal/captcha/captcha.go
@@ -64,11 +64,11 @@ func (c *Captcha) Verify(token string) (error, bool) {
 	}
 
 	var r captchaResp
-	if json.Unmarshal(body, &r); err != nil {
+	if err := json.Unmarshal(body, &r); err != nil {
 		return err, true
 	}
 
-	if r.Success != true {
+	if !r.Success {
 		return fmt.Errorf("captcha failed: %s", strings.Join(r.ErrorCodes, ",")), false
 	}
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/knadh/listmonk/internal/i18n"
 	"github.com/knadh/listmonk/models"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -594,7 +596,7 @@ func (m *Manager) trackLink(url, campUUID, subUUID string) string {
 // sendNotif sends a notification to registered admin e-mails.
 func (m *Manager) sendNotif(c *models.Campaign, status, reason string) error {
 	var (
-		subject = fmt.Sprintf("%s: %s", strings.Title(status), c.Name)
+		subject = fmt.Sprintf("%s: %s", cases.Title(language.Und).String(status), c.Name)
 		data    = map[string]interface{}{
 			"ID":     c.ID,
 			"Name":   c.Name,

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -30,7 +30,7 @@ type Server struct {
 
 	// Rest of the options are embedded directly from the smtppool lib.
 	// The JSON tag is for config unmarshal to work.
-	smtppool.Opt `json:"squash"`
+	smtppool.Opt `json:",squash"`
 
 	pool *smtppool.Pool
 }

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -30,7 +30,7 @@ type Server struct {
 
 	// Rest of the options are embedded directly from the smtppool lib.
 	// The JSON tag is for config unmarshal to work.
-	smtppool.Opt `json:",squash"`
+	smtppool.Opt `json:"squash"`
 
 	pool *smtppool.Pool
 }

--- a/internal/subimporter/importer.go
+++ b/internal/subimporter/importer.go
@@ -26,6 +26,8 @@ import (
 	"github.com/knadh/listmonk/internal/i18n"
 	"github.com/knadh/listmonk/models"
 	"github.com/lib/pq"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -246,7 +248,7 @@ func (im *Importer) sendNotif(status string) error {
 			Total:    s.Total,
 		}
 		subject = fmt.Sprintf("%s: %s import",
-			strings.Title(status),
+			cases.Title(language.Und).String(status),
 			s.Name)
 	)
 	return im.opt.NotifCB(subject, out)
@@ -648,7 +650,7 @@ func (im *Importer) ValidateFields(s SubReq) (SubReq, error) {
 
 		parts := strings.Fields(strings.ReplaceAll(name, ".", " "))
 		for n, p := range parts {
-			parts[n] = strings.Title(p)
+			parts[n] = cases.Title(language.Und).String(p)
 		}
 
 		s.Name = strings.Join(parts, " ")


### PR DESCRIPTION
1.Updated Usage of strings.Title:

Replaced the deprecated strings.Title function with golang.org/x/text/cases for handling Unicode punctuation properly.

2.Resolved Syntax Issue in email.go:

Fixed syntax in internal/messenger/email/email.go at line 33

3.Resolved Syntax Issue in captcha.go:

Addressed a syntax issue in internal/captcha/captcha.go at line 67.