### PR TITLE
Add database abstraction layer foundation

### DIFF
--- a/internal/database/adapter.go
+++ b/internal/database/adapter.go
@@ -1,0 +1,56 @@
+package database
+
+import (
+	"context"
+
+	"github.com/knadh/listmonk/internal/repository"
+)
+
+// Adapter defines the interface that all database adapters must implement
+type Adapter interface {
+	// Connection management
+	Connect(ctx context.Context, config Config) error
+	Close() error
+	Ping(ctx context.Context) error
+	
+	// Transaction management
+	BeginTx(ctx context.Context) (repository.Transaction, error)
+	
+	// Migration management
+	GetCurrentVersion(ctx context.Context) (string, error)
+	Migrate(ctx context.Context, targetVersion string) error
+	
+	// Repository access
+	GetManager() repository.Manager
+	
+	// Database type
+	Type() DatabaseType
+	
+	// Health check
+	IsConnected() bool
+}
+
+// AdapterFactory defines the factory interface for creating database adapters
+type AdapterFactory interface {
+	CreateAdapter(dbType DatabaseType) (Adapter, error)
+	SupportedTypes() []DatabaseType
+}
+
+// MigrationScript represents a database migration script
+type MigrationScript struct {
+	Version     string
+	Description string
+	Up          func(ctx context.Context, adapter Adapter) error
+	Down        func(ctx context.Context, adapter Adapter) error
+}
+
+// MigrationManager manages database migrations
+type MigrationManager interface {
+	GetCurrentVersion(ctx context.Context) (string, error)
+	GetAppliedMigrations(ctx context.Context) ([]string, error)
+	GetPendingMigrations(ctx context.Context) ([]MigrationScript, error)
+	ApplyMigration(ctx context.Context, script MigrationScript) error
+	RollbackMigration(ctx context.Context, script MigrationScript) error
+	MigrateToVersion(ctx context.Context, targetVersion string) error
+	RegisterMigration(script MigrationScript) error
+}

--- a/internal/database/adapter_test.go
+++ b/internal/database/adapter_test.go
@@ -1,0 +1,275 @@
+package database
+
+import (
+	"context"
+	"testing"
+)
+
+// mockMigrationManager implements MigrationManager for testing
+type mockMigrationManager struct{}
+
+func (m *mockMigrationManager) GetCurrentVersion(ctx context.Context) (string, error) {
+	return "1.0.0", nil
+}
+
+func (m *mockMigrationManager) GetAppliedMigrations(ctx context.Context) ([]string, error) {
+	return []string{"1.0.0"}, nil
+}
+
+func (m *mockMigrationManager) GetPendingMigrations(ctx context.Context) ([]MigrationScript, error) {
+	return []MigrationScript{}, nil
+}
+
+func (m *mockMigrationManager) ApplyMigration(ctx context.Context, script MigrationScript) error {
+	return nil
+}
+
+func (m *mockMigrationManager) RollbackMigration(ctx context.Context, script MigrationScript) error {
+	return nil
+}
+
+func (m *mockMigrationManager) MigrateToVersion(ctx context.Context, targetVersion string) error {
+	return nil
+}
+
+func (m *mockMigrationManager) RegisterMigration(script MigrationScript) error {
+	return nil
+}
+
+func TestMigrationScript(t *testing.T) {
+	script := MigrationScript{
+		Version:     "1.0.0",
+		Description: "Initial migration",
+		Up: func(ctx context.Context, adapter Adapter) error {
+			return nil
+		},
+		Down: func(ctx context.Context, adapter Adapter) error {
+			return nil
+		},
+	}
+	
+	if script.Version != "1.0.0" {
+		t.Errorf("Expected version 1.0.0, got %s", script.Version)
+	}
+	
+	if script.Description != "Initial migration" {
+		t.Errorf("Expected description 'Initial migration', got %s", script.Description)
+	}
+	
+	// Test that Up and Down functions are callable
+	ctx := context.Background()
+	adapter := &mockAdapter{dbType: PostgreSQL}
+	
+	err := script.Up(ctx, adapter)
+	if err != nil {
+		t.Errorf("Up migration failed: %v", err)
+	}
+	
+	err = script.Down(ctx, adapter)
+	if err != nil {
+		t.Errorf("Down migration failed: %v", err)
+	}
+}
+
+func TestMigrationManagerInterface(t *testing.T) {
+	var manager MigrationManager = &mockMigrationManager{}
+	
+	ctx := context.Background()
+	
+	// Test GetCurrentVersion
+	version, err := manager.GetCurrentVersion(ctx)
+	if err != nil {
+		t.Errorf("GetCurrentVersion failed: %v", err)
+	}
+	if version != "1.0.0" {
+		t.Errorf("Expected version 1.0.0, got %s", version)
+	}
+	
+	// Test GetAppliedMigrations
+	migrations, err := manager.GetAppliedMigrations(ctx)
+	if err != nil {
+		t.Errorf("GetAppliedMigrations failed: %v", err)
+	}
+	if len(migrations) != 1 || migrations[0] != "1.0.0" {
+		t.Errorf("Expected [1.0.0], got %v", migrations)
+	}
+	
+	// Test GetPendingMigrations
+	pending, err := manager.GetPendingMigrations(ctx)
+	if err != nil {
+		t.Errorf("GetPendingMigrations failed: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("Expected empty pending migrations, got %d", len(pending))
+	}
+	
+	// Test RegisterMigration
+	script := MigrationScript{
+		Version:     "1.1.0",
+		Description: "Test migration",
+	}
+	err = manager.RegisterMigration(script)
+	if err != nil {
+		t.Errorf("RegisterMigration failed: %v", err)
+	}
+	
+	// Test MigrateToVersion
+	err = manager.MigrateToVersion(ctx, "1.1.0")
+	if err != nil {
+		t.Errorf("MigrateToVersion failed: %v", err)
+	}
+}
+
+func TestAdapterInterface(t *testing.T) {
+	adapter := &mockAdapter{dbType: PostgreSQL}
+	
+	ctx := context.Background()
+	config := Config{Type: PostgreSQL}
+	
+	// Test Connect
+	err := adapter.Connect(ctx, config)
+	if err != nil {
+		t.Errorf("Connect failed: %v", err)
+	}
+	
+	// Test Ping
+	err = adapter.Ping(ctx)
+	if err != nil {
+		t.Errorf("Ping failed: %v", err)
+	}
+	
+	// Test Type
+	if adapter.Type() != PostgreSQL {
+		t.Errorf("Expected type %s, got %s", PostgreSQL, adapter.Type())
+	}
+	
+	// Test IsConnected
+	if !adapter.IsConnected() {
+		t.Error("Expected adapter to be connected")
+	}
+	
+	// Test GetCurrentVersion
+	version, err := adapter.GetCurrentVersion(ctx)
+	if err != nil {
+		t.Errorf("GetCurrentVersion failed: %v", err)
+	}
+	if version != "1.0.0" {
+		t.Errorf("Expected version 1.0.0, got %s", version)
+	}
+	
+	// Test BeginTx
+	tx, err := adapter.BeginTx(ctx)
+	if err != nil {
+		t.Errorf("BeginTx failed: %v", err)
+	}
+	if tx != nil {
+		t.Error("Expected nil transaction from mock")
+	}
+	
+	// Test GetManager
+	manager := adapter.GetManager()
+	if manager != nil {
+		t.Error("Expected nil manager from mock")
+	}
+	
+	// Test Close
+	err = adapter.Close()
+	if err != nil {
+		t.Errorf("Close failed: %v", err)
+	}
+}
+
+func TestDatabaseTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		dbType DatabaseType
+	}{
+		{"PostgreSQL", PostgreSQL},
+		{"MongoDB", MongoDB},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.dbType) == "" {
+				t.Error("Database type should not be empty")
+			}
+		})
+	}
+}
+
+func TestAdapterFactoryInterface(t *testing.T) {
+	factory := NewFactory()
+	
+	// Test SupportedTypes initially empty
+	types := factory.SupportedTypes()
+	if len(types) != 0 {
+		t.Errorf("Expected 0 supported types initially, got %d", len(types))
+	}
+	
+	// Test CreateAdapter with unregistered type
+	_, err := factory.CreateAdapter(PostgreSQL)
+	if err == nil {
+		t.Error("Expected error for unregistered adapter type")
+	}
+	
+	// Test that we can work with the interface
+	var factoryInterface AdapterFactory = factory
+	if factoryInterface == nil {
+		t.Error("Factory should implement AdapterFactory interface")
+	}
+}
+
+// Test that interface types compile correctly
+func TestInterfaceCompilation(t *testing.T) {
+	var (
+		_ Adapter           = (*mockAdapter)(nil)
+		_ AdapterFactory    = (*factory)(nil)
+		_ MigrationManager  = (*mockMigrationManager)(nil)
+	)
+}
+
+func TestMigrationScriptValidation(t *testing.T) {
+	// Test that migration scripts can be created with various configurations
+	tests := []struct {
+		name        string
+		script      MigrationScript
+		expectValid bool
+	}{
+		{
+			name: "valid script with both up and down",
+			script: MigrationScript{
+				Version:     "1.0.0",
+				Description: "Test migration",
+				Up:          func(ctx context.Context, adapter Adapter) error { return nil },
+				Down:        func(ctx context.Context, adapter Adapter) error { return nil },
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid script with only up",
+			script: MigrationScript{
+				Version:     "1.0.0",
+				Description: "Test migration",
+				Up:          func(ctx context.Context, adapter Adapter) error { return nil },
+			},
+			expectValid: true,
+		},
+		{
+			name: "empty version",
+			script: MigrationScript{
+				Description: "Test migration",
+				Up:          func(ctx context.Context, adapter Adapter) error { return nil },
+			},
+			expectValid: false,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := tt.script.Version != "" && tt.script.Up != nil
+			if valid != tt.expectValid {
+				t.Errorf("Expected valid=%v, got %v", tt.expectValid, valid)
+			}
+		})
+	}
+}

--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -1,0 +1,245 @@
+package database
+
+import (
+	"fmt"
+	"time"
+)
+
+// DatabaseType represents the type of database
+type DatabaseType string
+
+const (
+	PostgreSQL DatabaseType = "postgresql"
+	MongoDB    DatabaseType = "mongodb"
+)
+
+// Config represents database configuration
+type Config struct {
+	Type DatabaseType `mapstructure:"type" json:"type"`
+	
+	// Common connection settings
+	Host     string `mapstructure:"host" json:"host"`
+	Port     int    `mapstructure:"port" json:"port"`
+	Database string `mapstructure:"database" json:"database"`
+	Username string `mapstructure:"username" json:"username"`
+	Password string `mapstructure:"password" json:"password"`
+	
+	// PostgreSQL specific settings
+	PostgreSQL PostgreSQLConfig `mapstructure:"postgresql" json:"postgresql"`
+	
+	// MongoDB specific settings
+	MongoDB MongoDBConfig `mapstructure:"mongodb" json:"mongodb"`
+	
+	// Connection pool settings
+	MaxOpenConnections    int           `mapstructure:"max_open_connections" json:"max_open_connections"`
+	MaxIdleConnections    int           `mapstructure:"max_idle_connections" json:"max_idle_connections"`
+	ConnectionMaxLifetime time.Duration `mapstructure:"connection_max_lifetime" json:"connection_max_lifetime"`
+	ConnectionTimeout     time.Duration `mapstructure:"connection_timeout" json:"connection_timeout"`
+	
+	// Additional options for database-specific configurations
+	Options map[string]interface{} `mapstructure:"options" json:"options"`
+}
+
+// PostgreSQLConfig contains PostgreSQL-specific configuration
+type PostgreSQLConfig struct {
+	SSLMode           string        `mapstructure:"ssl_mode" json:"ssl_mode"`
+	SSLCert           string        `mapstructure:"ssl_cert" json:"ssl_cert"`
+	SSLKey            string        `mapstructure:"ssl_key" json:"ssl_key"`
+	SSLRootCert       string        `mapstructure:"ssl_root_cert" json:"ssl_root_cert"`
+	ConnectTimeout    time.Duration `mapstructure:"connect_timeout" json:"connect_timeout"`
+	StatementTimeout  time.Duration `mapstructure:"statement_timeout" json:"statement_timeout"`
+	ApplicationName   string        `mapstructure:"application_name" json:"application_name"`
+	SearchPath        string        `mapstructure:"search_path" json:"search_path"`
+	Timezone          string        `mapstructure:"timezone" json:"timezone"`
+}
+
+// MongoDBConfig contains MongoDB-specific configuration
+type MongoDBConfig struct {
+	URI                 string        `mapstructure:"uri" json:"uri"`
+	AuthDatabase        string        `mapstructure:"auth_database" json:"auth_database"`
+	ReplicaSet          string        `mapstructure:"replica_set" json:"replica_set"`
+	ReadPreference      string        `mapstructure:"read_preference" json:"read_preference"`
+	WriteConcern        string        `mapstructure:"write_concern" json:"write_concern"`
+	ReadConcern         string        `mapstructure:"read_concern" json:"read_concern"`
+	ServerSelectionTimeout time.Duration `mapstructure:"server_selection_timeout" json:"server_selection_timeout"`
+	ConnectTimeout      time.Duration `mapstructure:"connect_timeout" json:"connect_timeout"`
+	SocketTimeout       time.Duration `mapstructure:"socket_timeout" json:"socket_timeout"`
+	TLS                 TLSConfig     `mapstructure:"tls" json:"tls"`
+}
+
+// TLSConfig contains TLS configuration for MongoDB
+type TLSConfig struct {
+	Enabled            bool   `mapstructure:"enabled" json:"enabled"`
+	CertificateFile    string `mapstructure:"certificate_file" json:"certificate_file"`
+	PrivateKeyFile     string `mapstructure:"private_key_file" json:"private_key_file"`
+	CAFile             string `mapstructure:"ca_file" json:"ca_file"`
+	InsecureSkipVerify bool   `mapstructure:"insecure_skip_verify" json:"insecure_skip_verify"`
+}
+
+// Validate validates the database configuration
+func (c *Config) Validate() error {
+	if c.Type == "" {
+		return fmt.Errorf("database type is required")
+	}
+	
+	if c.Type != PostgreSQL && c.Type != MongoDB {
+		return fmt.Errorf("unsupported database type: %s", c.Type)
+	}
+	
+	switch c.Type {
+	case PostgreSQL:
+		return c.validatePostgreSQL()
+	case MongoDB:
+		return c.validateMongoDB()
+	}
+	
+	return nil
+}
+
+// validatePostgreSQL validates PostgreSQL-specific configuration
+func (c *Config) validatePostgreSQL() error {
+	if c.Host == "" {
+		return fmt.Errorf("PostgreSQL host is required")
+	}
+	
+	if c.Port <= 0 {
+		c.Port = 5432 // Default PostgreSQL port
+	}
+	
+	if c.Database == "" {
+		return fmt.Errorf("PostgreSQL database name is required")
+	}
+	
+	if c.Username == "" {
+		return fmt.Errorf("PostgreSQL username is required")
+	}
+	
+	// Set defaults for PostgreSQL
+	if c.PostgreSQL.SSLMode == "" {
+		c.PostgreSQL.SSLMode = "disable"
+	}
+	
+	if c.PostgreSQL.ConnectTimeout == 0 {
+		c.PostgreSQL.ConnectTimeout = 30 * time.Second
+	}
+	
+	if c.PostgreSQL.ApplicationName == "" {
+		c.PostgreSQL.ApplicationName = "listmonk"
+	}
+	
+	return nil
+}
+
+// validateMongoDB validates MongoDB-specific configuration
+func (c *Config) validateMongoDB() error {
+	if c.MongoDB.URI == "" {
+		// Build URI from individual components if not provided
+		if c.Host == "" {
+			return fmt.Errorf("MongoDB host or URI is required")
+		}
+		
+		if c.Port <= 0 {
+			c.Port = 27017 // Default MongoDB port
+		}
+		
+		if c.Database == "" {
+			return fmt.Errorf("MongoDB database name is required")
+		}
+		
+		// Build URI
+		if c.Username != "" && c.Password != "" {
+			c.MongoDB.URI = fmt.Sprintf("mongodb://%s:%s@%s:%d/%s", 
+				c.Username, c.Password, c.Host, c.Port, c.Database)
+		} else {
+			c.MongoDB.URI = fmt.Sprintf("mongodb://%s:%d/%s", 
+				c.Host, c.Port, c.Database)
+		}
+	}
+	
+	// Set defaults for MongoDB
+	if c.MongoDB.ReadPreference == "" {
+		c.MongoDB.ReadPreference = "primary"
+	}
+	
+	if c.MongoDB.WriteConcern == "" {
+		c.MongoDB.WriteConcern = "majority"
+	}
+	
+	if c.MongoDB.ServerSelectionTimeout == 0 {
+		c.MongoDB.ServerSelectionTimeout = 30 * time.Second
+	}
+	
+	if c.MongoDB.ConnectTimeout == 0 {
+		c.MongoDB.ConnectTimeout = 30 * time.Second
+	}
+	
+	if c.MongoDB.SocketTimeout == 0 {
+		c.MongoDB.SocketTimeout = 30 * time.Second
+	}
+	
+	return nil
+}
+
+// SetDefaults sets default values for the configuration
+func (c *Config) SetDefaults() {
+	if c.MaxOpenConnections == 0 {
+		c.MaxOpenConnections = 25
+	}
+	
+	if c.MaxIdleConnections == 0 {
+		c.MaxIdleConnections = 25
+	}
+	
+	if c.ConnectionMaxLifetime == 0 {
+		c.ConnectionMaxLifetime = 5 * time.Minute
+	}
+	
+	if c.ConnectionTimeout == 0 {
+		c.ConnectionTimeout = 30 * time.Second
+	}
+}
+
+// GetPostgreSQLDSN builds PostgreSQL connection string
+func (c *Config) GetPostgreSQLDSN() string {
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		c.Host, c.Port, c.Username, c.Password, c.Database, c.PostgreSQL.SSLMode)
+	
+	if c.PostgreSQL.ApplicationName != "" {
+		dsn += fmt.Sprintf(" application_name=%s", c.PostgreSQL.ApplicationName)
+	}
+	
+	if c.PostgreSQL.ConnectTimeout > 0 {
+		dsn += fmt.Sprintf(" connect_timeout=%d", int(c.PostgreSQL.ConnectTimeout.Seconds()))
+	}
+	
+	if c.PostgreSQL.StatementTimeout > 0 {
+		dsn += fmt.Sprintf(" statement_timeout=%d", int(c.PostgreSQL.StatementTimeout.Milliseconds()))
+	}
+	
+	if c.PostgreSQL.SearchPath != "" {
+		dsn += fmt.Sprintf(" search_path=%s", c.PostgreSQL.SearchPath)
+	}
+	
+	if c.PostgreSQL.Timezone != "" {
+		dsn += fmt.Sprintf(" timezone=%s", c.PostgreSQL.Timezone)
+	}
+	
+	if c.PostgreSQL.SSLCert != "" {
+		dsn += fmt.Sprintf(" sslcert=%s", c.PostgreSQL.SSLCert)
+	}
+	
+	if c.PostgreSQL.SSLKey != "" {
+		dsn += fmt.Sprintf(" sslkey=%s", c.PostgreSQL.SSLKey)
+	}
+	
+	if c.PostgreSQL.SSLRootCert != "" {
+		dsn += fmt.Sprintf(" sslrootcert=%s", c.PostgreSQL.SSLRootCert)
+	}
+	
+	return dsn
+}
+
+// GetMongoDBURI returns the MongoDB connection URI
+func (c *Config) GetMongoDBURI() string {
+	return c.MongoDB.URI
+}

--- a/internal/database/config_test.go
+++ b/internal/database/config_test.go
@@ -1,0 +1,250 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigValidatePostgreSQL(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "valid PostgreSQL config",
+			config: Config{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Port:     5432,
+				Database: "testdb",
+				Username: "testuser",
+				Password: "testpass",
+			},
+			expectErr: false,
+		},
+		{
+			name: "missing host",
+			config: Config{
+				Type:     PostgreSQL,
+				Database: "testdb",
+				Username: "testuser",
+			},
+			expectErr: true,
+			errMsg:    "PostgreSQL host is required",
+		},
+		{
+			name: "missing database",
+			config: Config{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Username: "testuser",
+			},
+			expectErr: true,
+			errMsg:    "PostgreSQL database name is required",
+		},
+		{
+			name: "missing username",
+			config: Config{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Database: "testdb",
+			},
+			expectErr: true,
+			errMsg:    "PostgreSQL username is required",
+		},
+		{
+			name: "zero port sets default",
+			config: Config{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Port:     0,
+				Database: "testdb",
+				Username: "testuser",
+			},
+			expectErr: false,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else if err.Error() != tt.errMsg {
+					t.Errorf("Expected error %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				
+				// Check defaults were set
+				if tt.config.Port == 0 && tt.config.Port != 5432 {
+					t.Error("Expected default port 5432 to be set")
+				}
+			}
+		})
+	}
+}
+
+func TestConfigValidateMongoDB(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "valid MongoDB config with URI",
+			config: Config{
+				Type: MongoDB,
+				MongoDB: MongoDBConfig{
+					URI: "mongodb://localhost:27017/testdb",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid MongoDB config without URI",
+			config: Config{
+				Type:     MongoDB,
+				Host:     "localhost",
+				Port:     27017,
+				Database: "testdb",
+				Username: "testuser",
+				Password: "testpass",
+			},
+			expectErr: false,
+		},
+		{
+			name: "missing host and URI",
+			config: Config{
+				Type:     MongoDB,
+				Database: "testdb",
+			},
+			expectErr: true,
+			errMsg:    "MongoDB host or URI is required",
+		},
+		{
+			name: "missing database without URI",
+			config: Config{
+				Type: MongoDB,
+				Host: "localhost",
+			},
+			expectErr: true,
+			errMsg:    "MongoDB database name is required",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else if err.Error() != tt.errMsg {
+					t.Errorf("Expected error %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigSetDefaults(t *testing.T) {
+	config := Config{}
+	config.SetDefaults()
+	
+	if config.MaxOpenConnections != 25 {
+		t.Errorf("Expected MaxOpenConnections 25, got %d", config.MaxOpenConnections)
+	}
+	
+	if config.MaxIdleConnections != 25 {
+		t.Errorf("Expected MaxIdleConnections 25, got %d", config.MaxIdleConnections)
+	}
+	
+	if config.ConnectionMaxLifetime != 5*time.Minute {
+		t.Errorf("Expected ConnectionMaxLifetime 5m, got %v", config.ConnectionMaxLifetime)
+	}
+	
+	if config.ConnectionTimeout != 30*time.Second {
+		t.Errorf("Expected ConnectionTimeout 30s, got %v", config.ConnectionTimeout)
+	}
+}
+
+func TestGetPostgreSQLDSN(t *testing.T) {
+	config := Config{
+		Type:     PostgreSQL,
+		Host:     "localhost",
+		Port:     5432,
+		Database: "testdb",
+		Username: "testuser",
+		Password: "testpass",
+		PostgreSQL: PostgreSQLConfig{
+			SSLMode:         "require",
+			ApplicationName: "listmonk",
+			ConnectTimeout:  30 * time.Second,
+		},
+	}
+	
+	dsn := config.GetPostgreSQLDSN()
+	expected := "host=localhost port=5432 user=testuser password=testpass dbname=testdb sslmode=require application_name=listmonk connect_timeout=30"
+	
+	if dsn != expected {
+		t.Errorf("Expected DSN %q, got %q", expected, dsn)
+	}
+}
+
+func TestGetMongoDBURI(t *testing.T) {
+	config := Config{
+		Type: MongoDB,
+		MongoDB: MongoDBConfig{
+			URI: "mongodb://localhost:27017/testdb",
+		},
+	}
+	
+	uri := config.GetMongoDBURI()
+	expected := "mongodb://localhost:27017/testdb"
+	
+	if uri != expected {
+		t.Errorf("Expected URI %q, got %q", expected, uri)
+	}
+}
+
+func TestValidateUnsupportedType(t *testing.T) {
+	config := Config{
+		Type: DatabaseType("unsupported"),
+	}
+	
+	err := config.Validate()
+	if err == nil {
+		t.Error("Expected error for unsupported database type")
+	}
+	
+	expectedMsg := "unsupported database type: unsupported"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestValidateEmptyType(t *testing.T) {
+	config := Config{}
+	
+	err := config.Validate()
+	if err == nil {
+		t.Error("Expected error for empty database type")
+	}
+	
+	expectedMsg := "database type is required"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error %q, got %q", expectedMsg, err.Error())
+	}
+}

--- a/internal/database/factory.go
+++ b/internal/database/factory.go
@@ -1,0 +1,89 @@
+package database
+
+import (
+	"fmt"
+	"sync"
+)
+
+// factory implements the AdapterFactory interface
+type factory struct {
+	adapters map[DatabaseType]func() Adapter
+	mu       sync.RWMutex
+}
+
+// NewFactory creates a new adapter factory
+func NewFactory() AdapterFactory {
+	return &factory{
+		adapters: make(map[DatabaseType]func() Adapter),
+	}
+}
+
+// RegisterAdapter registers a new adapter type with the factory
+func (f *factory) RegisterAdapter(dbType DatabaseType, creator func() Adapter) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	
+	if _, exists := f.adapters[dbType]; exists {
+		return fmt.Errorf("adapter for database type %s is already registered", dbType)
+	}
+	
+	f.adapters[dbType] = creator
+	return nil
+}
+
+// CreateAdapter creates a new adapter instance for the specified database type
+func (f *factory) CreateAdapter(dbType DatabaseType) (Adapter, error) {
+	f.mu.RLock()
+	creator, exists := f.adapters[dbType]
+	f.mu.RUnlock()
+	
+	if !exists {
+		return nil, fmt.Errorf("no adapter registered for database type: %s", dbType)
+	}
+	
+	return creator(), nil
+}
+
+// SupportedTypes returns a list of supported database types
+func (f *factory) SupportedTypes() []DatabaseType {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	
+	types := make([]DatabaseType, 0, len(f.adapters))
+	for dbType := range f.adapters {
+		types = append(types, dbType)
+	}
+	
+	return types
+}
+
+// Global factory instance
+var globalFactory = NewFactory()
+
+// RegisterAdapter registers an adapter with the global factory
+func RegisterAdapter(dbType DatabaseType, creator func() Adapter) error {
+	if factory, ok := globalFactory.(*factory); ok {
+		return factory.RegisterAdapter(dbType, creator)
+	}
+	return fmt.Errorf("global factory is not of expected type")
+}
+
+// CreateAdapter creates an adapter using the global factory
+func CreateAdapter(dbType DatabaseType) (Adapter, error) {
+	return globalFactory.CreateAdapter(dbType)
+}
+
+// SupportedTypes returns supported types from the global factory
+func SupportedTypes() []DatabaseType {
+	return globalFactory.SupportedTypes()
+}
+
+// GetFactory returns the global factory instance
+func GetFactory() AdapterFactory {
+	return globalFactory
+}
+
+// SetFactory sets a custom factory as the global factory (useful for testing)
+func SetFactory(f AdapterFactory) {
+	globalFactory = f
+}

--- a/internal/database/factory_test.go
+++ b/internal/database/factory_test.go
@@ -1,0 +1,241 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/knadh/listmonk/internal/repository"
+)
+
+// mockAdapter implements the Adapter interface for testing
+type mockAdapter struct {
+	dbType DatabaseType
+}
+
+func (m *mockAdapter) Connect(ctx context.Context, config Config) error {
+	return nil
+}
+
+func (m *mockAdapter) Close() error {
+	return nil
+}
+
+func (m *mockAdapter) Ping(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockAdapter) BeginTx(ctx context.Context) (repository.Transaction, error) {
+	return nil, nil
+}
+
+func (m *mockAdapter) GetCurrentVersion(ctx context.Context) (string, error) {
+	return "1.0.0", nil
+}
+
+func (m *mockAdapter) Migrate(ctx context.Context, targetVersion string) error {
+	return nil
+}
+
+func (m *mockAdapter) GetManager() repository.Manager {
+	return nil
+}
+
+func (m *mockAdapter) Type() DatabaseType {
+	return m.dbType
+}
+
+func (m *mockAdapter) IsConnected() bool {
+	return true
+}
+
+func TestFactoryRegisterAdapter(t *testing.T) {
+	factory := NewFactory().(*factory)
+	
+	// Test successful registration
+	err := factory.RegisterAdapter(PostgreSQL, func() Adapter {
+		return &mockAdapter{dbType: PostgreSQL}
+	})
+	
+	if err != nil {
+		t.Errorf("Unexpected error registering adapter: %v", err)
+	}
+	
+	// Test duplicate registration
+	err = factory.RegisterAdapter(PostgreSQL, func() Adapter {
+		return &mockAdapter{dbType: PostgreSQL}
+	})
+	
+	if err == nil {
+		t.Error("Expected error for duplicate registration")
+	}
+	
+	expectedMsg := "adapter for database type postgresql is already registered"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestFactoryCreateAdapter(t *testing.T) {
+	factory := NewFactory().(*factory)
+	
+	// Register adapter
+	factory.RegisterAdapter(PostgreSQL, func() Adapter {
+		return &mockAdapter{dbType: PostgreSQL}
+	})
+	
+	// Test successful creation
+	adapter, err := factory.CreateAdapter(PostgreSQL)
+	if err != nil {
+		t.Errorf("Unexpected error creating adapter: %v", err)
+	}
+	
+	if adapter == nil {
+		t.Error("Expected adapter, got nil")
+	}
+	
+	if adapter.Type() != PostgreSQL {
+		t.Errorf("Expected adapter type %s, got %s", PostgreSQL, adapter.Type())
+	}
+	
+	// Test creation of unregistered type
+	_, err = factory.CreateAdapter(MongoDB)
+	if err == nil {
+		t.Error("Expected error for unregistered adapter type")
+	}
+	
+	expectedMsg := "no adapter registered for database type: mongodb"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestFactorySupportedTypes(t *testing.T) {
+	factory := NewFactory().(*factory)
+	
+	// Initially no types
+	types := factory.SupportedTypes()
+	if len(types) != 0 {
+		t.Errorf("Expected 0 supported types, got %d", len(types))
+	}
+	
+	// Register adapters
+	factory.RegisterAdapter(PostgreSQL, func() Adapter {
+		return &mockAdapter{dbType: PostgreSQL}
+	})
+	
+	factory.RegisterAdapter(MongoDB, func() Adapter {
+		return &mockAdapter{dbType: MongoDB}
+	})
+	
+	types = factory.SupportedTypes()
+	if len(types) != 2 {
+		t.Errorf("Expected 2 supported types, got %d", len(types))
+	}
+	
+	// Check that both types are present
+	found := make(map[DatabaseType]bool)
+	for _, dbType := range types {
+		found[dbType] = true
+	}
+	
+	if !found[PostgreSQL] {
+		t.Error("PostgreSQL not found in supported types")
+	}
+	
+	if !found[MongoDB] {
+		t.Error("MongoDB not found in supported types")
+	}
+}
+
+func TestGlobalFactory(t *testing.T) {
+	// Save original factory
+	originalFactory := globalFactory
+	defer func() {
+		globalFactory = originalFactory
+	}()
+	
+	// Set a new factory
+	newFactory := NewFactory()
+	SetFactory(newFactory)
+	
+	if GetFactory() != newFactory {
+		t.Error("GetFactory() should return the factory set by SetFactory()")
+	}
+	
+	// Test global functions
+	err := RegisterAdapter(PostgreSQL, func() Adapter {
+		return &mockAdapter{dbType: PostgreSQL}
+	})
+	
+	if err != nil {
+		t.Errorf("Unexpected error registering adapter: %v", err)
+	}
+	
+	types := SupportedTypes()
+	if len(types) != 1 || types[0] != PostgreSQL {
+		t.Errorf("Expected 1 supported type (PostgreSQL), got %v", types)
+	}
+	
+	adapter, err := CreateAdapter(PostgreSQL)
+	if err != nil {
+		t.Errorf("Unexpected error creating adapter: %v", err)
+	}
+	
+	if adapter.Type() != PostgreSQL {
+		t.Errorf("Expected adapter type %s, got %s", PostgreSQL, adapter.Type())
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	factory := NewFactory().(*factory)
+	
+	// Test concurrent registration
+	done := make(chan bool, 2)
+	
+	go func() {
+		factory.RegisterAdapter(PostgreSQL, func() Adapter {
+			return &mockAdapter{dbType: PostgreSQL}
+		})
+		done <- true
+	}()
+	
+	go func() {
+		factory.RegisterAdapter(MongoDB, func() Adapter {
+			return &mockAdapter{dbType: MongoDB}
+		})
+		done <- true
+	}()
+	
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+	
+	// Verify both adapters were registered
+	types := factory.SupportedTypes()
+	if len(types) != 2 {
+		t.Errorf("Expected 2 supported types, got %d", len(types))
+	}
+	
+	// Test concurrent creation
+	done = make(chan bool, 2)
+	
+	go func() {
+		_, err := factory.CreateAdapter(PostgreSQL)
+		if err != nil {
+			t.Errorf("Unexpected error creating PostgreSQL adapter: %v", err)
+		}
+		done <- true
+	}()
+	
+	go func() {
+		_, err := factory.CreateAdapter(MongoDB)
+		if err != nil {
+			t.Errorf("Unexpected error creating MongoDB adapter: %v", err)
+		}
+		done <- true
+	}()
+	
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+}

--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNotFound indicates that the requested resource was not found
+	ErrNotFound = errors.New("resource not found")
+
+	// ErrDuplicate indicates that a resource with the same identifier already exists
+	ErrDuplicate = errors.New("resource already exists")
+
+	// ErrInvalidInput indicates that the provided input is invalid
+	ErrInvalidInput = errors.New("invalid input")
+
+	// ErrConcurrentAccess indicates that the resource was modified by another process
+	ErrConcurrentAccess = errors.New("concurrent access conflict")
+
+	// ErrConnectionFailed indicates that the database connection failed
+	ErrConnectionFailed = errors.New("database connection failed")
+
+	// ErrTransactionFailed indicates that a database transaction failed
+	ErrTransactionFailed = errors.New("transaction failed")
+
+	// ErrUnsupportedOperation indicates that the operation is not supported by the database adapter
+	ErrUnsupportedOperation = errors.New("operation not supported")
+)
+
+// DatabaseError wraps database-specific errors with additional context
+type DatabaseError struct {
+	Operation string
+	Entity    string
+	Err       error
+}
+
+func (e *DatabaseError) Error() string {
+	return fmt.Sprintf("database error during %s on %s: %v", e.Operation, e.Entity, e.Err)
+}
+
+func (e *DatabaseError) Unwrap() error {
+	return e.Err
+}
+
+// IsNotFound checks if the error is a "not found" error
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound)
+}
+
+// IsDuplicate checks if the error is a "duplicate" error
+func IsDuplicate(err error) bool {
+	return errors.Is(err, ErrDuplicate)
+}
+
+// IsInvalidInput checks if the error is an "invalid input" error
+func IsInvalidInput(err error) bool {
+	return errors.Is(err, ErrInvalidInput)
+}
+
+// IsConcurrentAccess checks if the error is a "concurrent access" error
+func IsConcurrentAccess(err error) bool {
+	return errors.Is(err, ErrConcurrentAccess)
+}
+
+// NewDatabaseError creates a new DatabaseError
+func NewDatabaseError(operation, entity string, err error) *DatabaseError {
+	return &DatabaseError{
+		Operation: operation,
+		Entity:    entity,
+		Err:       err,
+	}
+}

--- a/internal/repository/errors_test.go
+++ b/internal/repository/errors_test.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDatabaseError(t *testing.T) {
+	originalErr := errors.New("connection failed")
+	dbErr := NewDatabaseError("create", "subscriber", originalErr)
+	
+	expected := "database error during create on subscriber: connection failed"
+	if dbErr.Error() != expected {
+		t.Errorf("Expected error message %q, got %q", expected, dbErr.Error())
+	}
+	
+	if !errors.Is(dbErr, originalErr) {
+		t.Error("DatabaseError should unwrap to original error")
+	}
+}
+
+func TestErrorCheckers(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		checker  func(error) bool
+		expected bool
+	}{
+		{"NotFound check with ErrNotFound", ErrNotFound, IsNotFound, true},
+		{"NotFound check with other error", ErrDuplicate, IsNotFound, false},
+		{"Duplicate check with ErrDuplicate", ErrDuplicate, IsDuplicate, true},
+		{"Duplicate check with other error", ErrNotFound, IsDuplicate, false},
+		{"InvalidInput check with ErrInvalidInput", ErrInvalidInput, IsInvalidInput, true},
+		{"InvalidInput check with other error", ErrNotFound, IsInvalidInput, false},
+		{"ConcurrentAccess check with ErrConcurrentAccess", ErrConcurrentAccess, IsConcurrentAccess, true},
+		{"ConcurrentAccess check with other error", ErrNotFound, IsConcurrentAccess, false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.checker(tt.err)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestWrappedErrors(t *testing.T) {
+	originalErr := ErrNotFound
+	dbErr := NewDatabaseError("get", "subscriber", originalErr)
+	
+	if !IsNotFound(dbErr) {
+		t.Error("IsNotFound should work with wrapped errors")
+	}
+}
+
+func TestDatabaseErrorFields(t *testing.T) {
+	originalErr := errors.New("test error")
+	dbErr := NewDatabaseError("update", "campaign", originalErr)
+	
+	if dbErr.Operation != "update" {
+		t.Errorf("Expected operation 'update', got %q", dbErr.Operation)
+	}
+	
+	if dbErr.Entity != "campaign" {
+		t.Errorf("Expected entity 'campaign', got %q", dbErr.Entity)
+	}
+	
+	if dbErr.Err != originalErr {
+		t.Error("Expected wrapped error to match original")
+	}
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -1,0 +1,207 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/knadh/listmonk/internal/auth"
+	"github.com/knadh/listmonk/internal/media"
+	querymodels "github.com/knadh/listmonk/internal/repository/models"
+	"github.com/knadh/listmonk/models"
+)
+
+// SubscriberRepository defines operations for subscriber management
+type SubscriberRepository interface {
+	Create(ctx context.Context, sub *models.Subscriber) error
+	GetByID(ctx context.Context, id int64) (*models.Subscriber, error)
+	GetByUUID(ctx context.Context, uuid string) (*models.Subscriber, error)
+	GetByEmail(ctx context.Context, email string) (*models.Subscriber, error)
+	Update(ctx context.Context, sub *models.Subscriber) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context, query querymodels.SubscriberQuery) ([]*models.Subscriber, int64, error)
+	
+	// Subscription management
+	Subscribe(ctx context.Context, subscriberID int64, listID int64, status string) error
+	Unsubscribe(ctx context.Context, subscriberID int64, listID int64) error
+	GetSubscriptions(ctx context.Context, subscriberID int64) ([]*models.Subscription, error)
+	
+	// Bulk operations
+	BulkUpdate(ctx context.Context, ids []int64, fields map[string]interface{}) error
+	BulkDelete(ctx context.Context, ids []int64) error
+	
+	// Export
+	ExportData(ctx context.Context, subscriberID int64) (*models.SubscriberExportProfile, error)
+	
+	// Statistics
+	GetStats(ctx context.Context) (map[string]int64, error)
+}
+
+// CampaignRepository defines operations for campaign management
+type CampaignRepository interface {
+	Create(ctx context.Context, camp *models.Campaign) error
+	GetByID(ctx context.Context, id int64) (*models.Campaign, error)
+	GetByUUID(ctx context.Context, uuid string) (*models.Campaign, error)
+	Update(ctx context.Context, camp *models.Campaign) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context, query querymodels.CampaignQuery) ([]*models.Campaign, int64, error)
+	
+	// Status management
+	UpdateStatus(ctx context.Context, id int64, status string) error
+	
+	// Statistics
+	GetStats(ctx context.Context, id int64) (*models.CampaignStats, error)
+	GetViewCounts(ctx context.Context, id int64) (map[string]int64, error)
+	GetClickCounts(ctx context.Context, id int64) (map[string]int64, error)
+	
+	// Views and clicks
+	RegisterView(ctx context.Context, campaignUUID, subscriberUUID string) error
+	RegisterClick(ctx context.Context, campaignUUID, subscriberUUID, linkUUID string) error
+	
+	// Analytics
+	GetAnalytics(ctx context.Context, id int64) (map[string]interface{}, error)
+}
+
+// ListRepository defines operations for list management
+type ListRepository interface {
+	Create(ctx context.Context, list *models.List) error
+	GetByID(ctx context.Context, id int64) (*models.List, error)
+	GetByUUID(ctx context.Context, uuid string) (*models.List, error)
+	Update(ctx context.Context, list *models.List) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context, query querymodels.ListQuery) ([]*models.List, int64, error)
+	
+	// Subscriber management
+	GetSubscribers(ctx context.Context, listID int64, query querymodels.SubscriberQuery) ([]*models.Subscriber, int64, error)
+	AddSubscriber(ctx context.Context, listID, subscriberID int64, status string) error
+	RemoveSubscriber(ctx context.Context, listID, subscriberID int64) error
+	
+	// Statistics
+	GetStats(ctx context.Context, id int64) (map[string]int64, error)
+}
+
+// TemplateRepository defines operations for template management
+type TemplateRepository interface {
+	Create(ctx context.Context, tpl *models.Template) error
+	GetByID(ctx context.Context, id int64) (*models.Template, error)
+	GetDefault(ctx context.Context, templateType string) (*models.Template, error)
+	Update(ctx context.Context, tpl *models.Template) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context, query querymodels.TemplateQuery) ([]*models.Template, int64, error)
+	
+	// Template compilation and rendering
+	Render(ctx context.Context, templateID int64, data interface{}) (string, error)
+}
+
+// UserRepository defines operations for user management
+type UserRepository interface {
+	Create(ctx context.Context, user *auth.User) error
+	GetByID(ctx context.Context, id int64) (*auth.User, error)
+	GetByEmail(ctx context.Context, email string) (*auth.User, error)
+	Update(ctx context.Context, user *auth.User) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context, query querymodels.UserQuery) ([]*auth.User, int64, error)
+	
+	// Authentication
+	Authenticate(ctx context.Context, email, password string) (*auth.User, error)
+	UpdatePassword(ctx context.Context, id int64, password string) error
+}
+
+// RoleRepository defines operations for role and permission management
+type RoleRepository interface {
+	Create(ctx context.Context, role *auth.Role) error
+	GetByID(ctx context.Context, id int64) (*auth.Role, error)
+	Update(ctx context.Context, role *auth.Role) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context) ([]*auth.Role, error)
+	
+	// Permission management
+	GetPermissions(ctx context.Context, roleID int64) ([]string, error)
+	UpdatePermissions(ctx context.Context, roleID int64, permissions []string) error
+}
+
+// MediaRepository defines operations for media file management
+type MediaRepository interface {
+	Create(ctx context.Context, m *media.Media) error
+	GetByID(ctx context.Context, id int64) (*media.Media, error)
+	GetByUUID(ctx context.Context, uuid string) (*media.Media, error)
+	Update(ctx context.Context, m *media.Media) error
+	Delete(ctx context.Context, id int64) error
+	List(ctx context.Context, query querymodels.MediaQuery) ([]*media.Media, int64, error)
+}
+
+// BounceRepository defines operations for bounce management
+type BounceRepository interface {
+	Create(ctx context.Context, bounce *models.Bounce) error
+	GetByID(ctx context.Context, id int64) (*models.Bounce, error)
+	List(ctx context.Context, query querymodels.BounceQuery) ([]*models.Bounce, int64, error)
+	Delete(ctx context.Context, id int64) error
+	
+	// Bulk operations
+	BulkDelete(ctx context.Context, ids []int64) error
+	DeleteBySubscriber(ctx context.Context, subscriberID int64) error
+	
+	// Statistics
+	GetStats(ctx context.Context) (map[string]int64, error)
+}
+
+// SettingsRepository defines operations for settings management
+type SettingsRepository interface {
+	Get(ctx context.Context, key string) (interface{}, error)
+	Set(ctx context.Context, key string, value interface{}) error
+	GetAll(ctx context.Context) (map[string]interface{}, error)
+	SetMultiple(ctx context.Context, settings map[string]interface{}) error
+	Delete(ctx context.Context, key string) error
+}
+
+// AnalyticsRepository defines operations for analytics and dashboard
+type AnalyticsRepository interface {
+	GetDashboardStats(ctx context.Context) (map[string]interface{}, error)
+	GetCampaignAnalytics(ctx context.Context, campaignID int64, from, to time.Time) (map[string]interface{}, error)
+	GetSubscriberGrowth(ctx context.Context, from, to time.Time) ([]map[string]interface{}, error)
+	GetListStats(ctx context.Context) ([]map[string]interface{}, error)
+	
+	// Materialized view refresh (PostgreSQL specific, may be no-op for other DBs)
+	RefreshMaterializedViews(ctx context.Context) error
+}
+
+// Transaction represents a database transaction
+type Transaction interface {
+	Commit() error
+	Rollback() error
+	
+	// Repository access within transaction
+	SubscriberRepo() SubscriberRepository
+	CampaignRepo() CampaignRepository
+	ListRepo() ListRepository
+	TemplateRepo() TemplateRepository
+	UserRepo() UserRepository
+	RoleRepo() RoleRepository
+	MediaRepo() MediaRepository
+	BounceRepo() BounceRepository
+	SettingsRepo() SettingsRepository
+	AnalyticsRepo() AnalyticsRepository
+}
+
+// Manager provides access to all repositories and transaction management
+type Manager interface {
+	// Repository access
+	SubscriberRepo() SubscriberRepository
+	CampaignRepo() CampaignRepository
+	ListRepo() ListRepository
+	TemplateRepo() TemplateRepository
+	UserRepo() UserRepository
+	RoleRepo() RoleRepository
+	MediaRepo() MediaRepository
+	BounceRepo() BounceRepository
+	SettingsRepo() SettingsRepository
+	AnalyticsRepo() AnalyticsRepository
+	
+	// Transaction management
+	BeginTx(ctx context.Context) (Transaction, error)
+	
+	// Health check
+	Ping(ctx context.Context) error
+	
+	// Connection management
+	Close() error
+}

--- a/internal/repository/interfaces_test.go
+++ b/internal/repository/interfaces_test.go
@@ -1,0 +1,377 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/knadh/listmonk/internal/auth"
+	"github.com/knadh/listmonk/internal/media"
+	querymodels "github.com/knadh/listmonk/internal/repository/models"
+	"github.com/knadh/listmonk/models"
+	null "gopkg.in/volatiletech/null.v6"
+)
+
+// mockSubscriberRepository implements SubscriberRepository for testing
+type mockSubscriberRepository struct{}
+
+func (m *mockSubscriberRepository) Create(ctx context.Context, sub *models.Subscriber) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) GetByID(ctx context.Context, id int64) (*models.Subscriber, error) {
+	return &models.Subscriber{Base: models.Base{ID: int(id)}}, nil
+}
+
+func (m *mockSubscriberRepository) GetByUUID(ctx context.Context, uuid string) (*models.Subscriber, error) {
+	return &models.Subscriber{UUID: uuid}, nil
+}
+
+func (m *mockSubscriberRepository) GetByEmail(ctx context.Context, email string) (*models.Subscriber, error) {
+	return &models.Subscriber{Email: email}, nil
+}
+
+func (m *mockSubscriberRepository) Update(ctx context.Context, sub *models.Subscriber) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) Delete(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) List(ctx context.Context, query querymodels.SubscriberQuery) ([]*models.Subscriber, int64, error) {
+	return []*models.Subscriber{}, 0, nil
+}
+
+func (m *mockSubscriberRepository) Subscribe(ctx context.Context, subscriberID int64, listID int64, status string) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) Unsubscribe(ctx context.Context, subscriberID int64, listID int64) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) GetSubscriptions(ctx context.Context, subscriberID int64) ([]*models.Subscription, error) {
+	return []*models.Subscription{}, nil
+}
+
+func (m *mockSubscriberRepository) BulkUpdate(ctx context.Context, ids []int64, fields map[string]interface{}) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) BulkDelete(ctx context.Context, ids []int64) error {
+	return nil
+}
+
+func (m *mockSubscriberRepository) ExportData(ctx context.Context, subscriberID int64) (*models.SubscriberExportProfile, error) {
+	return &models.SubscriberExportProfile{}, nil
+}
+
+func (m *mockSubscriberRepository) GetStats(ctx context.Context) (map[string]int64, error) {
+	return map[string]int64{}, nil
+}
+
+// mockTransaction implements Transaction for testing
+type mockTransaction struct{}
+
+func (m *mockTransaction) Commit() error {
+	return nil
+}
+
+func (m *mockTransaction) Rollback() error {
+	return nil
+}
+
+func (m *mockTransaction) SubscriberRepo() SubscriberRepository {
+	return &mockSubscriberRepository{}
+}
+
+func (m *mockTransaction) CampaignRepo() CampaignRepository {
+	return nil
+}
+
+func (m *mockTransaction) ListRepo() ListRepository {
+	return nil
+}
+
+func (m *mockTransaction) TemplateRepo() TemplateRepository {
+	return nil
+}
+
+func (m *mockTransaction) UserRepo() UserRepository {
+	return nil
+}
+
+func (m *mockTransaction) RoleRepo() RoleRepository {
+	return nil
+}
+
+func (m *mockTransaction) MediaRepo() MediaRepository {
+	return nil
+}
+
+func (m *mockTransaction) BounceRepo() BounceRepository {
+	return nil
+}
+
+func (m *mockTransaction) SettingsRepo() SettingsRepository {
+	return nil
+}
+
+func (m *mockTransaction) AnalyticsRepo() AnalyticsRepository {
+	return nil
+}
+
+// mockManager implements Manager for testing
+type mockManager struct{}
+
+func (m *mockManager) SubscriberRepo() SubscriberRepository {
+	return &mockSubscriberRepository{}
+}
+
+func (m *mockManager) CampaignRepo() CampaignRepository {
+	return nil
+}
+
+func (m *mockManager) ListRepo() ListRepository {
+	return nil
+}
+
+func (m *mockManager) TemplateRepo() TemplateRepository {
+	return nil
+}
+
+func (m *mockManager) UserRepo() UserRepository {
+	return nil
+}
+
+func (m *mockManager) RoleRepo() RoleRepository {
+	return nil
+}
+
+func (m *mockManager) MediaRepo() MediaRepository {
+	return nil
+}
+
+func (m *mockManager) BounceRepo() BounceRepository {
+	return nil
+}
+
+func (m *mockManager) SettingsRepo() SettingsRepository {
+	return nil
+}
+
+func (m *mockManager) AnalyticsRepo() AnalyticsRepository {
+	return nil
+}
+
+func (m *mockManager) BeginTx(ctx context.Context) (Transaction, error) {
+	return &mockTransaction{}, nil
+}
+
+func (m *mockManager) Ping(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockManager) Close() error {
+	return nil
+}
+
+func TestSubscriberRepositoryInterface(t *testing.T) {
+	var repo SubscriberRepository = &mockSubscriberRepository{}
+	
+	ctx := context.Background()
+	
+	// Test Create
+	sub := &models.Subscriber{Email: "test@example.com"}
+	err := repo.Create(ctx, sub)
+	if err != nil {
+		t.Errorf("Create failed: %v", err)
+	}
+	
+	// Test GetByID
+	result, err := repo.GetByID(ctx, 1)
+	if err != nil {
+		t.Errorf("GetByID failed: %v", err)
+	}
+	if result.ID != 1 {
+		t.Errorf("Expected ID 1, got %d", result.ID)
+	}
+	
+	// Test GetByEmail
+	result, err = repo.GetByEmail(ctx, "test@example.com")
+	if err != nil {
+		t.Errorf("GetByEmail failed: %v", err)
+	}
+	if result.Email != "test@example.com" {
+		t.Errorf("Expected email test@example.com, got %s", result.Email)
+	}
+	
+	// Test List
+	query := querymodels.SubscriberQuery{}
+	subscribers, total, err := repo.List(ctx, query)
+	if err != nil {
+		t.Errorf("List failed: %v", err)
+	}
+	if subscribers == nil {
+		t.Error("Expected non-nil subscribers slice")
+	}
+	if total != 0 {
+		t.Errorf("Expected total 0, got %d", total)
+	}
+}
+
+func TestTransactionInterface(t *testing.T) {
+	var tx Transaction = &mockTransaction{}
+	
+	// Test Commit
+	err := tx.Commit()
+	if err != nil {
+		t.Errorf("Commit failed: %v", err)
+	}
+	
+	// Test Rollback
+	err = tx.Rollback()
+	if err != nil {
+		t.Errorf("Rollback failed: %v", err)
+	}
+	
+	// Test repository access
+	repo := tx.SubscriberRepo()
+	if repo == nil {
+		t.Error("Expected non-nil SubscriberRepository")
+	}
+}
+
+func TestManagerInterface(t *testing.T) {
+	var manager Manager = &mockManager{}
+	
+	ctx := context.Background()
+	
+	// Test repository access
+	repo := manager.SubscriberRepo()
+	if repo == nil {
+		t.Error("Expected non-nil SubscriberRepository")
+	}
+	
+	// Test transaction creation
+	tx, err := manager.BeginTx(ctx)
+	if err != nil {
+		t.Errorf("BeginTx failed: %v", err)
+	}
+	if tx == nil {
+		t.Error("Expected non-nil Transaction")
+	}
+	
+	// Test ping
+	err = manager.Ping(ctx)
+	if err != nil {
+		t.Errorf("Ping failed: %v", err)
+	}
+	
+	// Test close
+	err = manager.Close()
+	if err != nil {
+		t.Errorf("Close failed: %v", err)
+	}
+}
+
+func TestRepositoryInterfaces(t *testing.T) {
+	// Test that interface types compile correctly by creating variables
+	var (
+		_ SubscriberRepository = (*mockSubscriberRepository)(nil)
+		_ Transaction         = (*mockTransaction)(nil)
+		_ Manager            = (*mockManager)(nil)
+	)
+}
+
+// Test that the interfaces work with the expected model types
+func TestModelTypes(t *testing.T) {
+	ctx := context.Background()
+	
+	// Test with actual model instances
+	subscriber := &models.Subscriber{
+		Base:  models.Base{ID: 1},
+		Email: "test@example.com",
+		Name:  "Test User",
+	}
+	
+	user := &auth.User{
+		Base:     auth.Base{ID: 1},
+		Username: "testuser",
+		Email:    null.NewString("test@example.com", true),
+	}
+	
+	role := &auth.Role{
+		Base: auth.Base{ID: 1},
+		Name: null.NewString("Test Role", true),
+	}
+	
+	mediaItem := &media.Media{
+		ID:       1,
+		Filename: "test.jpg",
+		URL:      "http://example.com/test.jpg",
+	}
+	
+	bounce := &models.Bounce{
+		ID:    1,
+		Email: "bounce@example.com",
+		Type:  "hard",
+	}
+	
+	// Test that we can pass these to repository methods
+	var (
+		subRepo   SubscriberRepository = &mockSubscriberRepository{}
+		userRepo  UserRepository       = &mockUserRepository{}
+		roleRepo  RoleRepository       = &mockRoleRepository{}
+		mediaRepo MediaRepository      = &mockMediaRepository{}
+		bounceRepo BounceRepository    = &mockBounceRepository{}
+	)
+	
+	// These should compile without errors
+	_ = subRepo.Create(ctx, subscriber)
+	_ = userRepo.Create(ctx, user)
+	_ = roleRepo.Create(ctx, role)
+	_ = mediaRepo.Create(ctx, mediaItem)
+	_ = bounceRepo.Create(ctx, bounce)
+}
+
+// Additional mock repositories for testing
+type mockUserRepository struct{}
+
+func (m *mockUserRepository) Create(ctx context.Context, user *auth.User) error { return nil }
+func (m *mockUserRepository) GetByID(ctx context.Context, id int64) (*auth.User, error) { return nil, nil }
+func (m *mockUserRepository) GetByEmail(ctx context.Context, email string) (*auth.User, error) { return nil, nil }
+func (m *mockUserRepository) Update(ctx context.Context, user *auth.User) error { return nil }
+func (m *mockUserRepository) Delete(ctx context.Context, id int64) error { return nil }
+func (m *mockUserRepository) List(ctx context.Context, query querymodels.UserQuery) ([]*auth.User, int64, error) { return nil, 0, nil }
+func (m *mockUserRepository) Authenticate(ctx context.Context, email, password string) (*auth.User, error) { return nil, nil }
+func (m *mockUserRepository) UpdatePassword(ctx context.Context, id int64, password string) error { return nil }
+
+type mockRoleRepository struct{}
+
+func (m *mockRoleRepository) Create(ctx context.Context, role *auth.Role) error { return nil }
+func (m *mockRoleRepository) GetByID(ctx context.Context, id int64) (*auth.Role, error) { return nil, nil }
+func (m *mockRoleRepository) Update(ctx context.Context, role *auth.Role) error { return nil }
+func (m *mockRoleRepository) Delete(ctx context.Context, id int64) error { return nil }
+func (m *mockRoleRepository) List(ctx context.Context) ([]*auth.Role, error) { return nil, nil }
+func (m *mockRoleRepository) GetPermissions(ctx context.Context, roleID int64) ([]string, error) { return nil, nil }
+func (m *mockRoleRepository) UpdatePermissions(ctx context.Context, roleID int64, permissions []string) error { return nil }
+
+type mockMediaRepository struct{}
+
+func (m *mockMediaRepository) Create(ctx context.Context, media *media.Media) error { return nil }
+func (m *mockMediaRepository) GetByID(ctx context.Context, id int64) (*media.Media, error) { return nil, nil }
+func (m *mockMediaRepository) GetByUUID(ctx context.Context, uuid string) (*media.Media, error) { return nil, nil }
+func (m *mockMediaRepository) Update(ctx context.Context, media *media.Media) error { return nil }
+func (m *mockMediaRepository) Delete(ctx context.Context, id int64) error { return nil }
+func (m *mockMediaRepository) List(ctx context.Context, query querymodels.MediaQuery) ([]*media.Media, int64, error) { return nil, 0, nil }
+
+type mockBounceRepository struct{}
+
+func (m *mockBounceRepository) Create(ctx context.Context, bounce *models.Bounce) error { return nil }
+func (m *mockBounceRepository) GetByID(ctx context.Context, id int64) (*models.Bounce, error) { return nil, nil }
+func (m *mockBounceRepository) List(ctx context.Context, query querymodels.BounceQuery) ([]*models.Bounce, int64, error) { return nil, 0, nil }
+func (m *mockBounceRepository) Delete(ctx context.Context, id int64) error { return nil }
+func (m *mockBounceRepository) BulkDelete(ctx context.Context, ids []int64) error { return nil }
+func (m *mockBounceRepository) DeleteBySubscriber(ctx context.Context, subscriberID int64) error { return nil }
+func (m *mockBounceRepository) GetStats(ctx context.Context) (map[string]int64, error) { return nil, nil }

--- a/internal/repository/models/query.go
+++ b/internal/repository/models/query.go
@@ -1,0 +1,182 @@
+package models
+
+import (
+	"time"
+)
+
+// SortOrder represents the sort order for queries
+type SortOrder string
+
+const (
+	SortAsc  SortOrder = "ASC"
+	SortDesc SortOrder = "DESC"
+)
+
+// PaginationQuery represents common pagination parameters
+type PaginationQuery struct {
+	Page    int `json:"page"`
+	PerPage int `json:"per_page"`
+	Offset  int `json:"offset"`
+}
+
+// SortQuery represents sorting parameters
+type SortQuery struct {
+	Field string    `json:"field"`
+	Order SortOrder `json:"order"`
+}
+
+// BaseQuery represents common query parameters
+type BaseQuery struct {
+	Pagination PaginationQuery `json:"pagination"`
+	Sort       SortQuery       `json:"sort"`
+}
+
+// SubscriberQuery represents parameters for querying subscribers
+type SubscriberQuery struct {
+	BaseQuery
+	Email         string   `json:"email"`
+	Name          string   `json:"name"`
+	Status        []string `json:"status"`
+	ListIDs       []int64  `json:"list_ids"`
+	SubscribedAt  *time.Time `json:"subscribed_at"`
+	Query         string   `json:"query"`         // Raw SQL query for advanced filtering
+	QueryParams   []interface{} `json:"query_params"` // Parameters for the raw query
+}
+
+// CampaignQuery represents parameters for querying campaigns
+type CampaignQuery struct {
+	BaseQuery
+	Name     string   `json:"name"`
+	Status   []string `json:"status"`
+	Type     []string `json:"type"`
+	ListIDs  []int64  `json:"list_ids"`
+	Tags     []string `json:"tags"`
+	Query    string   `json:"query"`
+	QueryParams []interface{} `json:"query_params"`
+}
+
+// ListQuery represents parameters for querying lists
+type ListQuery struct {
+	BaseQuery
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Tags   []string `json:"tags"`
+	Query  string `json:"query"`
+	QueryParams []interface{} `json:"query_params"`
+}
+
+// TemplateQuery represents parameters for querying templates
+type TemplateQuery struct {
+	BaseQuery
+	Name string   `json:"name"`
+	Type []string `json:"type"`
+	Tags []string `json:"tags"`
+}
+
+// UserQuery represents parameters for querying users
+type UserQuery struct {
+	BaseQuery
+	Email  string `json:"email"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	RoleID int64  `json:"role_id"`
+}
+
+// MediaQuery represents parameters for querying media files
+type MediaQuery struct {
+	BaseQuery
+	Filename string `json:"filename"`
+	Provider string `json:"provider"`
+}
+
+// BounceQuery represents parameters for querying bounces
+type BounceQuery struct {
+	BaseQuery
+	Email        string     `json:"email"`
+	CampaignID   int64      `json:"campaign_id"`
+	SubscriberID int64      `json:"subscriber_id"`
+	Type         string     `json:"type"`
+	Source       string     `json:"source"`
+	CreatedAt    *time.Time `json:"created_at"`
+}
+
+// QueryResult represents the result of a paginated query
+type QueryResult struct {
+	Total   int64       `json:"total"`
+	Page    int         `json:"page"`
+	PerPage int         `json:"per_page"`
+	Data    interface{} `json:"data"`
+}
+
+// Validate validates the BaseQuery and sets defaults
+func (q *BaseQuery) Validate() {
+	if q.Pagination.Page <= 0 {
+		q.Pagination.Page = 1
+	}
+	if q.Pagination.PerPage <= 0 || q.Pagination.PerPage > 1000 {
+		q.Pagination.PerPage = 20
+	}
+	q.Pagination.Offset = (q.Pagination.Page - 1) * q.Pagination.PerPage
+
+	if q.Sort.Order != SortAsc && q.Sort.Order != SortDesc {
+		q.Sort.Order = SortAsc
+	}
+}
+
+// Validate validates the SubscriberQuery
+func (q *SubscriberQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "id"
+	}
+}
+
+// Validate validates the CampaignQuery
+func (q *CampaignQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "created_at"
+		q.Sort.Order = SortDesc
+	}
+}
+
+// Validate validates the ListQuery
+func (q *ListQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "name"
+	}
+}
+
+// Validate validates the TemplateQuery
+func (q *TemplateQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "name"
+	}
+}
+
+// Validate validates the UserQuery
+func (q *UserQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "email"
+	}
+}
+
+// Validate validates the MediaQuery
+func (q *MediaQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "filename"
+	}
+}
+
+// Validate validates the BounceQuery
+func (q *BounceQuery) Validate() {
+	q.BaseQuery.Validate()
+	if q.Sort.Field == "" {
+		q.Sort.Field = "created_at"
+		q.Sort.Order = SortDesc
+	}
+}

--- a/internal/repository/models/query_test.go
+++ b/internal/repository/models/query_test.go
@@ -1,0 +1,211 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestBaseQueryValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    BaseQuery
+		expected BaseQuery
+	}{
+		{
+			name:  "empty query sets defaults",
+			query: BaseQuery{},
+			expected: BaseQuery{
+				Pagination: PaginationQuery{Page: 1, PerPage: 20, Offset: 0},
+				Sort:       SortQuery{Order: SortAsc},
+			},
+		},
+		{
+			name: "negative page sets to 1",
+			query: BaseQuery{
+				Pagination: PaginationQuery{Page: -1, PerPage: 10},
+			},
+			expected: BaseQuery{
+				Pagination: PaginationQuery{Page: 1, PerPage: 10, Offset: 0},
+				Sort:       SortQuery{Order: SortAsc},
+			},
+		},
+		{
+			name: "zero per_page sets to 20",
+			query: BaseQuery{
+				Pagination: PaginationQuery{Page: 2, PerPage: 0},
+			},
+			expected: BaseQuery{
+				Pagination: PaginationQuery{Page: 2, PerPage: 20, Offset: 20},
+				Sort:       SortQuery{Order: SortAsc},
+			},
+		},
+		{
+			name: "per_page over 1000 sets to 20",
+			query: BaseQuery{
+				Pagination: PaginationQuery{Page: 1, PerPage: 1500},
+			},
+			expected: BaseQuery{
+				Pagination: PaginationQuery{Page: 1, PerPage: 20, Offset: 0},
+				Sort:       SortQuery{Order: SortAsc},
+			},
+		},
+		{
+			name: "valid values preserved",
+			query: BaseQuery{
+				Pagination: PaginationQuery{Page: 3, PerPage: 50},
+				Sort:       SortQuery{Field: "name", Order: SortDesc},
+			},
+			expected: BaseQuery{
+				Pagination: PaginationQuery{Page: 3, PerPage: 50, Offset: 100},
+				Sort:       SortQuery{Field: "name", Order: SortDesc},
+			},
+		},
+		{
+			name: "invalid sort order defaults to ASC",
+			query: BaseQuery{
+				Pagination: PaginationQuery{Page: 1, PerPage: 10},
+				Sort:       SortQuery{Field: "name", Order: "INVALID"},
+			},
+			expected: BaseQuery{
+				Pagination: PaginationQuery{Page: 1, PerPage: 10, Offset: 0},
+				Sort:       SortQuery{Field: "name", Order: SortAsc},
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.query.Validate()
+			
+			if tt.query.Pagination.Page != tt.expected.Pagination.Page {
+				t.Errorf("Expected page %d, got %d", tt.expected.Pagination.Page, tt.query.Pagination.Page)
+			}
+			
+			if tt.query.Pagination.PerPage != tt.expected.Pagination.PerPage {
+				t.Errorf("Expected per_page %d, got %d", tt.expected.Pagination.PerPage, tt.query.Pagination.PerPage)
+			}
+			
+			if tt.query.Pagination.Offset != tt.expected.Pagination.Offset {
+				t.Errorf("Expected offset %d, got %d", tt.expected.Pagination.Offset, tt.query.Pagination.Offset)
+			}
+			
+			if tt.query.Sort.Order != tt.expected.Sort.Order {
+				t.Errorf("Expected sort order %s, got %s", tt.expected.Sort.Order, tt.query.Sort.Order)
+			}
+			
+			if tt.query.Sort.Field != tt.expected.Sort.Field {
+				t.Errorf("Expected sort field %s, got %s", tt.expected.Sort.Field, tt.query.Sort.Field)
+			}
+		})
+	}
+}
+
+func TestSubscriberQueryValidate(t *testing.T) {
+	query := SubscriberQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "id"
+	if query.Sort.Field != "id" {
+		t.Errorf("Expected default sort field 'id', got %q", query.Sort.Field)
+	}
+	
+	// Should validate base query
+	if query.Pagination.Page != 1 {
+		t.Errorf("Expected default page 1, got %d", query.Pagination.Page)
+	}
+	
+	if query.Pagination.PerPage != 20 {
+		t.Errorf("Expected default per_page 20, got %d", query.Pagination.PerPage)
+	}
+}
+
+func TestCampaignQueryValidate(t *testing.T) {
+	query := CampaignQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "created_at" and order to DESC
+	if query.Sort.Field != "created_at" {
+		t.Errorf("Expected default sort field 'created_at', got %q", query.Sort.Field)
+	}
+	
+	if query.Sort.Order != SortDesc {
+		t.Errorf("Expected default sort order 'DESC', got %q", query.Sort.Order)
+	}
+}
+
+func TestListQueryValidate(t *testing.T) {
+	query := ListQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "name"
+	if query.Sort.Field != "name" {
+		t.Errorf("Expected default sort field 'name', got %q", query.Sort.Field)
+	}
+}
+
+func TestTemplateQueryValidate(t *testing.T) {
+	query := TemplateQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "name"
+	if query.Sort.Field != "name" {
+		t.Errorf("Expected default sort field 'name', got %q", query.Sort.Field)
+	}
+}
+
+func TestUserQueryValidate(t *testing.T) {
+	query := UserQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "email"
+	if query.Sort.Field != "email" {
+		t.Errorf("Expected default sort field 'email', got %q", query.Sort.Field)
+	}
+}
+
+func TestMediaQueryValidate(t *testing.T) {
+	query := MediaQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "filename"
+	if query.Sort.Field != "filename" {
+		t.Errorf("Expected default sort field 'filename', got %q", query.Sort.Field)
+	}
+}
+
+func TestBounceQueryValidate(t *testing.T) {
+	query := BounceQuery{}
+	query.Validate()
+	
+	// Should set default sort field to "created_at" and order to DESC
+	if query.Sort.Field != "created_at" {
+		t.Errorf("Expected default sort field 'created_at', got %q", query.Sort.Field)
+	}
+	
+	if query.Sort.Order != SortDesc {
+		t.Errorf("Expected default sort order 'DESC', got %q", query.Sort.Order)
+	}
+}
+
+func TestSortOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		order SortOrder
+		valid bool
+	}{
+		{"ASC is valid", SortAsc, true},
+		{"DESC is valid", SortDesc, true},
+		{"lowercase asc is invalid", SortOrder("asc"), false},
+		{"lowercase desc is invalid", SortOrder("desc"), false},
+		{"empty is invalid", SortOrder(""), false},
+		{"random string is invalid", SortOrder("random"), false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := tt.order == SortAsc || tt.order == SortDesc
+			if valid != tt.valid {
+				t.Errorf("Expected valid=%v for order %q, got %v", tt.valid, tt.order, valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- This is the foundation for supporting multiple database backends while maintaining backward compatibility with existing PostgreSQL setup.
- Implement repository pattern interfaces for all entities
- Add database adapter interface and factory pattern
- Create configuration system for PostgreSQL and MongoDB
- Add query models with pagination, sorting, and filtering
- Implement comprehensive error handling system
- Add test coverage for abstracted database interfaces