### PR TITLE
Fix: LogView regex for milliseconds & add span file support

### DIFF
--- a/frontend/src/assets/style.scss
+++ b/frontend/src/assets/style.scss
@@ -973,11 +973,12 @@ section.analytics {
       margin-bottom: 2px;
     }
 
-    .timestamp {
+    .timestamp, .file {
       color: $primary;
       display: inline-block;
       min-width: 175px;
       margin-right: 5px;
+      user-select: auto;
     }
 
     .line:hover {

--- a/frontend/src/components/LogView.vue
+++ b/frontend/src/components/LogView.vue
@@ -4,7 +4,8 @@
     <div class="lines" ref="lines">
       <template v-for="(l, i) in lines">
         <span :set="line = splitLine(l)" :key="i" class="line">
-          <span class="timestamp" :title="line.file">{{ line.timestamp }}</span>
+          <span class="timestamp">{{ line.timestamp }}&nbsp;</span>
+          <span class="file">{{ line.file }}:&nbsp;</span>
           <span class="log-message">{{ line.message }}</span>
         </span>
       </template>
@@ -15,8 +16,8 @@
 <script>
 // Regexp for splitting log lines in the following format to
 // [timestamp] [file] [message].
-// 2021/05/01 00:00:00 init.go:99: reading config: config.toml
-const reFormatLine = /^([0-9\s:/]+) (.+?\.go:[0-9]+):\s/g;
+// 2021/05/01 00:00:00:00 init.go:99: reading config: config.toml
+const reFormatLine = /^([0-9\s:/]+\.[0-9]{6}) (.+?\.go:[0-9]+):\s(.+)$/;
 
 export default {
   name: 'LogView',


### PR DESCRIPTION
This PR enhances the log parsing functionality by updating the regex to support milliseconds ([#30be235](https://github.com/knadh/listmonk/commit/30be235e2ab87697d563f0adc8fef8d72a8f3ce6)) in LogView.vue. Additionally, the .file class was merged with .timestamp in styles.scss, ensuring consistent styling and allowing users to select both elements together with proper spacing.