### PR TITLE
Fix too greedy TrackLink regex replacement.

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -116,8 +116,10 @@ var regTplFuncs = []regTplFunc{
 	// Convert the shorthand https://google.com@TrackLink to {{ TrackLink ... }}.
 	// This is for WYSIWYG editors that encode and break quotes {{ "" }} when inserted
 	// inside <a href="{{ TrackLink "https://these-quotes-break" }}>.
+	// The regex matches all characters that may occur in an URL
+	// (see "2. Characters" in RFC3986: https://www.ietf.org/rfc/rfc3986.txt)
 	{
-		regExp:  regexp.MustCompile(`(https?://.+?)@TrackLink`),
+		regExp:  regexp.MustCompile(`(https?://[\p{L}_\-\.~!#$&'()*+,/:;=?@\[\]]*)@TrackLink`),
 		replace: `{{ TrackLink "$1" . }}`,
 	},
 


### PR DESCRIPTION
Hi there!

First, thank you for developing and maintaining listmonk - it's an awesome tool and very easy to use!

I implemented listmonk at my company a few weeks ago, and one recurring issue reported by the marketing team is that they sometimes cannot save tracked links.

# Issue Description
After investigating, I found that the issue stems from the TrackLink regex replacement, which incorrectly matches more characters than intended. This results in template compilation errors like:
```
{"message":"Error compiling template: error compiling message: template: content:1: unexpected \"\u003e\" in operand"}
```
A minimal reproducible example is inserting two links in the same line:
```html
<a href="https://google.de">Untracked Link</a><a href="https://google.de@TrackLink">Tracked Link</a>
```

This causes the campaign to fail rendering.
![image](https://github.com/user-attachments/assets/2c97e962-1777-40d4-b530-d8e29cb35aa6)

# Root Cause
The issue occurs because the `@TrackLink` syntax regex matches too many characters, unintentionally breaking the DOM.
![Screenshot_20250317_172446](https://github.com/user-attachments/assets/115fce4e-78e7-4c34-b04f-a561ed395715)
As you can see here, the expression starts with the "https://" of the first link and ends with the second tracked link. 
Different combinations of imgs and links in the same link can of course also trigger this issue. 

# Fix
I updated the regex to only match characters that are valid in a URL per [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), ensuring a clean stop after the URL.

Let me know if you'd like any adjustments. Thanks!