### PR TITLE
 Optimize the Import subscribers, instead of using single query used bulk insert / upsert.

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -580,8 +580,8 @@ func initImporter(q *models.Queries, db *sqlx.DB, core *core.Core, i *i18n.I18n,
 		subimporter.Options{
 			DomainBlocklist:    ko.Strings("privacy.domain_blocklist"),
 			DomainAllowlist:    ko.Strings("privacy.domain_allowlist"),
-			UpsertStmt:         q.UpsertSubscriber.Stmt,
-			BlocklistStmt:      q.UpsertBlocklistSubscriber.Stmt,
+			UpsertStmt:         q.UpsertBulkSubscriber.Stmt,
+			BlocklistStmt:      q.UpsertBulkBlocklistSubscriber.Stmt,
 			UpdateListDateStmt: q.UpdateListsDate.Stmt,
 
 			// Hook for triggering admin notifications and refreshing stats materialized

--- a/models/queries.go
+++ b/models/queries.go
@@ -36,6 +36,8 @@ type Queries struct {
 	DeleteOrphanSubscribers         *sqlx.Stmt `query:"delete-orphan-subscribers"`
 	UnsubscribeByCampaign           *sqlx.Stmt `query:"unsubscribe-by-campaign"`
 	ExportSubscriberData            *sqlx.Stmt `query:"export-subscriber-data"`
+	UpsertBulkSubscriber            *sqlx.Stmt `query:"upsert-bulk-subscriber"`
+	UpsertBulkBlocklistSubscriber   *sqlx.Stmt `query:"upsert-bulk-blocklist-subscriber"`
 
 	// Non-prepared arbitrary subscriber queries.
 	QuerySubscribers                       string     `query:"query-subscribers"`


### PR DESCRIPTION
 Optimize the Import subscribers, instead of using single query used bulk insert / upsert. This will help to import subscribers faster compare to single query.
