### PR TITLE
Add Kloudbean Hosting Link

### DIFF
--- a/docs/site/layouts/index.html
+++ b/docs/site/layouts/index.html
@@ -50,6 +50,8 @@
 
           <br />
           <h3>Hosting providers</h3>
+          <a href="https://www.kloudbean.com/listmonk-self-hosted"><img src="https://storage-basic.kloudbean.com/opensource/deploy_on_kloudbean_listmonk.svg" alt="One-click deploy on Kloudbean" style="max-height: 32px;" /></a>
+          <br />
           <a href="https://railway.app/new/template/listmonk"><img src="https://railway.app/button.svg" alt="One-click deploy on Railway" style="max-height: 32px;" /></a>
           <br />
           <a href="https://www.pikapods.com/pods?run=listmonk"><img src="https://www.pikapods.com/static/run-button.svg" alt="Deploy on PikaPod" /></a>


### PR DESCRIPTION
Add Kloudbean URL for Hosting in `docs/site/layouts/index.html`.