### PR TITLE
feat: add /api/tx/external endpoint for sending transactional emails to external recipients

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -179,6 +179,7 @@ func initHTTPHandlers(e *echo.Echo, a *App) {
 		g.DELETE("/api/maintenance/subscriptions/unconfirmed", pm(a.GCSubscriptions, "settings:maintain"))
 
 		g.POST("/api/tx", pm(a.SendTxMessage, "tx:send"))
+		g.POST("/api/tx/external", pm(a.SendExternalTxMessage, "tx:send"))
 
 		g.GET("/api/profile", a.GetUserProfile)
 		g.PUT("/api/profile", a.UpdateUserProfile)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -202,3 +202,140 @@ func (a *App) validateTxMessage(m models.TxMessage) (models.TxMessage, error) {
 
 	return m, nil
 }
+
+// SendExternalTxMessage handles the sending of a transactional message to external email addresses.
+func (a *App) SendExternalTxMessage(c echo.Context) error {
+	var m models.TxMessage
+
+	// If it's a multipart form, there may be file attachments.
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "multipart/form-data") {
+		form, err := c.MultipartForm()
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest,
+				a.i18n.Ts("globals.messages.invalidFields", "name", err.Error()))
+		}
+
+		data, ok := form.Value["data"]
+		if !ok || len(data) != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("globals.messages.invalidFields", "name", "data"))
+		}
+
+		// Parse the JSON data.
+		if err := json.Unmarshal([]byte(data[0]), &m); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest,
+				a.i18n.Ts("globals.messages.invalidFields", "name", fmt.Sprintf("data: %s", err.Error())))
+		}
+
+		// Attach files.
+		for _, f := range form.File["file"] {
+			file, err := f.Open()
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError,
+					a.i18n.Ts("globals.messages.invalidFields", "name", fmt.Sprintf("file: %s", err.Error())))
+			}
+			defer file.Close()
+
+			b, err := io.ReadAll(file)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError,
+					a.i18n.Ts("globals.messages.invalidFields", "name", fmt.Sprintf("file: %s", err.Error())))
+			}
+
+			m.Attachments = append(m.Attachments, models.Attachment{
+				Name:    f.Filename,
+				Header:  manager.MakeAttachmentHeader(f.Filename, "base64", f.Header.Get("Content-Type")),
+				Content: b,
+			})
+		}
+
+	} else if err := c.Bind(&m); err != nil {
+		return err
+	}
+
+	// Validate fields.
+	if r, err := a.validateExternalTxMessage(m); err != nil {
+		return err
+	} else {
+		m = r
+	}
+
+	// Get the cached tx template.
+	tpl, err := a.manager.GetTpl(m.TemplateID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.notFound", "name", fmt.Sprintf("template %d", m.TemplateID)))
+	}
+
+	// Create a dummy subscriber for template rendering.
+	dummySub := models.Subscriber{
+		Email: m.SubscriberEmails[0],
+		Name:  m.SubscriberEmails[0],
+	}
+
+	// Render the message.
+	if err := m.Render(dummySub, tpl); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.errorFetching", "name"))
+	}
+
+	// Prepare the final message.
+	msg := models.Message{}
+	msg.To = m.SubscriberEmails
+	msg.From = m.FromEmail
+	msg.Subject = m.Subject
+	msg.ContentType = m.ContentType
+	msg.Messenger = m.Messenger
+	msg.Body = m.Body
+	for _, a := range m.Attachments {
+		msg.Attachments = append(msg.Attachments, models.Attachment{
+			Name:    a.Name,
+			Header:  a.Header,
+			Content: a.Content,
+		})
+	}
+
+	// Optional headers.
+	if len(m.Headers) != 0 {
+		msg.Headers = make(textproto.MIMEHeader, len(m.Headers))
+		for _, set := range m.Headers {
+			for hdr, val := range set {
+				msg.Headers.Add(hdr, val)
+			}
+		}
+	}
+
+	if err := a.manager.PushMessage(msg); err != nil {
+		a.log.Printf("error sending message (%s): %v", msg.Subject, err)
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{true})
+}
+
+// validateExternalTxMessage validates the external tx message fields.
+func (a *App) validateExternalTxMessage(m models.TxMessage) (models.TxMessage, error) {
+	if len(m.SubscriberEmails) == 0 {
+		return m, echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidFields", "name", "subscriber_emails is required"))
+	}
+
+	for n, email := range m.SubscriberEmails {
+		em, err := a.importer.SanitizeEmail(email)
+		if err != nil {
+			return m, echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		m.SubscriberEmails[n] = em
+	}
+
+	if m.FromEmail == "" {
+		m.FromEmail = a.cfg.FromEmail
+	}
+
+	if m.Messenger == "" {
+		m.Messenger = emailMsgr
+	} else if !a.manager.HasMessenger(m.Messenger) {
+		return m, echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("campaigns.fieldInvalidMessenger", "name", m.Messenger))
+	}
+
+	return m, nil
+}

--- a/docs/swagger/collections.yaml
+++ b/docs/swagger/collections.yaml
@@ -1912,16 +1912,39 @@ paths:
 
   /tx:
     post:
+      description: handles sending of transactional message to a subscriber
+      operationId: sendTxMessage
       tags:
         - Transactional
-      description: send message to a subscriber
-      operationId: transactWithSubscriber
       requestBody:
         description: email message to a subscriber
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/TransactionalMessage"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: boolean
+
+  /tx/external:
+    post:
+      description: handles sending of transactional message to any email address without requiring the recipient to be a subscriber
+      operationId: sendExternalTxMessage
+      tags:
+        - Transactional
+      requestBody:
+        description: email message to external recipients
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalTransactionalMessage"
       responses:
         "200":
           description: OK
@@ -4079,3 +4102,36 @@ components:
           type: string
         content_type:
           type: string
+
+    ExternalTransactionalMessage:
+      type: object
+      required:
+        - subscriber_emails
+        - template_id
+        - subject
+      properties:
+        subscriber_emails:
+          type: array
+          items:
+            type: string
+          description: List of email addresses to send the message to
+        template_id:
+          type: integer
+          description: ID of the template to use
+        subject:
+          type: string
+          description: Subject of the email
+        data:
+          type: object
+          description: Optional data to be used in the template
+        attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              filename:
+                type: string
+              content:
+                type: string
+                format: binary
+          description: Optional file attachments


### PR DESCRIPTION
…
This pull request introduces a new feature to support sending transactional messages to external email addresses. The changes include adding a new API endpoint, implementing the handler logic, and updating the Swagger documentation to reflect the new functionality.

### New API Endpoint for External Transactional Messages:

* **API Route Addition**: Added a new POST route `/api/tx/external` in `initHTTPHandlers` to handle external transactional messages. This route is protected by the `tx:send` permission middleware. (`cmd/handlers.go`, [cmd/handlers.goR182](diffhunk://#diff-24c3c3f7fdbb5229d8d25688d0991525cbc6fe4f5fa7455e85b8110883444f32R182))
* **Handler Implementation**: Implemented the `SendExternalTxMessage` function in `cmd/tx.go`. The function handles multipart form data for attachments, validates the message fields, renders the email template, and sends the message using the application's message manager. (`cmd/tx.go`, [cmd/tx.goR205-R341](diffhunk://#diff-a1f28c4d5541eeb8f333ed0f3068eaf2ba2b49b57b262079b4ddf55a91e6e94eR205-R341))

### Documentation Updates:

* **Swagger Documentation for `/tx/external`**: Added the `/tx/external` endpoint to the Swagger documentation, including its description, operation ID, request body schema, and response structure. (`docs/swagger/collections.yaml`, [docs/swagger/collections.yamlR1936-R1958](diffhunk://#diff-764ccaca71ec82db7fb5818a312e316bb824a50001890e6ae793d8b714acdc00R1936-R1958))
* **New Schema for ExternalTransactionalMessage**: Defined a new schema `ExternalTransactionalMessage` in the Swagger components section. This schema includes required fields like `subscriber_emails`, `template_id`, and `subject`, along with optional fields for `data` and `attachments`. (`docs/swagger/collections.yaml`, [docs/swagger/collections.yamlR4105-R4137](diffhunk://#diff-764ccaca71ec82db7fb5818a312e316bb824a50001890e6ae793d8b714acdc00R4105-R4137))

### Minor Documentation Fix:

* **Updated Description for `/tx` Endpoint**: Updated the description and operation ID for the existing `/tx` endpoint to better reflect its purpose of sending messages to subscribers. (`docs/swagger/collections.yaml`, [docs/swagger/collections.yamlR1915-L1918](diffhunk://#diff-764ccaca71ec82db7fb5818a312e316bb824a50001890e6ae793d8b714acdc00R1915-L1918))