### PR TITLE
fix: typo in callout under the settings page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -87,7 +87,7 @@
             <b-icon icon="warning-empty" />
             Remove the <code>admin_username</code> and <code>admin_password</code> fields from the TOML
             configuration file or environment variables. If you are using APIs, create and use new API credentials
-            before removing the them. Visit
+            before removing them. Visit
             <router-link :to="{ name: 'users' }">
               Admin -> Settings -> Users
             </router-link> dashboard. <a href="https://listmonk.app/docs/upgrade/#upgrading-to-v4xx" target="_blank"


### PR DESCRIPTION
I was setting up Listmonk and noticed there was a typo in the callout.

<details><summary>Screenshot</summary>
<p>

![CleanShot 2025-02-03 at 07 59 32@2x](https://github.com/user-attachments/assets/828d4a3c-1571-4d22-8443-5ea6fb26cac9)

</p>
</details> 

---

Thanks for listmonk, Kailash! 💖