### PR TITLE
Update Node.js version to 18 in app.Dockerfile

### DIFF
--- a/dev/app.Dockerfile
+++ b/dev/app.Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20 AS go
 
-FROM node:16 AS node
+FROM node:18 AS node
 
 COPY --from=go /usr/local/go /usr/local/go
 ENV GOPATH /go


### PR DESCRIPTION
This update changes the Node.js version in app.Dockerfile from 16 to 18 to resolve compatibility issues with eslint-define-config@2.1.0.