### PR TITLE
Fix ambiguity in cs-cz translation

### DIFF
--- a/i18n/cs-cz.json
+++ b/i18n/cs-cz.json
@@ -348,7 +348,7 @@
     "public.privacyWipe": "Vymažte svá data",
     "public.privacyWipeHelp": "Odstraňte všechny své odběry a související data z databáze trvale.",
     "public.sub": "Odebírat",
-    "public.subConfirmed": "Odebrání úspěšně potvrzeno.",
+    "public.subConfirmed": "Přihlášení k odběru bylo potvrzeno.",
     "public.subConfirmedTitle": "Potvrzeno",
     "public.subName": "Jméno (volitelné)",
     "public.subNotFound": "Odběr nebyl nalezen.",


### PR DESCRIPTION
This PR fixes unclear wording, where it might seem like user has unsubscribed when they confirmed the subscription.