### PR TITLE
Support for docker/podman secrets loading secrets from secret files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # Install dependencies
-RUN apk --no-cache add ca-certificates tzdata shadow su-exec
+RUN apk --no-cache add ca-certificates tzdata shadow su-exec bash
 
 # Set the working directory
 WORKDIR /listmonk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,9 @@ services:
 
     environment:                                              # The same params as in config.toml are passed as env vars here.
       LISTMONK_app__address: 0.0.0.0:9000
-      LISTMONK_db__user: *db-user
-      LISTMONK_db__password: *db-password
-      LISTMONK_db__database: *db-name
+      LISTMONK_db__user: *db-user                             # LISTMONK_db__user_FILE also available for docker secrets
+      LISTMONK_db__password: *db-password                     # LISTMONK_db__password_FILE also available for docker secrets
+      LISTMONK_db__database: *db-name                         # LISTMONK_db__database_FILE also available for docker secrets
       LISTMONK_db__host: listmonk_db
       LISTMONK_db__port: 5432
       LISTMONK_db__ssl_mode: disable
@@ -35,6 +35,9 @@ services:
       TZ: Etc/UTC
       LISTMONK_ADMIN_USER: ${LISTMONK_ADMIN_USER:-}           # If these (optional) are set during the first `docker compose up`, then the Super Admin user is automatically created.
       LISTMONK_ADMIN_PASSWORD: ${LISTMONK_ADMIN_PASSWORD:-}   # Otherwise, the user can be setup on the web app after the first visit to http://localhost:9000
+
+      # LISTMONK_ADMIN_USER_FILE also available for docker secrets
+      # LISTMONK_ADMIN_PASSWORD_FILE also available for docker secrets
     volumes:
       - ./uploads:/listmonk/uploads:rw                        # Mount an uploads directory on the host to /listmonk/uploads inside the container.
                                                               # To use this, change directory path in Admin -> Settings -> Media to /listmonk/uploads
@@ -49,7 +52,7 @@ services:
     networks:
       - listmonk
     environment:
-      <<: *db-credentials
+      <<: *db-credentials                                     # POSTGRES_PASSWORD_FILE, POSTGRES_USER_FILE, POSTGRES_DB_FILE also available for docker secrets
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U listmonk"]
       interval: 10s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,6 +34,25 @@ create_user() {
 create_group
 create_user
 
+load_env_from_file() {
+  VAR_NAME=$1
+  eval "value=\${$VAR_NAME:-}"
+  if [ -z "$value" ]; then
+    eval "value_FILE=\${${VAR_NAME}_FILE:-}"
+    if [ -n "$value_FILE" ]; then
+      TEMP=$(cat "$value_FILE")
+      eval "export $VAR_NAME=\"$TEMP\""
+      echo "Loaded $VAR_NAME"
+    fi
+  fi
+}
+
+load_env_from_file LISTMONK_db__user
+load_env_from_file LISTMONK_db__password
+load_env_from_file LISTMONK_db__database
+load_env_from_file LISTMONK_ADMIN_USER
+load_env_from_file LISTMONK_ADMIN_PASSWORD
+
 # Try to set the ownership of the app directory to the app user.
 if ! chown -R ${PUID}:${PGID} /listmonk 2>/dev/null; then
   echo "Warning: Failed to change ownership of /listmonk. Readonly volume?"


### PR DESCRIPTION
A common convention for using docker and podman is to provide a secondary environment variable option with a suffix of `_FILE` for secret variables.

For example, the Postgres docker image supports the env var `POSTGRES_USER`, but it also supports `POSTGRES_USER_FILE`. You can then set `POSTGRES_USER_FILE` to the path of a file containing the expected username.

This is how docker and podman secrets work as they expose secrets at container runtime via the path `/run/secrets/[secretname]`

I simply added a step in the entry point script that scans for the environment variables that are secret worthy, if they don't exist already, it checks their `_FILE` variant. If that exists, it'll read it in and store it in the expected variable.

Ideally, I think this would be better done in the main program, but I don't have time to learn Go and all that. In the meantime, this provides nearly the same functionality in the entry point script. If possible, it'd be great to get this merged in until someone else can take on that responsibility. (should be an easy "first contributor" task, I would imagine)