### PR TITLE
Rewrite handlers

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -25,20 +25,17 @@ type serverConfig struct {
 }
 
 // handleGetServerConfig returns general server config.
-func handleGetServerConfig(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
+func (h *Handler) handleGetServerConfig(c echo.Context) error {
 	out := serverConfig{
-		RootURL:       app.constants.RootURL,
-		FromEmail:     app.constants.FromEmail,
-		Lang:          app.constants.Lang,
-		Permissions:   app.constants.PermissionsRaw,
-		HasLegacyUser: app.constants.HasLegacyUser,
+		RootURL:       h.app.constants.RootURL,
+		FromEmail:     h.app.constants.FromEmail,
+		Lang:          h.app.constants.Lang,
+		Permissions:   h.app.constants.PermissionsRaw,
+		HasLegacyUser: h.app.constants.HasLegacyUser,
 	}
 
 	// Language list.
-	langList, err := getI18nLangList(app.constants.Lang, app)
+	langList, err := getI18nLangList(h.app.constants.Lang, h.app)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			fmt.Sprintf("Error loading language list: %v", err))
@@ -47,7 +44,7 @@ func handleGetServerConfig(c echo.Context) error {
 
 	// Sort messenger names with `email` always as the first item.
 	var names []string
-	for name := range app.messengers {
+	for name := range h.app.messengers {
 		if name == emailMsgr {
 			continue
 		}
@@ -57,22 +54,18 @@ func handleGetServerConfig(c echo.Context) error {
 	out.Messengers = append(out.Messengers, emailMsgr)
 	out.Messengers = append(out.Messengers, names...)
 
-	app.Lock()
-	out.NeedsRestart = app.needsRestart
-	out.Update = app.update
-	app.Unlock()
+	h.app.RLock()
+	out.NeedsRestart = h.app.needsRestart
+	out.Update = h.app.update
+	h.app.RUnlock()
 	out.Version = versionString
 
 	return c.JSON(http.StatusOK, okResp{out})
 }
 
 // handleGetDashboardCharts returns chart data points to render ont he dashboard.
-func handleGetDashboardCharts(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
-	out, err := app.core.GetDashboardCharts()
+func (h *Handler) handleGetDashboardCharts(c echo.Context) error {
+	out, err := h.app.core.GetDashboardCharts()
 	if err != nil {
 		return err
 	}
@@ -81,12 +74,8 @@ func handleGetDashboardCharts(c echo.Context) error {
 }
 
 // handleGetDashboardCounts returns stats counts to show on the dashboard.
-func handleGetDashboardCounts(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
-	out, err := app.core.GetDashboardCounts()
+func (h *Handler) handleGetDashboardCounts(c echo.Context) error {
+	out, err := h.app.core.GetDashboardCounts()
 	if err != nil {
 		return err
 	}
@@ -95,11 +84,10 @@ func handleGetDashboardCounts(c echo.Context) error {
 }
 
 // handleReloadApp restarts the app.
-func handleReloadApp(c echo.Context) error {
-	app := c.Get("app").(*App)
+func (h *Handler) handleReloadApp(c echo.Context) error {
 	go func() {
 		<-time.After(time.Millisecond * 500)
-		app.chReload <- syscall.SIGHUP
+		h.app.chReload <- syscall.SIGHUP
 	}()
 	return c.JSON(http.StatusOK, okResp{true})
 }

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -11,19 +11,15 @@ import (
 
 // handleEventStream serves an endpoint that never closes and pushes a
 // live event stream (text/event-stream) such as a error messages.
-func handleEventStream(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
-	h := c.Response().Header()
-	h.Set(echo.HeaderContentType, "text/event-stream")
-	h.Set(echo.HeaderCacheControl, "no-store")
-	h.Set(echo.HeaderConnection, "keep-alive")
+func (h *Handler) handleEventStream(c echo.Context) error {
+	header := c.Response().Header()
+	header.Set(echo.HeaderContentType, "text/event-stream")
+	header.Set(echo.HeaderCacheControl, "no-store")
+	header.Set(echo.HeaderConnection, "keep-alive")
 
 	// Subscribe to the event stream with a random ID.
 	id := fmt.Sprintf("api:%v", time.Now().UnixNano())
-	sub, err := app.events.Subscribe(id)
+	sub, err := h.app.events.Subscribe(id)
 	if err != nil {
 		log.Fatalf("error subscribing to events: %v", err)
 	}
@@ -34,7 +30,7 @@ func handleEventStream(c echo.Context) error {
 		case e := <-sub:
 			b, err := json.Marshal(e)
 			if err != nil {
-				app.log.Printf("error marshalling event: %v", err)
+				h.app.log.Printf("error marshalling event: %v", err)
 				continue
 			}
 
@@ -43,7 +39,7 @@ func handleEventStream(c echo.Context) error {
 
 		case <-ctx.Done():
 			// On HTTP connection close, unsubscribe.
-			app.events.Unsubscribe(id)
+			h.app.events.Unsubscribe(id)
 			return nil
 		}
 	}

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -78,7 +78,15 @@ func newHandler(app *App) (*Handler, error) {
 		EnablePublicSubPage: app.constants.EnablePublicSubPage,
 		EnablePublicArchive: app.constants.EnablePublicArchive,
 		IndividualTracking:  app.constants.Privacy.IndividualTracking,
+		I18n:                app.i18n,
 	}
+
+	h := &Handler{
+		app:  app,
+		echo: e,
+	}
+
+	return h, nil
 }
 
 func (h *Handler) register() {
@@ -145,130 +153,130 @@ func (h *Handler) initHTTPHandlers() {
 	)
 
 	// Authenticated endpoints.
-	admin.GET("", handleAdminPage)
-	admin.GET("/custom.css", serveCustomAppearance("admin.custom_css"))
-	admin.GET("/custom.js", serveCustomAppearance("admin.custom_js"))
-	admin.GET("/*", handleAdminPage)
+	admin.GET("", h.handleAdminPage)
+	admin.GET("/custom.css", h.serveCustomAppearance("admin.custom_css"))
+	admin.GET("/custom.js", h.serveCustomAppearance("admin.custom_js"))
+	admin.GET("/*", h.handleAdminPage)
 
 	pm := h.app.auth.Perm
 
 	// API endpoints.
-	api.GET("/api/health", handleHealthCheck)
-	api.GET("/api/config", handleGetServerConfig)
-	api.GET("/api/lang/:lang", handleGetI18nLang)
-	api.GET("/api/dashboard/charts", handleGetDashboardCharts)
-	api.GET("/api/dashboard/counts", handleGetDashboardCounts)
+	api.GET("/api/health", h.handleHealthCheck)
+	api.GET("/api/config", h.handleGetServerConfig)
+	api.GET("/api/lang/:lang", h.handleGetI18nLang)
+	api.GET("/api/dashboard/charts", h.handleGetDashboardCharts)
+	api.GET("/api/dashboard/counts", h.handleGetDashboardCounts)
 
-	api.GET("/api/settings", handleGetSettings, pm("settings:get"))
-	api.PUT("/api/settings", handleUpdateSettings, pm("settings:manage"))
-	api.POST("/api/settings/smtp/test", handleTestSMTPSettings, pm("settings:manage"))
-	api.POST("/api/admin/reload", handleReloadApp, pm("settings:manage"))
-	api.GET("/api/logs", handleGetLogs, pm("settings:get"))
-	api.GET("/api/events", handleEventStream, pm("settings:get"))
-	api.GET("/api/about", handleGetAboutInfo)
+	api.GET("/api/settings", h.handleGetSettings, pm("settings:get"))
+	api.PUT("/api/settings", h.handleUpdateSettings, pm("settings:manage"))
+	api.POST("/api/settings/smtp/test", h.handleTestSMTPSettings, pm("settings:manage"))
+	api.POST("/api/admin/reload", h.handleReloadApp, pm("settings:manage"))
+	api.GET("/api/logs", h.handleGetLogs, pm("settings:get"))
+	api.GET("/api/events", h.handleEventStream, pm("settings:get"))
+	api.GET("/api/about", h.handleGetAboutInfo)
 
-	api.GET("/api/subscribers", handleQuerySubscribers, pm("subscribers:get_all", "subscribers:get"))
-	api.GET("/api/subscribers/:id", handleGetSubscriber, pm("subscribers:get_all", "subscribers:get"))
-	api.GET("/api/subscribers/:id/export", handleExportSubscriberData, pm("subscribers:get_all", "subscribers:get"))
-	api.GET("/api/subscribers/:id/bounces", handleGetSubscriberBounces, pm("bounces:get"))
-	api.DELETE("/api/subscribers/:id/bounces", handleDeleteSubscriberBounces, pm("bounces:manage"))
-	api.POST("/api/subscribers", handleCreateSubscriber, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/:id", handleUpdateSubscriber, pm("subscribers:manage"))
-	api.POST("/api/subscribers/:id/optin", handleSubscriberSendOptin, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/blocklist", handleBlocklistSubscribers, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/:id/blocklist", handleBlocklistSubscribers, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/lists/:id", handleManageSubscriberLists, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/lists", handleManageSubscriberLists, pm("subscribers:manage"))
-	api.DELETE("/api/subscribers/:id", handleDeleteSubscribers, pm("subscribers:manage"))
-	api.DELETE("/api/subscribers", handleDeleteSubscribers, pm("subscribers:manage"))
+	api.GET("/api/subscribers", h.handleQuerySubscribers, pm("subscribers:get_all", "subscribers:get"))
+	api.GET("/api/subscribers/:id", h.handleGetSubscriber, pm("subscribers:get_all", "subscribers:get"))
+	api.GET("/api/subscribers/:id/export", h.handleExportSubscriberData, pm("subscribers:get_all", "subscribers:get"))
+	api.GET("/api/subscribers/:id/bounces", h.handleGetSubscriberBounces, pm("bounces:get"))
+	api.DELETE("/api/subscribers/:id/bounces", h.handleDeleteSubscriberBounces, pm("bounces:manage"))
+	api.POST("/api/subscribers", h.handleCreateSubscriber, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/:id", h.handleUpdateSubscriber, pm("subscribers:manage"))
+	api.POST("/api/subscribers/:id/optin", h.handleSubscriberSendOptin, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/blocklist", h.handleBlocklistSubscribers, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/:id/blocklist", h.handleBlocklistSubscribers, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/lists/:id", h.handleManageSubscriberLists, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/lists", h.handleManageSubscriberLists, pm("subscribers:manage"))
+	api.DELETE("/api/subscribers/:id", h.handleDeleteSubscribers, pm("subscribers:manage"))
+	api.DELETE("/api/subscribers", h.handleDeleteSubscribers, pm("subscribers:manage"))
 
-	api.GET("/api/bounces", handleGetBounces, pm("bounces:get"))
-	api.GET("/api/bounces/:id", handleGetBounces, pm("bounces:get"))
-	api.DELETE("/api/bounces", handleDeleteBounces, pm("bounces:manage"))
-	api.DELETE("/api/bounces/:id", handleDeleteBounces, pm("bounces:manage"))
+	api.GET("/api/bounces", h.handleGetBounces, pm("bounces:get"))
+	api.GET("/api/bounces/:id", h.handleGetBounces, pm("bounces:get"))
+	api.DELETE("/api/bounces", h.handleDeleteBounces, pm("bounces:manage"))
+	api.DELETE("/api/bounces/:id", h.handleDeleteBounces, pm("bounces:manage"))
 
 	// Subscriber operations based on arbitrary SQL queries.
 	// These aren't very REST-like.
-	api.POST("/api/subscribers/query/delete", handleDeleteSubscribersByQuery, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/query/blocklist", handleBlocklistSubscribersByQuery, pm("subscribers:manage"))
-	api.PUT("/api/subscribers/query/lists", handleManageSubscriberListsByQuery, pm("subscribers:manage"))
+	api.POST("/api/subscribers/query/delete", h.handleDeleteSubscribersByQuery, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/query/blocklist", h.handleBlocklistSubscribersByQuery, pm("subscribers:manage"))
+	api.PUT("/api/subscribers/query/lists", h.handleManageSubscriberListsByQuery, pm("subscribers:manage"))
 	api.GET("/api/subscribers/export",
-		handleExportSubscribers,
+		h.handleExportSubscribers,
 		middleware.GzipWithConfig(middleware.GzipConfig{Level: 9}),
 		pm("subscribers:get_all", "subscribers:get"),
 	)
 
-	api.GET("/api/import/subscribers", handleGetImportSubscribers, pm("subscribers:import"))
-	api.GET("/api/import/subscribers/logs", handleGetImportSubscriberStats, pm("subscribers:import"))
-	api.POST("/api/import/subscribers", handleImportSubscribers, pm("subscribers:import"))
-	api.DELETE("/api/import/subscribers", handleStopImportSubscribers, pm("subscribers:import"))
+	api.GET("/api/import/subscribers", h.handleGetImportSubscribers, pm("subscribers:import"))
+	api.GET("/api/import/subscribers/logs", h.handleGetImportSubscriberStats, pm("subscribers:import"))
+	api.POST("/api/import/subscribers", h.handleImportSubscribers, pm("subscribers:import"))
+	api.DELETE("/api/import/subscribers", h.handleStopImportSubscribers, pm("subscribers:import"))
 
 	// Individual list permissions are applied directly within handleGetLists.
-	api.GET("/api/lists", handleGetLists)
-	api.GET("/api/lists/:id", listPerm(handleGetList))
-	api.POST("/api/lists", handleCreateList, pm("lists:manage_all"))
-	api.PUT("/api/lists/:id", listPerm(handleUpdateList))
-	api.DELETE("/api/lists/:id", listPerm(handleDeleteLists))
+	api.GET("/api/lists", h.handleGetLists)
+	api.GET("/api/lists/:id", h.handleGetList, h.listPerm())
+	api.POST("/api/lists", h.handleCreateList, pm("lists:manage_all"))
+	api.PUT("/api/lists/:id", h.handleUpdateList, h.listPerm())
+	api.DELETE("/api/lists/:id", h.handleDeleteLists, h.listPerm())
 
-	api.GET("/api/campaigns", handleGetCampaigns, pm("campaigns:get"))
-	api.GET("/api/campaigns/running/stats", handleGetRunningCampaignStats, pm("campaigns:get"))
-	api.GET("/api/campaigns/:id", handleGetCampaign, pm("campaigns:get"))
-	api.GET("/api/campaigns/analytics/:type", handleGetCampaignViewAnalytics, pm("campaigns:get_analytics"))
-	api.GET("/api/campaigns/:id/preview", handlePreviewCampaign, pm("campaigns:get"))
-	api.POST("/api/campaigns/:id/preview", handlePreviewCampaign, pm("campaigns:get"))
-	api.POST("/api/campaigns/:id/content", handleCampaignContent, pm("campaigns:manage"))
-	api.POST("/api/campaigns/:id/text", handlePreviewCampaign, pm("campaigns:manage"))
-	api.POST("/api/campaigns/:id/test", handleTestCampaign, pm("campaigns:manage"))
-	api.POST("/api/campaigns", handleCreateCampaign, pm("campaigns:manage"))
-	api.PUT("/api/campaigns/:id", handleUpdateCampaign, pm("campaigns:manage"))
-	api.PUT("/api/campaigns/:id/status", handleUpdateCampaignStatus, pm("campaigns:manage"))
-	api.PUT("/api/campaigns/:id/archive", handleUpdateCampaignArchive, pm("campaigns:manage"))
-	api.DELETE("/api/campaigns/:id", handleDeleteCampaign, pm("campaigns:manage"))
+	api.GET("/api/campaigns", h.handleGetCampaigns, pm("campaigns:get"))
+	api.GET("/api/campaigns/running/stats", h.handleGetRunningCampaignStats, pm("campaigns:get"))
+	api.GET("/api/campaigns/:id", h.handleGetCampaign, pm("campaigns:get"))
+	api.GET("/api/campaigns/analytics/:type", h.handleGetCampaignViewAnalytics, pm("campaigns:get_analytics"))
+	api.GET("/api/campaigns/:id/preview", h.handlePreviewCampaign, pm("campaigns:get"))
+	api.POST("/api/campaigns/:id/preview", h.handlePreviewCampaign, pm("campaigns:get"))
+	api.POST("/api/campaigns/:id/content", h.handleCampaignContent, pm("campaigns:manage"))
+	api.POST("/api/campaigns/:id/text", h.handlePreviewCampaign, pm("campaigns:manage"))
+	api.POST("/api/campaigns/:id/test", h.handleTestCampaign, pm("campaigns:manage"))
+	api.POST("/api/campaigns", h.handleCreateCampaign, pm("campaigns:manage"))
+	api.PUT("/api/campaigns/:id", h.handleUpdateCampaign, pm("campaigns:manage"))
+	api.PUT("/api/campaigns/:id/status", h.handleUpdateCampaignStatus, pm("campaigns:manage"))
+	api.PUT("/api/campaigns/:id/archive", h.handleUpdateCampaignArchive, pm("campaigns:manage"))
+	api.DELETE("/api/campaigns/:id", h.handleDeleteCampaign, pm("campaigns:manage"))
 
-	api.GET("/api/media", handleGetMedia, pm("media:get"))
-	api.GET("/api/media/:id", handleGetMedia, pm("media:get"))
-	api.POST("/api/media", handleUploadMedia, pm("media:manage"))
-	api.DELETE("/api/media/:id", handleDeleteMedia, pm("media:manage"))
+	api.GET("/api/media", h.handleGetMedia, pm("media:get"))
+	api.GET("/api/media/:id", h.handleGetMedia, pm("media:get"))
+	api.POST("/api/media", h.handleUploadMedia, pm("media:manage"))
+	api.DELETE("/api/media/:id", h.handleDeleteMedia, pm("media:manage"))
 
-	api.GET("/api/templates", handleGetTemplates, pm("templates:get"))
-	api.GET("/api/templates/:id", handleGetTemplates, pm("templates:get"))
-	api.GET("/api/templates/:id/preview", handlePreviewTemplate, pm("templates:get"))
-	api.POST("/api/templates/preview", handlePreviewTemplate, pm("templates:get"))
-	api.POST("/api/templates", handleCreateTemplate, pm("templates:manage"))
-	api.PUT("/api/templates/:id", handleUpdateTemplate, pm("templates:manage"))
-	api.PUT("/api/templates/:id/default", handleTemplateSetDefault, pm("templates:manage"))
-	api.DELETE("/api/templates/:id", handleDeleteTemplate, pm("templates:manage"))
+	api.GET("/api/templates", h.handleGetTemplates, pm("templates:get"))
+	api.GET("/api/templates/:id", h.handleGetTemplates, pm("templates:get"))
+	api.GET("/api/templates/:id/preview", h.handlePreviewTemplate, pm("templates:get"))
+	api.POST("/api/templates/preview", h.handlePreviewTemplate, pm("templates:get"))
+	api.POST("/api/templates", h.handleCreateTemplate, pm("templates:manage"))
+	api.PUT("/api/templates/:id", h.handleUpdateTemplate, pm("templates:manage"))
+	api.PUT("/api/templates/:id/default", h.handleTemplateSetDefault, pm("templates:manage"))
+	api.DELETE("/api/templates/:id", h.handleDeleteTemplate, pm("templates:manage"))
 
-	api.DELETE("/api/maintenance/subscribers/:type", handleGCSubscribers, pm("settings:maintain"))
-	api.DELETE("/api/maintenance/analytics/:type", handleGCCampaignAnalytics, pm("settings:maintain"))
-	api.DELETE("/api/maintenance/subscriptions/unconfirmed", handleGCSubscriptions, pm("settings:maintain"))
+	api.DELETE("/api/maintenance/subscribers/:type", h.handleGCSubscribers, pm("settings:maintain"))
+	api.DELETE("/api/maintenance/analytics/:type", h.handleGCCampaignAnalytics, pm("settings:maintain"))
+	api.DELETE("/api/maintenance/subscriptions/unconfirmed", h.handleGCSubscriptions, pm("settings:maintain"))
 
-	api.POST("/api/tx", handleSendTxMessage, pm("tx:send"))
+	api.POST("/api/tx", h.handleSendTxMessage, pm("tx:send"))
 
-	api.GET("/api/profile", handleGetUserProfile)
-	api.PUT("/api/profile", handleUpdateUserProfile)
-	api.GET("/api/users", handleGetUsers, pm("users:get"))
-	api.GET("/api/users/:id", handleGetUsers, pm("users:get"))
-	api.POST("/api/users", handleCreateUser, pm("users:manage"))
-	api.PUT("/api/users/:id", handleUpdateUser, pm("users:manage"))
-	api.DELETE("/api/users", handleDeleteUsers, pm("users:manage"))
-	api.DELETE("/api/users/:id", handleDeleteUsers, pm("users:manage"))
-	api.POST("/api/logout", handleLogout)
+	api.GET("/api/profile", h.handleGetUserProfile)
+	api.PUT("/api/profile", h.handleUpdateUserProfile)
+	api.GET("/api/users", h.handleGetUsers, pm("users:get"))
+	api.GET("/api/users/:id", h.handleGetUsers, pm("users:get"))
+	api.POST("/api/users", h.handleCreateUser, pm("users:manage"))
+	api.PUT("/api/users/:id", h.handleUpdateUser, pm("users:manage"))
+	api.DELETE("/api/users", h.handleDeleteUsers, pm("users:manage"))
+	api.DELETE("/api/users/:id", h.handleDeleteUsers, pm("users:manage"))
+	api.POST("/api/logout", h.handleLogout)
 
-	api.GET("/api/roles/users", handleGetUserRoles, pm("roles:get"))
-	api.GET("/api/roles/lists", handleGeListRoles, pm("roles:get"))
-	api.POST("/api/roles/users", handleCreateUserRole, pm("roles:manage"))
-	api.POST("/api/roles/lists", handleCreateListRole, pm("roles:manage"))
-	api.PUT("/api/roles/users/:id", handleUpdateUserRole, pm("roles:manage"))
-	api.PUT("/api/roles/lists/:id", handleUpdateListRole, pm("roles:manage"))
-	api.DELETE("/api/roles/:id", handleDeleteRole, pm("roles:manage"))
+	api.GET("/api/roles/users", h.handleGetUserRoles, pm("roles:get"))
+	api.GET("/api/roles/lists", h.handleGetListRoles, pm("roles:get"))
+	api.POST("/api/roles/users", h.handleCreateUserRole, pm("roles:manage"))
+	api.POST("/api/roles/lists", h.handleCreateListRole, pm("roles:manage"))
+	api.PUT("/api/roles/users/:id", h.handleUpdateUserRole, pm("roles:manage"))
+	api.PUT("/api/roles/lists/:id", h.handleUpdateListRole, pm("roles:manage"))
+	api.DELETE("/api/roles/:id", h.handleDeleteRole, pm("roles:manage"))
 
 	if h.app.constants.BounceWebhooksEnabled {
 		// Private authenticated bounce endpoint.
-		api.POST("/webhooks/bounce", handleBounceWebhook, pm("webhooks:post_bounce"))
+		api.POST("/webhooks/bounce", h.handleBounceWebhook, pm("webhooks:post_bounce"))
 
 		// Public bounce endpoints for webservices like SES.
-		p.POST("/webhooks/service/:service", handleBounceWebhook)
+		p.POST("/webhooks/service/:service", h.handleBounceWebhook)
 	}
 
 	// =================================================================
@@ -280,54 +288,77 @@ func (h *Handler) initHTTPHandlers() {
 	})
 
 	// Public admin endpoints (login page, OIDC endpoints).
-	p.GET(path.Join(uriAdmin, "/login"), handleLoginPage)
-	p.POST(path.Join(uriAdmin, "/login"), handleLoginPage)
+	p.GET(path.Join(uriAdmin, "/login"), h.handleLoginPage)
+	p.POST(path.Join(uriAdmin, "/login"), h.handleLoginPage)
 
 	if h.app.constants.Security.OIDC.Enabled {
-		p.POST("/auth/oidc", handleOIDCLogin)
-		p.GET("/auth/oidc", handleOIDCFinish)
+		p.POST("/auth/oidc", h.handleOIDCLogin)
+		p.GET("/auth/oidc", h.handleOIDCFinish)
 	}
 
 	// Public APIs.
-	p.GET("/api/public/lists", handleGetPublicLists)
-	p.POST("/api/public/subscription", handlePublicSubscription)
+	p.GET("/api/public/lists", h.handleGetPublicLists)
+	p.POST("/api/public/subscription", h.handlePublicSubscription)
 	if h.app.constants.EnablePublicArchive {
-		p.GET("/api/public/archive", handleGetCampaignArchives)
+		p.GET("/api/public/archive", h.handleGetCampaignArchives)
 	}
 
 	// /public/static/* file server is registered in initHTTPServer().
 	// Public subscriber facing views.
-	p.GET("/subscription/form", handleSubscriptionFormPage)
-	p.POST("/subscription/form", handleSubscriptionForm)
-	p.GET("/subscription/:campUUID/:subUUID", noIndex(validateUUID(subscriberExists(handleSubscriptionPage),
-		"campUUID", "subUUID")))
-	p.POST("/subscription/:campUUID/:subUUID", validateUUID(subscriberExists(handleSubscriptionPrefs),
-		"campUUID", "subUUID"))
-	p.GET("/subscription/optin/:subUUID", noIndex(validateUUID(subscriberExists(handleOptinPage), "subUUID")))
-	p.POST("/subscription/optin/:subUUID", validateUUID(subscriberExists(handleOptinPage), "subUUID"))
-	p.POST("/subscription/export/:subUUID", validateUUID(subscriberExists(handleSelfExportSubscriberData),
-		"subUUID"))
-	p.POST("/subscription/wipe/:subUUID", validateUUID(subscriberExists(handleWipeSubscriberData),
-		"subUUID"))
-	p.GET("/link/:linkUUID/:campUUID/:subUUID", noIndex(validateUUID(handleLinkRedirect,
-		"linkUUID", "campUUID", "subUUID")))
-	p.GET("/campaign/:campUUID/:subUUID", noIndex(validateUUID(handleViewCampaignMessage,
-		"campUUID", "subUUID")))
-	p.GET("/campaign/:campUUID/:subUUID/px.png", noIndex(validateUUID(handleRegisterCampaignView,
-		"campUUID", "subUUID")))
+	p.GET("/subscription/form", h.handleSubscriptionFormPage)
+	p.POST("/subscription/form", h.handleSubscriptionForm)
+	p.GET("/subscription/:campUUID/:subUUID",
+		h.handleSubscriptionPage,
+		h.validateUUID("campUUID", "subUUID"),
+		h.subscriberExists("subUUID"),
+		noIndex(),
+	)
+	p.POST("/subscription/:campUUID/:subUUID", h.handleSubscriptionPrefs,
+		h.validateUUID("campUUID", "subUUID"),
+		h.subscriberExists("subUUID"),
+	)
+	p.GET("/subscription/optin/:subUUID", h.handleOptinPage,
+		h.validateUUID("subUUID"),
+		h.subscriberExists("subUUID"),
+		noIndex(),
+	)
+	p.POST("/subscription/optin/:subUUID", h.handleOptinPage,
+		h.validateUUID("subUUID"),
+		h.subscriberExists("subUUID"),
+	)
+	p.POST("/subscription/export/:subUUID", h.handleSelfExportSubscriberData,
+		h.validateUUID("subUUID"),
+		h.subscriberExists("subUUID"),
+	)
+	p.POST("/subscription/wipe/:subUUID", h.handleWipeSubscriberData,
+		h.validateUUID("subUUID"),
+		h.subscriberExists("subUUID"),
+	)
+	p.GET("/link/:linkUUID/:campUUID/:subUUID", h.handleLinkRedirect,
+		h.validateUUID("linkUUID", "campUUID", "subUUID"),
+		noIndex(),
+	)
+	p.GET("/campaign/:campUUID/:subUUID", h.handleViewCampaignMessage,
+		h.validateUUID("campUUID", "subUUID"),
+		noIndex(),
+	)
+	p.GET("/campaign/:campUUID/:subUUID/px.png", h.handleRegisterCampaignView,
+		h.validateUUID("campUUID", "subUUID"),
+		noIndex(),
+	)
 
 	if h.app.constants.EnablePublicArchive {
-		p.GET("/archive", handleCampaignArchivesPage)
-		p.GET("/archive.xml", handleGetCampaignArchivesFeed)
-		p.GET("/archive/:id", handleCampaignArchivePage)
-		p.GET("/archive/latest", handleCampaignArchivePageLatest)
+		p.GET("/archive", h.handleCampaignArchivesPage)
+		p.GET("/archive.xml", h.handleGetCampaignArchivesFeed)
+		p.GET("/archive/:id", h.handleCampaignArchivePage)
+		p.GET("/archive/latest", h.handleCampaignArchivePageLatest)
 	}
 
-	p.GET("/public/custom.css", serveCustomAppearance("public.custom_css"))
-	p.GET("/public/custom.js", serveCustomAppearance("public.custom_js"))
+	p.GET("/public/custom.css", h.serveCustomAppearance("public.custom_css"))
+	p.GET("/public/custom.js", h.serveCustomAppearance("public.custom_js"))
 
 	// Public health API endpoint.
-	p.GET("/health", handleHealthCheck)
+	p.GET("/health", h.handleHealthCheck)
 
 	// 404 pages.
 	p.RouteNotFound("/*", func(c echo.Context) error {
@@ -343,50 +374,47 @@ func (h *Handler) initHTTPHandlers() {
 }
 
 // handleAdminPage is the root handler that renders the Javascript admin frontend.
-func handleAdminPage(c echo.Context) error {
-	app := c.Get("app").(*App)
+func (h *Handler) handleAdminPage(c echo.Context) error {
 
-	b, err := app.fs.Read(path.Join(uriAdmin, "/index.html"))
+	b, err := h.app.fs.Read(path.Join(uriAdmin, "/index.html"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	b = bytes.ReplaceAll(b, []byte("asset_version"), []byte(app.constants.AssetVersion))
+	b = bytes.ReplaceAll(b, []byte("asset_version"), []byte(h.app.constants.AssetVersion))
 
 	return c.HTMLBlob(http.StatusOK, b)
 }
 
 // handleHealthCheck is a healthcheck endpoint that returns a 200 response.
-func handleHealthCheck(c echo.Context) error {
+func (h *Handler) handleHealthCheck(c echo.Context) error {
 	return c.JSON(http.StatusOK, okResp{true})
 }
 
 // serveCustomAppearance serves the given custom CSS/JS appearance blob
 // meant for customizing public and admin pages from the admin settings UI.
-func serveCustomAppearance(name string) echo.HandlerFunc {
+func (h *Handler) serveCustomAppearance(name string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var (
-			app = c.Get("app").(*App)
-
 			out []byte
 			hdr string
 		)
 
 		switch name {
 		case "admin.custom_css":
-			out = app.constants.Appearance.AdminCSS
+			out = h.app.constants.Appearance.AdminCSS
 			hdr = "text/css; charset=utf-8"
 
 		case "admin.custom_js":
-			out = app.constants.Appearance.AdminJS
+			out = h.app.constants.Appearance.AdminJS
 			hdr = "application/javascript; charset=utf-8"
 
 		case "public.custom_css":
-			out = app.constants.Appearance.PublicCSS
+			out = h.app.constants.Appearance.PublicCSS
 			hdr = "text/css; charset=utf-8"
 
 		case "public.custom_js":
-			out = app.constants.Appearance.PublicJS
+			out = h.app.constants.Appearance.PublicJS
 			hdr = "application/javascript; charset=utf-8"
 		}
 
@@ -395,49 +423,52 @@ func serveCustomAppearance(name string) echo.HandlerFunc {
 }
 
 // validateUUID middleware validates the UUID string format for a given set of params.
-func validateUUID(next echo.HandlerFunc, params ...string) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		app := c.Get("app").(*App)
-
-		for _, p := range params {
-			if !reUUID.MatchString(c.Param(p)) {
-				return c.Render(http.StatusBadRequest, tplMessage,
-					makeMsgTpl(app.i18n.T("public.errorTitle"), "",
-						app.i18n.T("globals.messages.invalidUUID")))
+func (h *Handler) validateUUID(params ...string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			for _, p := range params {
+				if !reUUID.MatchString(c.Param(p)) {
+					return c.Render(http.StatusBadRequest, tplMessage,
+						makeMsgTpl(h.app.i18n.T("public.errorTitle"), "",
+							h.app.i18n.T("globals.messages.invalidUUID")))
+				}
 			}
+			return next(c)
 		}
-		return next(c)
 	}
 }
 
 // subscriberExists middleware checks if a subscriber exists given the UUID
 // param in a request.
-func subscriberExists(next echo.HandlerFunc, params ...string) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		var (
-			app     = c.Get("app").(*App)
-			subUUID = c.Param("subUUID")
-		)
+func (h *Handler) subscriberExists(paramName string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var (
+				subUUID = c.Param(paramName)
+			)
 
-		if _, err := app.core.GetSubscriber(0, subUUID, ""); err != nil {
-			if er, ok := err.(*echo.HTTPError); ok && er.Code == http.StatusBadRequest {
-				return c.Render(http.StatusNotFound, tplMessage,
-					makeMsgTpl(app.i18n.T("public.notFoundTitle"), "", er.Message.(string)))
+			if _, err := h.app.core.GetSubscriber(0, subUUID, ""); err != nil {
+				if er, ok := err.(*echo.HTTPError); ok && er.Code == http.StatusBadRequest {
+					return c.Render(http.StatusNotFound, tplMessage,
+						makeMsgTpl(h.app.i18n.T("public.notFoundTitle"), "", er.Message.(string)))
+				}
+
+				h.app.log.Printf("error checking subscriber existence: %v", err)
+				return c.Render(http.StatusInternalServerError, tplMessage,
+					makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("public.errorProcessingRequest")))
 			}
 
-			app.log.Printf("error checking subscriber existence: %v", err)
-			return c.Render(http.StatusInternalServerError, tplMessage,
-				makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("public.errorProcessingRequest")))
+			return next(c)
 		}
-
-		return next(c)
 	}
 }
 
 // noIndex adds the HTTP header requesting robots to not crawl the page.
-func noIndex(next echo.HandlerFunc, params ...string) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("X-Robots-Tag", "noindex")
-		return next(c)
+func noIndex() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Response().Header().Set("X-Robots-Tag", "noindex")
+			return next(c)
+		}
 	}
 }

--- a/cmd/i18n.go
+++ b/cmd/i18n.go
@@ -22,15 +22,13 @@ type i18nLangRaw struct {
 }
 
 // handleGetI18nLang returns the JSON language pack given the language code.
-func handleGetI18nLang(c echo.Context) error {
-	app := c.Get("app").(*App)
-
+func (h *Handler) handleGetI18nLang(c echo.Context) error {
 	lang := c.Param("lang")
 	if len(lang) > 6 || reLangCode.MatchString(lang) {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid language code.")
 	}
 
-	i, ok, err := getI18nLang(lang, app.fs)
+	i, ok, err := getI18nLang(lang, h.app.fs)
 	if err != nil && !ok {
 		return echo.NewHTTPError(http.StatusBadRequest, "Unknown language.")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -275,7 +275,7 @@ func main() {
 	closerWait := make(chan bool)
 	<-awaitReload(app.chReload, closerWait, func() {
 		// Stop the HTTP server.
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := h.echo.Shutdown(ctx); err != nil {
 			lo.Printf("error shutting down server: %v", err)

--- a/cmd/maintenance.go
+++ b/cmd/maintenance.go
@@ -8,11 +8,8 @@ import (
 )
 
 // handleGCSubscribers garbage collects (deletes) orphaned or blocklisted subscribers.
-func handleGCSubscribers(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-		typ = c.Param("type")
-	)
+func (h *Handler) handleGCSubscribers(c echo.Context) error {
+	typ := c.Param("type")
 
 	var (
 		n   int
@@ -21,11 +18,11 @@ func handleGCSubscribers(c echo.Context) error {
 
 	switch typ {
 	case "blocklisted":
-		n, err = app.core.DeleteBlocklistedSubscribers()
+		n, err = h.app.core.DeleteBlocklistedSubscribers()
 	case "orphan":
-		n, err = app.core.DeleteOrphanSubscribers()
+		n, err = h.app.core.DeleteOrphanSubscribers()
 	default:
-		err = echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidData"))
+		err = echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidData"))
 	}
 
 	if err != nil {
@@ -38,17 +35,13 @@ func handleGCSubscribers(c echo.Context) error {
 }
 
 // handleGCSubscriptions garbage collects (deletes) orphaned or blocklisted subscribers.
-func handleGCSubscriptions(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
+func (h *Handler) handleGCSubscriptions(c echo.Context) error {
 	t, err := time.Parse(time.RFC3339, c.FormValue("before_date"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidData"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidData"))
 	}
 
-	n, err := app.core.DeleteUnconfirmedSubscriptions(t)
+	n, err := h.app.core.DeleteUnconfirmedSubscriptions(t)
 	if err != nil {
 		return err
 	}
@@ -59,29 +52,26 @@ func handleGCSubscriptions(c echo.Context) error {
 }
 
 // handleGCCampaignAnalytics garbage collects (deletes) campaign analytics.
-func handleGCCampaignAnalytics(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-		typ = c.Param("type")
-	)
+func (h *Handler) handleGCCampaignAnalytics(c echo.Context) error {
+	typ := c.Param("type")
 
 	t, err := time.Parse(time.RFC3339, c.FormValue("before_date"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidData"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidData"))
 	}
 
 	switch typ {
 	case "all":
-		if err := app.core.DeleteCampaignViews(t); err != nil {
+		if err := h.app.core.DeleteCampaignViews(t); err != nil {
 			return err
 		}
-		err = app.core.DeleteCampaignLinkClicks(t)
+		err = h.app.core.DeleteCampaignLinkClicks(t)
 	case "views":
-		err = app.core.DeleteCampaignViews(t)
+		err = h.app.core.DeleteCampaignViews(t)
 	case "clicks":
-		err = app.core.DeleteCampaignLinkClicks(t)
+		err = h.app.core.DeleteCampaignLinkClicks(t)
 	default:
-		err = echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidData"))
+		err = echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidData"))
 	}
 
 	if err != nil {

--- a/cmd/public.go
+++ b/cmd/public.go
@@ -34,6 +34,7 @@ type tplRenderer struct {
 	EnablePublicSubPage bool
 	EnablePublicArchive bool
 	IndividualTracking  bool
+	I18n                *i18n.I18n
 }
 
 // tplData is the data container that is injected
@@ -103,21 +104,17 @@ func (t *tplRenderer) Render(w io.Writer, name string, data interface{}, c echo.
 		EnablePublicArchive: t.EnablePublicArchive,
 		IndividualTracking:  t.IndividualTracking,
 		Data:                data,
-		L:                   c.Get("app").(*App).i18n,
+		L:                   t.I18n,
 	})
 }
 
 // handleGetPublicLists returns the list of public lists with minimal fields
 // required to submit a subscription.
-func handleGetPublicLists(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
+func (h *Handler) handleGetPublicLists(c echo.Context) error {
 	// Get all public lists.
-	lists, err := app.core.GetLists(models.ListTypePublic, true, nil)
+	lists, err := h.app.core.GetLists(models.ListTypePublic, true, nil)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("public.errorFetchingLists"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("public.errorFetchingLists"))
 	}
 
 	type list struct {
@@ -138,52 +135,51 @@ func handleGetPublicLists(c echo.Context) error {
 
 // handleViewCampaignMessage renders the HTML view of a campaign message.
 // This is the view the {{ MessageURL }} template tag links to in e-mail campaigns.
-func handleViewCampaignMessage(c echo.Context) error {
+func (h *Handler) handleViewCampaignMessage(c echo.Context) error {
 	var (
-		app      = c.Get("app").(*App)
 		campUUID = c.Param("campUUID")
 		subUUID  = c.Param("subUUID")
 	)
 
 	// Get the campaign.
-	camp, err := app.core.GetCampaign(0, campUUID, "")
+	camp, err := h.app.core.GetCampaign(0, campUUID, "")
 	if err != nil {
 		if er, ok := err.(*echo.HTTPError); ok {
 			if er.Code == http.StatusBadRequest {
 				return c.Render(http.StatusNotFound, tplMessage,
-					makeMsgTpl(app.i18n.T("public.notFoundTitle"), "", app.i18n.T("public.campaignNotFound")))
+					makeMsgTpl(h.app.i18n.T("public.notFoundTitle"), "", h.app.i18n.T("public.campaignNotFound")))
 			}
 		}
 
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorFetchingCampaign")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorFetchingCampaign")))
 	}
 
 	// Get the subscriber.
-	sub, err := app.core.GetSubscriber(0, subUUID, "")
+	sub, err := h.app.core.GetSubscriber(0, subUUID, "")
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.Render(http.StatusNotFound, tplMessage,
-				makeMsgTpl(app.i18n.T("public.notFoundTitle"), "", app.i18n.T("public.errorFetchingEmail")))
+				makeMsgTpl(h.app.i18n.T("public.notFoundTitle"), "", h.app.i18n.T("public.errorFetchingEmail")))
 		}
 
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorFetchingCampaign")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorFetchingCampaign")))
 	}
 
 	// Compile the template.
-	if err := camp.CompileTemplate(app.manager.TemplateFuncs(&camp)); err != nil {
-		app.log.Printf("error compiling template: %v", err)
+	if err := camp.CompileTemplate(h.app.manager.TemplateFuncs(&camp)); err != nil {
+		h.app.log.Printf("error compiling template: %v", err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorFetchingCampaign")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorFetchingCampaign")))
 	}
 
 	// Render the message body.
-	msg, err := app.manager.NewCampaignMessage(&camp, sub)
+	msg, err := h.app.manager.NewCampaignMessage(&camp, sub)
 	if err != nil {
-		app.log.Printf("error rendering message: %v", err)
+		h.app.log.Printf("error rendering message: %v", err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorFetchingCampaign")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorFetchingCampaign")))
 	}
 
 	return c.HTML(http.StatusOK, string(msg.Body()))
@@ -192,41 +188,40 @@ func handleViewCampaignMessage(c echo.Context) error {
 // handleSubscriptionPage renders the subscription management page and
 // handles unsubscriptions. This is the view that {{ UnsubscribeURL }} in
 // campaigns link to.
-func handleSubscriptionPage(c echo.Context) error {
+func (h *Handler) handleSubscriptionPage(c echo.Context) error {
 	var (
-		app           = c.Get("app").(*App)
 		subUUID       = c.Param("subUUID")
 		showManage, _ = strconv.ParseBool(c.FormValue("manage"))
 		out           = unsubTpl{}
 	)
 	out.SubUUID = subUUID
-	out.Title = app.i18n.T("public.unsubscribeTitle")
-	out.AllowBlocklist = app.constants.Privacy.AllowBlocklist
-	out.AllowExport = app.constants.Privacy.AllowExport
-	out.AllowWipe = app.constants.Privacy.AllowWipe
-	out.AllowPreferences = app.constants.Privacy.AllowPreferences
+	out.Title = h.app.i18n.T("public.unsubscribeTitle")
+	out.AllowBlocklist = h.app.constants.Privacy.AllowBlocklist
+	out.AllowExport = h.app.constants.Privacy.AllowExport
+	out.AllowWipe = h.app.constants.Privacy.AllowWipe
+	out.AllowPreferences = h.app.constants.Privacy.AllowPreferences
 
-	s, err := app.core.GetSubscriber(0, subUUID, "")
+	s, err := h.app.core.GetSubscriber(0, subUUID, "")
 	if err != nil {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorProcessingRequest")))
 	}
 	out.Subscriber = s
 
 	if s.Status == models.SubscriberStatusBlockListed {
 		return c.Render(http.StatusOK, tplMessage,
-			makeMsgTpl(app.i18n.T("public.noSubTitle"), "", app.i18n.Ts("public.blocklisted")))
+			makeMsgTpl(h.app.i18n.T("public.noSubTitle"), "", h.app.i18n.Ts("public.blocklisted")))
 	}
 
 	// Only show preference management if it's enabled in settings.
-	if app.constants.Privacy.AllowPreferences {
+	if h.app.constants.Privacy.AllowPreferences {
 		out.ShowManage = showManage
 	}
 	if out.ShowManage {
 		// Get the subscriber's lists.
-		subs, err := app.core.GetSubscriptions(0, subUUID, false)
+		subs, err := h.app.core.GetSubscriptions(0, subUUID, false)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("public.errorFetchingLists"))
+			return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("public.errorFetchingLists"))
 		}
 
 		out.Subscriptions = make([]models.Subscription, 0, len(subs))
@@ -245,9 +240,8 @@ func handleSubscriptionPage(c echo.Context) error {
 // handleSubscriptionPrefs renders the subscription management page and
 // handles unsubscriptions. This is the view that {{ UnsubscribeURL }} in
 // campaigns link to.
-func handleSubscriptionPrefs(c echo.Context) error {
+func (h *Handler) handleSubscriptionPrefs(c echo.Context) error {
 	var (
-		app      = c.Get("app").(*App)
 		campUUID = c.Param("campUUID")
 		subUUID  = c.Param("subUUID")
 
@@ -262,47 +256,47 @@ func handleSubscriptionPrefs(c echo.Context) error {
 	// Read the form.
 	if err := c.Bind(&req); err != nil {
 		return c.Render(http.StatusBadRequest, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("globals.messages.invalidData")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("globals.messages.invalidData")))
 	}
 
 	// Simple unsubscribe.
-	blocklist := app.constants.Privacy.AllowBlocklist && req.Blocklist
+	blocklist := h.app.constants.Privacy.AllowBlocklist && req.Blocklist
 	if !req.Manage || blocklist {
-		if err := app.core.UnsubscribeByCampaign(subUUID, campUUID, blocklist); err != nil {
+		if err := h.app.core.UnsubscribeByCampaign(subUUID, campUUID, blocklist); err != nil {
 			return c.Render(http.StatusInternalServerError, tplMessage,
-				makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("public.errorProcessingRequest")))
+				makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("public.errorProcessingRequest")))
 		}
 
 		return c.Render(http.StatusOK, tplMessage,
-			makeMsgTpl(app.i18n.T("public.unsubbedTitle"), "", app.i18n.T("public.unsubbedInfo")))
+			makeMsgTpl(h.app.i18n.T("public.unsubbedTitle"), "", h.app.i18n.T("public.unsubbedInfo")))
 	}
 
 	// Is preference management enabled?
-	if !app.constants.Privacy.AllowPreferences {
+	if !h.app.constants.Privacy.AllowPreferences {
 		return c.Render(http.StatusBadRequest, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("public.invalidFeature")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("public.invalidFeature")))
 	}
 
 	// Manage preferences.
 	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" || len(req.Name) > 256 {
 		return c.Render(http.StatusBadRequest, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("subscribers.invalidName")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("subscribers.invalidName")))
 	}
 
 	// Get the subscriber from the DB.
-	sub, err := app.core.GetSubscriber(0, subUUID, "")
+	sub, err := h.app.core.GetSubscriber(0, subUUID, "")
 	if err != nil {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("globals.messages.pFound",
-				"name", app.i18n.T("globals.terms.subscriber"))))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("globals.messages.pFound",
+				"name", h.app.i18n.T("globals.terms.subscriber"))))
 	}
 	sub.Name = req.Name
 
 	// Update name.
-	if _, err := app.core.UpdateSubscriber(sub.ID, sub); err != nil {
+	if _, err := h.app.core.UpdateSubscriber(sub.ID, sub); err != nil {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("public.errorProcessingRequest")))
 	}
 
 	// Get the subscriber's lists and whatever is not sent in the request (unchecked),
@@ -312,9 +306,9 @@ func handleSubscriptionPrefs(c echo.Context) error {
 		reqUUIDs[u] = struct{}{}
 	}
 
-	subs, err := app.core.GetSubscriptions(0, subUUID, false)
+	subs, err := h.app.core.GetSubscriptions(0, subUUID, false)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("public.errorFetchingLists"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("public.errorFetchingLists"))
 	}
 
 	unsubUUIDs := make([]string, 0, len(req.ListUUIDs))
@@ -328,28 +322,27 @@ func handleSubscriptionPrefs(c echo.Context) error {
 	}
 
 	// Unsubscribe from lists.
-	if err := app.core.UnsubscribeLists([]int{sub.ID}, nil, unsubUUIDs); err != nil {
+	if err := h.app.core.UnsubscribeLists([]int{sub.ID}, nil, unsubUUIDs); err != nil {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("public.errorProcessingRequest")))
 
 	}
 
 	return c.Render(http.StatusOK, tplMessage,
-		makeMsgTpl(app.i18n.T("globals.messages.done"), "", app.i18n.T("public.prefsSaved")))
+		makeMsgTpl(h.app.i18n.T("globals.messages.done"), "", h.app.i18n.T("public.prefsSaved")))
 }
 
 // handleOptinPage renders the double opt-in confirmation page that subscribers
 // see when they click on the "Confirm subscription" button in double-optin
 // notifications.
-func handleOptinPage(c echo.Context) error {
+func (h *Handler) handleOptinPage(c echo.Context) error {
 	var (
-		app        = c.Get("app").(*App)
 		subUUID    = c.Param("subUUID")
 		confirm, _ = strconv.ParseBool(c.FormValue("confirm"))
 		out        = optinTpl{}
 	)
 	out.SubUUID = subUUID
-	out.Title = app.i18n.T("public.confirmOptinSubTitle")
+	out.Title = h.app.i18n.T("public.confirmOptinSubTitle")
 	out.SubUUID = subUUID
 
 	// Get and validate fields.
@@ -362,44 +355,40 @@ func handleOptinPage(c echo.Context) error {
 		for _, l := range out.ListUUIDs {
 			if !reUUID.MatchString(l) {
 				return c.Render(http.StatusBadRequest, tplMessage,
-					makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("globals.messages.invalidUUID")))
+					makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("globals.messages.invalidUUID")))
 			}
 		}
 	}
 
 	// Get the list of subscription lists where the subscriber hasn't confirmed.
-	lists, err := app.core.GetSubscriberLists(0, subUUID, nil, out.ListUUIDs, models.SubscriptionStatusUnconfirmed, "")
+	lists, err := h.app.core.GetSubscriberLists(0, subUUID, nil, out.ListUUIDs, models.SubscriptionStatusUnconfirmed, "")
 	if err != nil {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorFetchingLists")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorFetchingLists")))
 	}
 
 	// There are no lists to confirm.
 	if len(lists) == 0 {
 		return c.Render(http.StatusOK, tplMessage,
-			makeMsgTpl(app.i18n.T("public.noSubTitle"), "", app.i18n.Ts("public.noSubInfo")))
+			makeMsgTpl(h.app.i18n.T("public.noSubTitle"), "", h.app.i18n.Ts("public.noSubInfo")))
 	}
 	out.Lists = lists
 
 	// Confirm.
 	if confirm {
 		meta := models.JSON{}
-		if app.constants.Privacy.RecordOptinIP {
-			if h := c.Request().Header.Get("X-Forwarded-For"); h != "" {
-				meta["optin_ip"] = h
-			} else if h := c.Request().RemoteAddr; h != "" {
-				meta["optin_ip"] = strings.Split(h, ":")[0]
-			}
+		if h.app.constants.Privacy.RecordOptinIP {
+			meta["optin_ip"] = c.RealIP()
 		}
 
-		if err := app.core.ConfirmOptionSubscription(subUUID, out.ListUUIDs, meta); err != nil {
-			app.log.Printf("error unsubscribing: %v", err)
+		if err := h.app.core.ConfirmOptionSubscription(subUUID, out.ListUUIDs, meta); err != nil {
+			h.app.log.Printf("error unsubscribing: %v", err)
 			return c.Render(http.StatusInternalServerError, tplMessage,
-				makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorProcessingRequest")))
+				makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorProcessingRequest")))
 		}
 
 		return c.Render(http.StatusOK, tplMessage,
-			makeMsgTpl(app.i18n.T("public.subConfirmedTitle"), "", app.i18n.Ts("public.subConfirmed")))
+			makeMsgTpl(h.app.i18n.T("public.subConfirmedTitle"), "", h.app.i18n.Ts("public.subConfirmed")))
 	}
 
 	return c.Render(http.StatusOK, "optin", out)
@@ -407,34 +396,30 @@ func handleOptinPage(c echo.Context) error {
 
 // handleSubscriptionFormPage handles subscription requests coming from public
 // HTML subscription forms.
-func handleSubscriptionFormPage(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
-	if !app.constants.EnablePublicSubPage {
+func (h *Handler) handleSubscriptionFormPage(c echo.Context) error {
+	if !h.app.constants.EnablePublicSubPage {
 		return c.Render(http.StatusNotFound, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.invalidFeature")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.invalidFeature")))
 	}
 
 	// Get all public lists.
-	lists, err := app.core.GetLists(models.ListTypePublic, true, nil)
+	lists, err := h.app.core.GetLists(models.ListTypePublic, true, nil)
 	if err != nil {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorFetchingLists")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorFetchingLists")))
 	}
 
 	if len(lists) == 0 {
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.noListsAvailable")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.noListsAvailable")))
 	}
 
 	out := subFormTpl{}
-	out.Title = app.i18n.T("public.sub")
+	out.Title = h.app.i18n.T("public.sub")
 	out.Lists = lists
 
-	if app.constants.Security.EnableCaptcha {
-		out.CaptchaKey = app.constants.Security.CaptchaKey
+	if h.app.constants.Security.EnableCaptcha {
+		out.CaptchaKey = h.app.constants.Security.CaptchaKey
 	}
 
 	return c.Render(http.StatusOK, "subscription-form", out)
@@ -442,30 +427,26 @@ func handleSubscriptionFormPage(c echo.Context) error {
 
 // handleSubscriptionForm handles subscription requests coming from public
 // HTML subscription forms.
-func handleSubscriptionForm(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
+func (h *Handler) handleSubscriptionForm(c echo.Context) error {
 	// If there's a nonce value, a bot could've filled the form.
 	if c.FormValue("nonce") != "" {
-		return echo.NewHTTPError(http.StatusBadGateway, app.i18n.T("public.invalidFeature"))
+		return echo.NewHTTPError(http.StatusBadGateway, h.app.i18n.T("public.invalidFeature"))
 	}
 
 	// Process CAPTCHA.
-	if app.constants.Security.EnableCaptcha {
-		err, ok := app.captcha.Verify(c.FormValue("h-captcha-response"))
+	if h.app.constants.Security.EnableCaptcha {
+		err, ok := h.app.captcha.Verify(c.FormValue("h-captcha-response"))
 		if err != nil {
-			app.log.Printf("Captcha request failed: %v", err)
+			h.app.log.Printf("Captcha request failed: %v", err)
 		}
 
 		if !ok {
 			return c.Render(http.StatusBadRequest, tplMessage,
-				makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.T("public.invalidCaptcha")))
+				makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.T("public.invalidCaptcha")))
 		}
 	}
 
-	hasOptin, err := processSubForm(c)
+	hasOptin, err := h.processSubForm(c)
 	if err != nil {
 		e, ok := err.(*echo.HTTPError)
 		if !ok {
@@ -473,7 +454,7 @@ func handleSubscriptionForm(c echo.Context) error {
 		}
 
 		return c.Render(e.Code, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", fmt.Sprintf("%s", e.Message)))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", fmt.Sprintf("%s", e.Message)))
 	}
 
 	msg := "public.subConfirmed"
@@ -481,21 +462,17 @@ func handleSubscriptionForm(c echo.Context) error {
 		msg = "public.subOptinPending"
 	}
 
-	return c.Render(http.StatusOK, tplMessage, makeMsgTpl(app.i18n.T("public.subTitle"), "", app.i18n.Ts(msg)))
+	return c.Render(http.StatusOK, tplMessage, makeMsgTpl(h.app.i18n.T("public.subTitle"), "", h.app.i18n.Ts(msg)))
 }
 
 // handlePublicSubscription handles subscription requests coming from public
 // API calls.
-func handlePublicSubscription(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
-	if !app.constants.EnablePublicSubPage {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("public.invalidFeature"))
+func (h *Handler) handlePublicSubscription(c echo.Context) error {
+	if !h.app.constants.EnablePublicSubPage {
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("public.invalidFeature"))
 	}
 
-	hasOptin, err := processSubForm(c)
+	hasOptin, err := h.processSubForm(c)
 	if err != nil {
 		return err
 	}
@@ -508,23 +485,22 @@ func handlePublicSubscription(c echo.Context) error {
 // handleLinkRedirect redirects a link UUID to its original underlying link
 // after recording the link click for a particular subscriber in the particular
 // campaign. These links are generated by {{ TrackLink }} tags in campaigns.
-func handleLinkRedirect(c echo.Context) error {
+func (h *Handler) handleLinkRedirect(c echo.Context) error {
 	var (
-		app      = c.Get("app").(*App)
 		linkUUID = c.Param("linkUUID")
 		campUUID = c.Param("campUUID")
 		subUUID  = c.Param("subUUID")
 	)
 
 	// If individual tracking is disabled, do not record the subscriber ID.
-	if !app.constants.Privacy.IndividualTracking {
+	if !h.app.constants.Privacy.IndividualTracking {
 		subUUID = ""
 	}
 
-	url, err := app.core.RegisterCampaignLinkClick(linkUUID, campUUID, subUUID)
+	url, err := h.app.core.RegisterCampaignLinkClick(linkUUID, campUUID, subUUID)
 	if err != nil {
 		e := err.(*echo.HTTPError)
-		return c.Render(e.Code, tplMessage, makeMsgTpl(app.i18n.T("public.errorTitle"), "", e.Error()))
+		return c.Render(e.Code, tplMessage, makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", e.Error()))
 	}
 
 	return c.Redirect(http.StatusTemporaryRedirect, url)
@@ -534,22 +510,21 @@ func handleLinkRedirect(c echo.Context) error {
 // the form of an pixel image request. Regardless of errors, this handler
 // should always render the pixel image bytes. The pixel URL is generated by
 // the {{ TrackView }} template tag in campaigns.
-func handleRegisterCampaignView(c echo.Context) error {
+func (h *Handler) handleRegisterCampaignView(c echo.Context) error {
 	var (
-		app      = c.Get("app").(*App)
 		campUUID = c.Param("campUUID")
 		subUUID  = c.Param("subUUID")
 	)
 
 	// If individual tracking is disabled, do not record the subscriber ID.
-	if !app.constants.Privacy.IndividualTracking {
+	if !h.app.constants.Privacy.IndividualTracking {
 		subUUID = ""
 	}
 
 	// Exclude dummy hits from template previews.
 	if campUUID != dummyUUID && subUUID != dummyUUID {
-		if err := app.core.RegisterCampaignView(campUUID, subUUID); err != nil {
-			app.log.Printf("error registering campaign view: %s", err)
+		if err := h.app.core.RegisterCampaignView(campUUID, subUUID); err != nil {
+			h.app.log.Printf("error registering campaign view: %s", err)
 		}
 	}
 
@@ -561,46 +536,45 @@ func handleRegisterCampaignView(c echo.Context) error {
 // campaign views and clicks and produces a JSON report that is then e-mailed
 // to the subscriber. This is a privacy feature and the data that's exported
 // is dependent on the configuration.
-func handleSelfExportSubscriberData(c echo.Context) error {
+func (h *Handler) handleSelfExportSubscriberData(c echo.Context) error {
 	var (
-		app     = c.Get("app").(*App)
 		subUUID = c.Param("subUUID")
 	)
 	// Is export allowed?
-	if !app.constants.Privacy.AllowExport {
+	if !h.app.constants.Privacy.AllowExport {
 		return c.Render(http.StatusBadRequest, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.invalidFeature")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.invalidFeature")))
 	}
 
 	// Get the subscriber's data. A single query that gets the profile,
 	// list subscriptions, campaign views, and link clicks. Names of
 	// private lists are replaced with "Private list".
-	data, b, err := exportSubscriberData(0, subUUID, app.constants.Privacy.Exportable, app)
+	data, b, err := exportSubscriberData(0, subUUID, h.app.constants.Privacy.Exportable, h.app)
 	if err != nil {
-		app.log.Printf("error exporting subscriber data: %s", err)
+		h.app.log.Printf("error exporting subscriber data: %s", err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorProcessingRequest")))
 	}
 
 	// Prepare the attachment e-mail.
 	var msg bytes.Buffer
-	if err := app.notifTpls.tpls.ExecuteTemplate(&msg, notifSubscriberData, data); err != nil {
-		app.log.Printf("error compiling notification template '%s': %v", notifSubscriberData, err)
+	if err := h.app.notifTpls.tpls.ExecuteTemplate(&msg, notifSubscriberData, data); err != nil {
+		h.app.log.Printf("error compiling notification template '%s': %v", notifSubscriberData, err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorProcessingRequest")))
 	}
 
 	var (
-		subject = app.i18n.Ts("email.data.title")
+		subject = h.app.i18n.Ts("email.data.title")
 		body    = msg.Bytes()
 	)
 	subject, body = getTplSubject(subject, body)
 
 	// Send the data as a JSON attachment to the subscriber.
 	const fname = "data.json"
-	if err := app.messengers[emailMsgr].Push(models.Message{
-		ContentType: app.notifTpls.contentType,
-		From:        app.constants.FromEmail,
+	if err := h.app.messengers[emailMsgr].Push(models.Message{
+		ContentType: h.app.notifTpls.contentType,
+		From:        h.app.constants.FromEmail,
 		To:          []string{data.Email},
 		Subject:     subject,
 		Body:        body,
@@ -612,38 +586,37 @@ func handleSelfExportSubscriberData(c echo.Context) error {
 			},
 		},
 	}); err != nil {
-		app.log.Printf("error e-mailing subscriber profile: %s", err)
+		h.app.log.Printf("error e-mailing subscriber profile: %s", err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorProcessingRequest")))
 	}
 
 	return c.Render(http.StatusOK, tplMessage,
-		makeMsgTpl(app.i18n.T("public.dataSentTitle"), "", app.i18n.T("public.dataSent")))
+		makeMsgTpl(h.app.i18n.T("public.dataSentTitle"), "", h.app.i18n.T("public.dataSent")))
 }
 
 // handleWipeSubscriberData allows a subscriber to delete their data. The
 // profile and subscriptions are deleted, while the campaign_views and link
 // clicks remain as orphan data unconnected to any subscriber.
-func handleWipeSubscriberData(c echo.Context) error {
+func (h *Handler) handleWipeSubscriberData(c echo.Context) error {
 	var (
-		app     = c.Get("app").(*App)
 		subUUID = c.Param("subUUID")
 	)
 
 	// Is wiping allowed?
-	if !app.constants.Privacy.AllowWipe {
+	if !h.app.constants.Privacy.AllowWipe {
 		return c.Render(http.StatusBadRequest, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.invalidFeature")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.invalidFeature")))
 	}
 
-	if err := app.core.DeleteSubscribers(nil, []string{subUUID}); err != nil {
-		app.log.Printf("error wiping subscriber data: %s", err)
+	if err := h.app.core.DeleteSubscribers(nil, []string{subUUID}); err != nil {
+		h.app.log.Printf("error wiping subscriber data: %s", err)
 		return c.Render(http.StatusInternalServerError, tplMessage,
-			makeMsgTpl(app.i18n.T("public.errorTitle"), "", app.i18n.Ts("public.errorProcessingRequest")))
+			makeMsgTpl(h.app.i18n.T("public.errorTitle"), "", h.app.i18n.Ts("public.errorProcessingRequest")))
 	}
 
 	return c.Render(http.StatusOK, tplMessage,
-		makeMsgTpl(app.i18n.T("public.dataRemovedTitle"), "", app.i18n.T("public.dataRemoved")))
+		makeMsgTpl(h.app.i18n.T("public.dataRemovedTitle"), "", h.app.i18n.T("public.dataRemoved")))
 }
 
 // drawTransparentImage draws a transparent PNG of given dimensions
@@ -660,9 +633,8 @@ func drawTransparentImage(h, w int) []byte {
 // processSubForm processes an incoming form/public API subscription request.
 // The bool indicates whether there was subscription to an optin list so that
 // an appropriate message can be shown.
-func processSubForm(c echo.Context) (bool, error) {
+func (h *Handler) processSubForm(c echo.Context) (bool, error) {
 	var (
-		app = c.Get("app").(*App)
 		req struct {
 			Name          string   `form:"name" json:"name"`
 			Email         string   `form:"email" json:"email"`
@@ -676,7 +648,7 @@ func processSubForm(c echo.Context) (bool, error) {
 	}
 
 	if len(req.FormListUUIDs) == 0 {
-		return false, echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("public.noListsSelected"))
+		return false, echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("public.noListsSelected"))
 	}
 
 	// If there's no name, use the name bit from the e-mail.
@@ -687,10 +659,10 @@ func processSubForm(c echo.Context) (bool, error) {
 
 	// Validate fields.
 	if len(req.Email) > 1000 {
-		return false, echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("subscribers.invalidEmail"))
+		return false, echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("subscribers.invalidEmail"))
 	}
 
-	em, err := app.importer.SanitizeEmail(req.Email)
+	em, err := h.app.importer.SanitizeEmail(req.Email)
 	if err != nil {
 		return false, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -698,13 +670,13 @@ func processSubForm(c echo.Context) (bool, error) {
 
 	req.Name = strings.TrimSpace(req.Name)
 	if len(req.Name) == 0 || len(req.Name) > stdInputMaxLen {
-		return false, echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("subscribers.invalidName"))
+		return false, echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("subscribers.invalidName"))
 	}
 
 	listUUIDs := pq.StringArray(req.FormListUUIDs)
 
 	// Insert the subscriber into the DB.
-	_, hasOptin, err := app.core.InsertSubscriber(models.Subscriber{
+	_, hasOptin, err := h.app.core.InsertSubscriber(models.Subscriber{
 		Name:   req.Name,
 		Email:  req.Email,
 		Status: models.SubscriberStatusEnabled,
@@ -712,12 +684,12 @@ func processSubForm(c echo.Context) (bool, error) {
 	if err != nil {
 		// Subscriber already exists. Update subscriptions.
 		if e, ok := err.(*echo.HTTPError); ok && e.Code == http.StatusConflict {
-			sub, err := app.core.GetSubscriber(0, "", req.Email)
+			sub, err := h.app.core.GetSubscriber(0, "", req.Email)
 			if err != nil {
 				return false, err
 			}
 
-			_, hasOptin, err := app.core.UpdateSubscriberWithLists(sub.ID, sub, nil, listUUIDs, false, false)
+			_, hasOptin, err := h.app.core.UpdateSubscriberWithLists(sub.ID, sub, nil, listUUIDs, false, false)
 			if err != nil {
 				return false, err
 			}

--- a/cmd/roles.go
+++ b/cmd/roles.go
@@ -11,13 +11,10 @@ import (
 )
 
 // handleGetUserRoles retrieves roles.
-func handleGetUserRoles(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
+func (h *Handler) handleGetUserRoles(c echo.Context) error {
 
 	// Get all roles.
-	out, err := app.core.GetRoles()
+	out, err := h.app.core.GetRoles()
 	if err != nil {
 		return err
 	}
@@ -26,13 +23,9 @@ func handleGetUserRoles(c echo.Context) error {
 }
 
 // handleGeListRoles retrieves roles.
-func handleGeListRoles(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-	)
-
+func (h *Handler) handleGetListRoles(c echo.Context) error {
 	// Get all roles.
-	out, err := app.core.GetListRoles()
+	out, err := h.app.core.GetListRoles()
 	if err != nil {
 		return err
 	}
@@ -41,21 +34,20 @@ func handleGeListRoles(c echo.Context) error {
 }
 
 // handleCreateUserRole handles role creation.
-func handleCreateUserRole(c echo.Context) error {
+func (h *Handler) handleCreateUserRole(c echo.Context) error {
 	var (
-		app = c.Get("app").(*App)
-		r   = models.Role{}
+		r = models.Role{}
 	)
 
 	if err := c.Bind(&r); err != nil {
 		return err
 	}
 
-	if err := validateUserRole(r, app); err != nil {
+	if err := validateUserRole(r, h.app); err != nil {
 		return err
 	}
 
-	out, err := app.core.CreateRole(r)
+	out, err := h.app.core.CreateRole(r)
 	if err != nil {
 		return err
 	}
@@ -64,21 +56,20 @@ func handleCreateUserRole(c echo.Context) error {
 }
 
 // handleCreateListRole handles role creation.
-func handleCreateListRole(c echo.Context) error {
+func (h *Handler) handleCreateListRole(c echo.Context) error {
 	var (
-		app = c.Get("app").(*App)
-		r   = models.ListRole{}
+		r = models.ListRole{}
 	)
 
 	if err := c.Bind(&r); err != nil {
 		return err
 	}
 
-	if err := validateListRole(r, app); err != nil {
+	if err := validateListRole(r, h.app); err != nil {
 		return err
 	}
 
-	out, err := app.core.CreateListRole(r)
+	out, err := h.app.core.CreateListRole(r)
 	if err != nil {
 		return err
 	}
@@ -87,14 +78,13 @@ func handleCreateListRole(c echo.Context) error {
 }
 
 // handleUpdateUserRole handles role modification.
-func handleUpdateUserRole(c echo.Context) error {
+func (h *Handler) handleUpdateUserRole(c echo.Context) error {
 	var (
-		app   = c.Get("app").(*App)
 		id, _ = strconv.Atoi(c.Param("id"))
 	)
 
 	if id < 2 {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidID"))
 	}
 
 	// Incoming params.
@@ -103,20 +93,20 @@ func handleUpdateUserRole(c echo.Context) error {
 		return err
 	}
 
-	if err := validateUserRole(r, app); err != nil {
+	if err := validateUserRole(r, h.app); err != nil {
 		return err
 	}
 
 	// Validate.
 	r.Name.String = strings.TrimSpace(r.Name.String)
 
-	out, err := app.core.UpdateUserRole(id, r)
+	out, err := h.app.core.UpdateUserRole(id, r)
 	if err != nil {
 		return err
 	}
 
 	// Cache the API token for validating API queries without hitting the DB every time.
-	if _, err := cacheUsers(app.core, app.auth); err != nil {
+	if _, err := cacheUsers(h.app.core, h.app.auth); err != nil {
 		return err
 	}
 
@@ -124,14 +114,13 @@ func handleUpdateUserRole(c echo.Context) error {
 }
 
 // handleUpdateListRole handles role modification.
-func handleUpdateListRole(c echo.Context) error {
+func (h *Handler) handleUpdateListRole(c echo.Context) error {
 	var (
-		app   = c.Get("app").(*App)
 		id, _ = strconv.Atoi(c.Param("id"))
 	)
 
 	if id < 2 {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidID"))
 	}
 
 	// Incoming params.
@@ -140,20 +129,20 @@ func handleUpdateListRole(c echo.Context) error {
 		return err
 	}
 
-	if err := validateListRole(r, app); err != nil {
+	if err := validateListRole(r, h.app); err != nil {
 		return err
 	}
 
 	// Validate.
 	r.Name.String = strings.TrimSpace(r.Name.String)
 
-	out, err := app.core.UpdateListRole(id, r)
+	out, err := h.app.core.UpdateListRole(id, r)
 	if err != nil {
 		return err
 	}
 
 	// Cache the API token for validating API queries without hitting the DB every time.
-	if _, err := cacheUsers(app.core, app.auth); err != nil {
+	if _, err := cacheUsers(h.app.core, h.app.auth); err != nil {
 		return err
 	}
 
@@ -161,22 +150,21 @@ func handleUpdateListRole(c echo.Context) error {
 }
 
 // handleDeleteRole handles role deletion.
-func handleDeleteRole(c echo.Context) error {
+func (h *Handler) handleDeleteRole(c echo.Context) error {
 	var (
-		app   = c.Get("app").(*App)
 		id, _ = strconv.ParseInt(c.Param("id"), 10, 64)
 	)
 
 	if id < 1 {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("globals.messages.invalidID"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("globals.messages.invalidID"))
 	}
 
-	if err := app.core.DeleteRole(int(id)); err != nil {
+	if err := h.app.core.DeleteRole(int(id)); err != nil {
 		return err
 	}
 
 	// Cache the API token for validating API queries without hitting the DB every time.
-	if _, err := cacheUsers(app.core, app.auth); err != nil {
+	if _, err := cacheUsers(h.app.core, h.app.auth); err != nil {
 		return err
 	}
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -49,22 +49,20 @@ var (
 )
 
 // handleGetSettings returns settings from the DB.
-func handleGetSettings(c echo.Context) error {
-	app := c.Get("app").(*App)
-
-	s, err := app.core.GetSettings()
+func (h *Handler) handleGetSettings(c echo.Context) error {
+	s, err := h.app.core.GetSettings()
 	if err != nil {
 		return err
 	}
 
 	// Empty out passwords.
-	for i := 0; i < len(s.SMTP); i++ {
+	for i := range s.SMTP {
 		s.SMTP[i].Password = strings.Repeat(pwdMask, utf8.RuneCountInString(s.SMTP[i].Password))
 	}
-	for i := 0; i < len(s.BounceBoxes); i++ {
+	for i := range s.BounceBoxes {
 		s.BounceBoxes[i].Password = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceBoxes[i].Password))
 	}
-	for i := 0; i < len(s.Messengers); i++ {
+	for i := range s.Messengers {
 		s.Messengers[i].Password = strings.Repeat(pwdMask, utf8.RuneCountInString(s.Messengers[i].Password))
 	}
 
@@ -79,9 +77,8 @@ func handleGetSettings(c echo.Context) error {
 }
 
 // handleUpdateSettings returns settings from the DB.
-func handleUpdateSettings(c echo.Context) error {
+func (h *Handler) handleUpdateSettings(c echo.Context) error {
 	var (
-		app = c.Get("app").(*App)
 		set models.Settings
 	)
 
@@ -91,7 +88,7 @@ func handleUpdateSettings(c echo.Context) error {
 	}
 
 	// Get the existing settings.
-	cur, err := app.core.GetSettings()
+	cur, err := h.app.core.GetSettings()
 	if err != nil {
 		return err
 	}
@@ -126,7 +123,7 @@ func handleUpdateSettings(c echo.Context) error {
 		}
 	}
 	if !has {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("settings.errorNoSMTP"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("settings.errorNoSMTP"))
 	}
 
 	set.AppRootURL = strings.TrimRight(set.AppRootURL, "/")
@@ -146,7 +143,7 @@ func handleUpdateSettings(c echo.Context) error {
 		set.BounceBoxes[i].Host = strings.TrimSpace(s.Host)
 
 		if d, _ := time.ParseDuration(s.ScanInterval); d.Minutes() < 1 {
-			return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("settings.bounces.invalidScanInterval"))
+			return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("settings.bounces.invalidScanInterval"))
 		}
 
 		// If there's no password coming in from the frontend, copy the existing
@@ -181,10 +178,10 @@ func handleUpdateSettings(c echo.Context) error {
 		name := reAlphaNum.ReplaceAllString(strings.ToLower(m.Name), "")
 		if _, ok := names[name]; ok {
 			return echo.NewHTTPError(http.StatusBadRequest,
-				app.i18n.Ts("settings.duplicateMessengerName", "name", name))
+				h.app.i18n.Ts("settings.duplicateMessengerName", "name", name))
 		}
 		if len(name) == 0 {
-			return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("settings.invalidMessengerName"))
+			return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.T("settings.invalidMessengerName"))
 		}
 
 		set.Messengers[i].Name = name
@@ -228,21 +225,21 @@ func handleUpdateSettings(c echo.Context) error {
 	// Validate slow query caching cron.
 	if set.CacheSlowQueries {
 		if _, err := cron.ParseStandard(set.CacheSlowQueriesInterval); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.invalidData")+": slow query cron: "+err.Error())
+			return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.Ts("globals.messages.invalidData")+": slow query cron: "+err.Error())
 		}
 	}
 
 	// Update the settings in the DB.
-	if err := app.core.UpdateSettings(set); err != nil {
+	if err := h.app.core.UpdateSettings(set); err != nil {
 		return err
 	}
 
 	// If there are any active campaigns, don't do an auto reload and
 	// warn the user on the frontend.
-	if app.manager.HasRunningCampaigns() {
-		app.Lock()
-		app.needsRestart = true
-		app.Unlock()
+	if h.app.manager.HasRunningCampaigns() {
+		h.app.Lock()
+		h.app.needsRestart = true
+		h.app.Unlock()
 
 		return c.JSON(http.StatusOK, okResp{struct {
 			NeedsRestart bool `json:"needs_restart"`
@@ -252,45 +249,42 @@ func handleUpdateSettings(c echo.Context) error {
 	// No running campaigns. Reload the app.
 	go func() {
 		<-time.After(time.Millisecond * 500)
-		app.chReload <- syscall.SIGHUP
+		h.app.chReload <- syscall.SIGHUP
 	}()
 
 	return c.JSON(http.StatusOK, okResp{true})
 }
 
 // handleGetLogs returns the log entries stored in the log buffer.
-func handleGetLogs(c echo.Context) error {
-	app := c.Get("app").(*App)
-	return c.JSON(http.StatusOK, okResp{app.bufLog.Lines()})
+func (h *Handler) handleGetLogs(c echo.Context) error {
+	return c.JSON(http.StatusOK, okResp{h.app.bufLog.Lines()})
 }
 
 // handleTestSMTPSettings returns the log entries stored in the log buffer.
-func handleTestSMTPSettings(c echo.Context) error {
-	app := c.Get("app").(*App)
-
+func (h *Handler) handleTestSMTPSettings(c echo.Context) error {
 	// Copy the raw JSON post body.
 	reqBody, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		app.log.Printf("error reading SMTP test: %v", err)
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.internalError"))
+		h.app.log.Printf("error reading SMTP test: %v", err)
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.Ts("globals.messages.internalError"))
 	}
 
 	// Load the JSON into koanf to parse SMTP settings properly including timestrings.
 	ko := koanf.New(".")
 	if err := ko.Load(rawbytes.Provider(reqBody), json.Parser()); err != nil {
-		app.log.Printf("error unmarshalling SMTP test request: %v", err)
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.internalError"))
+		h.app.log.Printf("error unmarshalling SMTP test request: %v", err)
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.Ts("globals.messages.internalError"))
 	}
 
 	req := email.Server{}
 	if err := ko.UnmarshalWithConf("", &req, koanf.UnmarshalConf{Tag: "json"}); err != nil {
-		app.log.Printf("error scanning SMTP test request: %v", err)
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.internalError"))
+		h.app.log.Printf("error scanning SMTP test request: %v", err)
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.Ts("globals.messages.internalError"))
 	}
 
 	to := ko.String("email")
 	if to == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.missingFields", "name", "email"))
+		return echo.NewHTTPError(http.StatusBadRequest, h.app.i18n.Ts("globals.messages.missingFields", "name", "email"))
 	}
 
 	// Initialize a new SMTP pool.
@@ -300,37 +294,34 @@ func handleTestSMTPSettings(c echo.Context) error {
 	msgr, err := email.New(req)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest,
-			app.i18n.Ts("globals.messages.errorCreating", "name", "SMTP", "error", err.Error()))
+			h.app.i18n.Ts("globals.messages.errorCreating", "name", "SMTP", "error", err.Error()))
 	}
 
 	var b bytes.Buffer
-	if err := app.notifTpls.tpls.ExecuteTemplate(&b, "smtp-test", nil); err != nil {
-		app.log.Printf("error compiling notification template '%s': %v", "smtp-test", err)
+	if err := h.app.notifTpls.tpls.ExecuteTemplate(&b, "smtp-test", nil); err != nil {
+		h.app.log.Printf("error compiling notification template '%s': %v", "smtp-test", err)
 		return err
 	}
 
 	m := models.Message{}
-	m.ContentType = app.notifTpls.contentType
-	m.From = app.constants.FromEmail
+	m.ContentType = h.app.notifTpls.contentType
+	m.From = h.app.constants.FromEmail
 	m.To = []string{to}
-	m.Subject = app.i18n.T("settings.smtp.testConnection")
+	m.Subject = h.app.i18n.T("settings.smtp.testConnection")
 	m.Body = b.Bytes()
 	if err := msgr.Push(m); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	return c.JSON(http.StatusOK, okResp{app.bufLog.Lines()})
+	return c.JSON(http.StatusOK, okResp{h.app.bufLog.Lines()})
 }
 
-func handleGetAboutInfo(c echo.Context) error {
-	var (
-		app = c.Get("app").(*App)
-		mem runtime.MemStats
-	)
+func (h *Handler) handleGetAboutInfo(c echo.Context) error {
+	var mem runtime.MemStats
 
 	runtime.ReadMemStats(&mem)
 
-	out := app.about
+	out := h.app.about
 	out.System.AllocMB = mem.Alloc / 1024 / 1024
 	out.System.OSMB = mem.Sys / 1024 / 1024
 


### PR DESCRIPTION
This pull request refactors several handler functions in the `cmd` package to use a receiver of type `Handler` instead of directly accessing the `App` instance from the context. This change improves code readability and maintainability by encapsulating the application logic within the `Handler` type