### PR TITLE
Update countLines for improved accuracy

### DIFF
--- a/internal/subimporter/importer.go
+++ b/internal/subimporter/importer.go
@@ -707,11 +707,10 @@ func (s *Session) mapCSVHeaders(csvHdrs []string, knownHdrs map[string]bool) map
 // Credit: https://stackoverflow.com/a/24563853
 func countLines(r io.Reader) (int, error) {
 	var (
-		buf       = make([]byte, 32*1024)
-		count     = 0
-		lineSep   = byte('\n')
-		lastByte  byte
-		bytesRead int
+		buf      = make([]byte, 32*1024)
+		count    = 0
+		lineSep  = byte('\n')
+		lastByte byte
 	)
 
 	for {
@@ -719,7 +718,6 @@ func countLines(r io.Reader) (int, error) {
 		if c > 0 {
 			count += bytes.Count(buf[:c], []byte{lineSep})
 			lastByte = buf[c-1]
-			bytesRead += c
 		}
 
 		if err == io.EOF {
@@ -730,7 +728,7 @@ func countLines(r io.Reader) (int, error) {
 		}
 	}
 
-	if bytesRead > 0 && lastByte != lineSep {
+	if lastByte != 0 && lastByte != lineSep {
 		count++
 	}
 

--- a/internal/subimporter/importer.go
+++ b/internal/subimporter/importer.go
@@ -707,23 +707,34 @@ func (s *Session) mapCSVHeaders(csvHdrs []string, knownHdrs map[string]bool) map
 // Credit: https://stackoverflow.com/a/24563853
 func countLines(r io.Reader) (int, error) {
 	var (
-		buf     = make([]byte, 32*1024)
-		count   = 0
-		lineSep = []byte{'\n'}
+		buf       = make([]byte, 32*1024)
+		count     = 0
+		lineSep   = byte('\n')
+		lastByte  byte
+		bytesRead int
 	)
 
 	for {
 		c, err := r.Read(buf)
-		count += bytes.Count(buf[:c], lineSep)
+		if c > 0 {
+			count += bytes.Count(buf[:c], []byte{lineSep})
+			lastByte = buf[c-1]
+			bytesRead += c
+		}
 
-		switch {
-		case err == io.EOF:
-			return count, nil
-
-		case err != nil:
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
 			return count, err
 		}
 	}
+
+	if bytesRead > 0 && lastByte != lineSep {
+		count++
+	}
+
+	return count, nil
 }
 
 func makeDomainMap(domains []string) (map[string]struct{}, bool) {


### PR DESCRIPTION
Closes issue #2541 

Just a small change to the `countLines` function which just checks if the last byte is a line break (`\n`) and adds one to the total count if it's not. This means that the row count remains more accurate if there is no trailing line break.

This does not introduce any logic to distinguish between "blank" and non "blank" lines and therefore still does not guarantee an accurate row count (even just in the case of multiple trailing line breaks), but does approach a _more_ accurate row count.