### PR TITLE
Add missing header for campaigns in template

### DIFF
--- a/docs/docs/content/templating.md
+++ b/docs/docs/content/templating.md
@@ -31,6 +31,8 @@ There are several template functions and expressions that can be used in campaig
 | `{{ .Subscriber.CreatedAt }}` | Timestamp when the subscriber was first added                                                |
 | `{{ .Subscriber.UpdatedAt }}` | Timestamp when the subscriber was modified                                                   |
 
+### Campaigns
+
 | Expression            | Description                                              |
 | --------------------- | -------------------------------------------------------- |
 | `{{ .Campaign.UUID }}`      | The randomly generated unique ID of the campaign         |


### PR DESCRIPTION
Issue mentioned in #2526 

This pull request adds a new section to the templating documentation to support campaigns. The most important change introduces template expressions for accessing campaign-related data.

Documentation updates:

* [`docs/docs/content/templating.md`](diffhunk://#diff-343d376cb084447fe4c20472fedaf29731f454aeb1bafa808cbd56408fb474ebR34-R35): Added a new "Campaigns" section with template expressions, including `{{ .Campaign.UUID }}` to retrieve the unique ID of a campaign.