### PR TITLE
TrackLink regex: Add missing charset for numbers.

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -109,7 +109,7 @@ var regTplFuncs = []regTplFunc{
 	// The regex matches all characters that may occur in an URL
 	// (see "2. Characters" in RFC3986: https://www.ietf.org/rfc/rfc3986.txt)
 	{
-		regExp:  regexp.MustCompile(`(https?://[\p{L}_\-\.~!#$&'()*+,/:;=?@\[\]]*)@TrackLink`),
+		regExp:  regexp.MustCompile(`(https?://[\p{L}\p{N}_\-\.~!#$&'()*+,/:;=?@\[\]]*)@TrackLink`),
 		replace: `{{ TrackLink "$1" . }}`,
 	},
 


### PR DESCRIPTION
Hi @knadh,
I noticed an additional oversight in my last MR #2355. 
`\p{L}` does not include numbers... :man_facepalming: 

Here's the fix, adding `\p{N}`. Sorry bout that!