### PR TITLE
Changed Raw CSV example in the import page to comply with RFC 5322

### DIFF
--- a/frontend/src/views/Import.vue
+++ b/frontend/src/views/Import.vue
@@ -279,8 +279,8 @@ export default Vue.extend({
 
     renderExample() {
       const h = 'email, name, attributes\n'
-        + 'user1 @mail.com, "User One", "{""age"": 42, ""planet"": ""Mars""}"\n'
-        + 'user2 @mail.com, "User Two", "{""age"": 24, ""job"": ""Time Traveller""}"';
+        + 'user1@mail.com, "User One", "{""age"": 42, ""planet"": ""Mars""}"\n'
+        + 'user2@mail.com, "User Two", "{""age"": 24, ""job"": ""Time Traveller""}"';
 
       this.example = h;
     },


### PR DESCRIPTION
The example raw CSV given did not work as an import, and according to the [documentation of the function that raised the error](https://pkg.go.dev/net/mail#ParseAddress), `ParseAdress`, the verification of the validity of mails is done according to [RFC 5322](https://www.rfc-editor.org/rfc/rfc5322.html), which specifies that the local part  of the mail (before the `@`) cannot contain spaces if it is not quoted
In [section 3.4.1](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1):
> The locally
   interpreted string is either a quoted-string or a dot-atom.  If the
   string can be represented as a dot-atom (that is, it contains no
   characters other than atext characters or "." surrounded by atext
   characters), then the dot-atom form SHOULD be used and the quoted-
   string form SHOULD NOT be used.

And the format of `atext` is defined in [section 3.2.3](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3)) as follows :

```
atext           =   ALPHA / DIGIT /    ; Printable US-ASCII
                       "!" / "#" /        ;  characters not including
                       "$" / "%" /        ;  specials.  Used for atoms.
                       "&" / "'" /
                       "*" / "+" /
                       "-" / "/" /
                       "=" / "?" /
                       "^" / "_" /
                       "`" / "{" /
                       "|" / "}" /
                       "~"
```