### PR TITLE
Updating documentation to reflect AWS Console changes

### DIFF
--- a/docs/docs/content/bounces.md
+++ b/docs/docs/content/bounces.md
@@ -74,7 +74,7 @@ If using SES as your SMTP provider, automatic bounce processing is the recommend
     - Endpoint: `https://listmonk.yoursite.com/webhooks/service/ses`
     - Enable raw message delivery: `Disabled` (unchecked)
 4. SES will then make a request to your listmonk instance to confirm the subscription. After a page refresh, the subscription should have a status of "Confirmed". If not, your endpoint may be incorrect or not publicly accessible.
-5. In the AWS console, go to [Simple Email Service](https://console.aws.amazon.com/ses/) and click "Verified identities" in the left sidebar.
+5. In the AWS console, go to [Simple Email Service](https://console.aws.amazon.com/ses/) and click "Identities" in the left sidebar.
 6. Click your domain and go to the "Notifications" tab.
 7. Next to "Feedback notifications", click "Edit".
 8. For both "Bounce feedback" and "Complaint feedback", use the following settings:


### PR DESCRIPTION
The AWS Console now has "Identities" instead of "Verified Identities" in the left sidebar. This PR just updates the docs to match.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/78dfd9ca-ee22-4950-bc72-8bbda3be59b2" />
