### PR TITLE
Add SQL snippets feature

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -175,6 +175,14 @@ func initHTTPHandlers(e *echo.Echo, a *App) {
 		g.PUT("/api/templates/:id/default", pm(hasID(a.TemplateSetDefault), "templates:manage"))
 		g.DELETE("/api/templates/:id", pm(hasID(a.DeleteTemplate), "templates:manage"))
 
+		// SQL snippets
+		g.GET("/api/sql-snippets", pm(a.HandleGetSQLSnippets, "subscribers:sql_query"))
+		g.GET("/api/sql-snippets/:id", pm(hasID(a.HandleGetSQLSnippets), "subscribers:sql_query"))
+		g.POST("/api/sql-snippets", pm(a.HandleCreateSQLSnippet, "subscribers:sql_query"))
+		g.PUT("/api/sql-snippets/:id", pm(hasID(a.HandleUpdateSQLSnippet), "subscribers:sql_query"))
+		g.DELETE("/api/sql-snippets/:id", pm(hasID(a.HandleDeleteSQLSnippet), "subscribers:sql_query"))
+		g.POST("/api/sql-snippets/validate", pm(a.HandleValidateSQLSnippet, "subscribers:sql_query"))
+
 		g.DELETE("/api/maintenance/subscribers/:type", pm(a.GCSubscribers, "settings:maintain"))
 		g.DELETE("/api/maintenance/analytics/:type", pm(a.GCCampaignAnalytics, "settings:maintain"))
 		g.DELETE("/api/maintenance/subscriptions/unconfirmed", pm(a.GCSubscriptions, "settings:maintain"))

--- a/cmd/sql_snippets.go
+++ b/cmd/sql_snippets.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/knadh/listmonk/internal/auth"
+	"github.com/knadh/listmonk/models"
+	"github.com/labstack/echo/v4"
+)
+
+// HandleGetSQLSnippets handles the retrieval of SQL snippets.
+func (a *App) HandleGetSQLSnippets(c echo.Context) error {
+	// Get the authenticated user.
+	user := auth.GetUser(c)
+
+	// Check permissions
+	if !user.HasPerm(auth.PermSubscribersSqlQuery) {
+		return echo.NewHTTPError(http.StatusForbidden,
+			a.i18n.Ts("globals.messages.permissionDenied", "name", auth.PermSubscribersSqlQuery))
+	}
+
+	var (
+		pg       = a.pg.NewFromURL(c.Request().URL.Query())
+		id, _    = strconv.Atoi(c.Param("id"))
+		name     = c.QueryParam("name")
+		isActive *bool
+	)
+
+	if v := c.QueryParam("is_active"); v != "" {
+		if val, err := strconv.ParseBool(v); err == nil {
+			isActive = &val
+		}
+	}
+
+	// Single snippet by ID.
+	if id > 0 {
+		out, err := a.core.GetSQLSnippet(id, "")
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, okResp{out})
+	}
+
+	// Multiple snippets.
+	out, err := a.core.GetSQLSnippets(0, name, isActive, pg.Offset, pg.Limit)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{out})
+}
+
+// HandleCreateSQLSnippet handles the creation of a SQL snippet.
+func (a *App) HandleCreateSQLSnippet(c echo.Context) error {
+	var s models.SQLSnippet
+	if err := c.Bind(&s); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidData", "error", err.Error()))
+	}
+
+	// Get the authenticated user.
+	user := auth.GetUser(c)
+
+	// Check permissions
+	if !user.HasPerm(auth.PermSubscribersSqlQuery) {
+		return echo.NewHTTPError(http.StatusForbidden,
+			a.i18n.Ts("globals.messages.permissionDenied", "name", auth.PermSubscribersSqlQuery))
+	}
+
+	// Validate the SQL snippet
+	if err := a.core.ValidateSQLSnippet(s.QuerySQL); err != nil {
+		return err
+	}
+
+	out, err := a.core.CreateSQLSnippet(s, user.ID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusCreated, okResp{out})
+}
+
+// HandleUpdateSQLSnippet handles the updating of a SQL snippet.
+func (a *App) HandleUpdateSQLSnippet(c echo.Context) error {
+	var s models.SQLSnippet
+	if err := c.Bind(&s); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidData", "error", err.Error()))
+	}
+
+	id, _ := strconv.Atoi(c.Param("id"))
+	if id < 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("globals.messages.invalidID"))
+	}
+
+	// Get the authenticated user.
+	user := auth.GetUser(c)
+
+	// Check permissions
+	if !user.HasPerm(auth.PermSubscribersSqlQuery) {
+		return echo.NewHTTPError(http.StatusForbidden,
+			a.i18n.Ts("globals.messages.permissionDenied", "name", auth.PermSubscribersSqlQuery))
+	}
+
+	// Validate the SQL snippet if it's being changed
+	if s.QuerySQL != "" {
+		if err := a.core.ValidateSQLSnippet(s.QuerySQL); err != nil {
+			return err
+		}
+	}
+
+	out, err := a.core.UpdateSQLSnippet(id, s)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{out})
+}
+
+// HandleDeleteSQLSnippet handles the deletion of a SQL snippet.
+func (a *App) HandleDeleteSQLSnippet(c echo.Context) error {
+	id, _ := strconv.Atoi(c.Param("id"))
+	if id < 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("globals.messages.invalidID"))
+	}
+
+	// Get the authenticated user.
+	user := auth.GetUser(c)
+
+	// Check permissions
+	if !user.HasPerm(auth.PermSubscribersSqlQuery) {
+		return echo.NewHTTPError(http.StatusForbidden,
+			a.i18n.Ts("globals.messages.permissionDenied", "name", auth.PermSubscribersSqlQuery))
+	}
+
+	if err := a.core.DeleteSQLSnippet(id); err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{true})
+}
+
+// HandleValidateSQLSnippet handles the validation of a SQL snippet.
+func (a *App) HandleValidateSQLSnippet(c echo.Context) error {
+	var req struct {
+		QuerySQL string `json:"query_sql"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidData", "error", err.Error()))
+	}
+
+	// Get the authenticated user.
+	user := auth.GetUser(c)
+
+	// Check permissions
+	if !user.HasPerm(auth.PermSubscribersSqlQuery) {
+		return echo.NewHTTPError(http.StatusForbidden,
+			a.i18n.Ts("globals.messages.permissionDenied", "name", auth.PermSubscribersSqlQuery))
+	}
+
+	if err := a.core.ValidateSQLSnippet(req.QuerySQL); err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{map[string]bool{"valid": true}})
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -41,6 +41,7 @@ var migList = []migFunc{
 	{"v4.0.0", migrations.V4_0_0},
 	{"v4.1.0", migrations.V4_1_0},
 	{"v5.0.0", migrations.V5_0_0},
+	{"v5.1.0", migrations.V5_1_0},
 }
 
 // upgrade upgrades the database to the current version by running SQL migration files

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -532,3 +532,37 @@ export const deleteRole = (id) => http.delete(
   `/api/roles/${id}`,
   { loading: models.userRoles },
 );
+
+// SQL Snippets.
+export const getSQLSnippets = (params) => http.get(
+  '/api/sql-snippets',
+  { params, loading: models.sqlSnippets },
+);
+
+export const getSQLSnippet = (id) => http.get(
+  `/api/sql-snippets/${id}`,
+  { loading: models.sqlSnippets },
+);
+
+export const createSQLSnippet = (data) => http.post(
+  '/api/sql-snippets',
+  data,
+  { loading: models.sqlSnippets },
+);
+
+export const updateSQLSnippet = (id, data) => http.put(
+  `/api/sql-snippets/${id}`,
+  data,
+  { loading: models.sqlSnippets },
+);
+
+export const deleteSQLSnippet = (id) => http.delete(
+  `/api/sql-snippets/${id}`,
+  { loading: models.sqlSnippets },
+);
+
+export const validateSQLSnippet = (data) => http.post(
+  '/api/sql-snippets/validate',
+  data,
+  { loading: models.sqlSnippets },
+);

--- a/frontend/src/components/Navigation.vue
+++ b/frontend/src/components/Navigation.vue
@@ -20,6 +20,8 @@
         :label="$t('menu.allSubscribers')" />
       <b-menu-item v-if="$can('subscribers:import')" :to="{ name: 'import' }" tag="router-link"
         :active="activeItem.import" data-cy="import" icon="file-upload-outline" :label="$t('menu.import')" />
+      <b-menu-item v-if="$can('subscribers:sql_query')" :to="{ name: 'sql-snippets' }" tag="router-link" :active="activeItem['sql-snippets']"
+        data-cy="sql-snippets" icon="code-tags" :label="$t('sqlSnippets.title')" />
       <b-menu-item v-if="$can('bounces:get')" :to="{ name: 'bounces' }" tag="router-link" :active="activeItem.bounces"
         data-cy="bounces" icon="email-bounce" :label="$t('globals.terms.bounces')" />
     </b-menu-item><!-- subscribers -->

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -17,6 +17,7 @@ export const models = Object.freeze({
   profile: 'profile',
   userRoles: 'userRoles',
   listRoles: 'listRoles',
+  sqlSnippets: 'sqlSnippets',
   settings: 'settings',
   logs: 'logs',
   maintenance: 'maintenance',

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -48,6 +48,12 @@ const routes = [
     component: () => import('../views/Import.vue'),
   },
   {
+    path: '/sql-snippets',
+    name: 'sql-snippets',
+    meta: { title: 'sqlSnippets.title', group: 'subscribers' },
+    component: () => import('../views/SqlSnippets.vue'),
+  },
+  {
     path: '/subscribers/bounces',
     name: 'bounces',
     meta: { title: 'globals.terms.bounces', group: 'subscribers' },

--- a/frontend/src/views/SqlSnippets.vue
+++ b/frontend/src/views/SqlSnippets.vue
@@ -1,0 +1,284 @@
+<template>
+  <section class="sql-snippets">
+    <header class="columns">
+      <div class="column is-two-thirds">
+        <h1 class="title is-4">{{ $t('sqlSnippets.title') }}</h1>
+        <p class="has-text-grey">{{ $t('sqlSnippets.description') }}</p>
+      </div>
+      <div class="column has-text-right">
+        <b-button type="is-primary" icon-left="plus" @click="showForm" data-cy="btn-new">
+          {{ $t('globals.buttons.new') }}
+        </b-button>
+      </div>
+    </header>
+
+    <div class="table-container">
+      <table class="table is-fullwidth is-striped is-hoverable">
+        <thead>
+          <tr>
+            <th>{{ $t('globals.fields.name') }}</th>
+            <th>{{ $t('globals.fields.description') }}</th>
+            <th>{{ $t('globals.fields.status') }}</th>
+            <th>{{ $t('globals.fields.createdAt') }}</th>
+            <th>{{ $t('globals.fields.updatedAt') }}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="sqlSnippets.length === 0">
+            <td colspan="6" class="has-text-centered">
+              {{ $t('globals.messages.emptyState') }}
+            </td>
+          </tr>
+          <tr v-for="snippet in sqlSnippets" :key="snippet.id" :class="{ 'has-text-grey': !snippet.is_active }">
+            <td>
+              <div>
+                <strong>{{ snippet.name }}</strong>
+              </div>
+            </td>
+            <td>{{ snippet.description }}</td>
+            <td>
+              <b-tag :type="snippet.is_active ? 'is-success' : 'is-light'">
+                {{ snippet.is_active ? $t('globals.terms.enabled') : $t('globals.terms.disabled') }}
+              </b-tag>
+            </td>
+            <td>{{ $utils.niceDate(snippet.created_at, true) }}</td>
+            <td>{{ $utils.niceDate(snippet.updated_at, true) }}</td>
+            <td class="actions">
+              <div>
+                <b-button @click="showForm(snippet)" icon-left="edit-outline" size="is-small" type="is-text">
+                  {{ $t('globals.buttons.edit') }}
+                </b-button>
+                <b-button @click="deleteSnippet(snippet)" icon-left="trash-can-outline" size="is-small" type="is-text">
+                  {{ $t('globals.buttons.delete') }}
+                </b-button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- SQL Snippet Form Modal -->
+    <b-modal trap-focus :active.sync="form.isVisible" :width="600" scroll="keep">
+      <form @submit.prevent="onSubmit">
+        <div class="modal-card" style="width: auto">
+          <header class="modal-card-head">
+            <h4 class="modal-card-title">
+              {{ form.id ? $t('globals.buttons.edit') : $t('globals.buttons.new') }}
+              {{ $t('sqlSnippets.snippet') }}
+            </h4>
+          </header>
+          <section class="modal-card-body">
+            <div class="columns">
+              <div class="column">
+                <b-field :label="$t('globals.fields.name')" label-position="on-border">
+                  <b-input v-model="form.name" name="name" :ref="'focus'" maxlength="200" required />
+                </b-field>
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column">
+                <b-field :label="$t('globals.fields.description')" label-position="on-border">
+                  <b-input v-model="form.description" name="description" maxlength="500" type="textarea" />
+                </b-field>
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column">
+                <b-field :label="$t('sqlSnippets.querySQL')" label-position="on-border">
+                  <code-editor v-model="form.query_sql" language="sql" :placeholder="$t('sqlSnippets.queryPlaceholder')" />
+                </b-field>
+                <p class="is-size-7 has-text-grey">
+                  {{ $t('sqlSnippets.queryHelp') }}
+                </p>
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column is-6">
+                <b-field>
+                  <b-checkbox v-model="form.is_active">{{ $t('globals.fields.status') }}</b-checkbox>
+                </b-field>
+              </div>
+              <div class="column is-6 has-text-right">
+                <b-button @click="validateQuery" type="is-info" icon-left="check" :loading="isValidating">
+                  {{ $t('sqlSnippets.validate') }}
+                </b-button>
+              </div>
+            </div>
+
+            <div v-if="validationMessage" class="notification" :class="validationMessage.type">
+              {{ validationMessage.text }}
+            </div>
+          </section>
+          <footer class="modal-card-foot has-text-right">
+            <b-button @click="form.isVisible = false">{{ $t('globals.buttons.cancel') }}</b-button>
+            <b-button native-type="submit" type="is-primary" :loading="loading.sqlSnippets">
+              {{ $t('globals.buttons.save') }}
+            </b-button>
+          </footer>
+        </div>
+      </form>
+    </b-modal>
+  </section>
+</template>
+
+<script>
+import CodeEditor from '../components/CodeEditor.vue';
+
+export default {
+  name: 'SqlSnippets',
+
+  components: {
+    CodeEditor,
+  },
+
+  data() {
+    return {
+      sqlSnippets: [],
+      form: this.initForm(),
+      isValidating: false,
+      validationMessage: null,
+    };
+  },
+
+  computed: {
+    loading() {
+      return this.$store.state.loading;
+    },
+  },
+
+  methods: {
+    initForm() {
+      return {
+        isVisible: false,
+        id: 0,
+        name: '',
+        description: '',
+        query_sql: '',
+        is_active: true,
+      };
+    },
+
+    showForm(snippet = null) {
+      this.form = this.initForm();
+      this.validationMessage = null;
+
+      if (snippet) {
+        this.form = { ...this.form, ...snippet };
+      }
+
+      this.form.isVisible = true;
+      this.$nextTick(() => {
+        this.$refs.focus.focus();
+      });
+    },
+
+    onSubmit() {
+      if (this.form.id) {
+        this.updateSnippet();
+      } else {
+        this.createSnippet();
+      }
+    },
+
+    createSnippet() {
+      this.$api.createSQLSnippet(this.form).then((data) => {
+        this.$buefy.toast.open({
+          message: this.$t('globals.messages.created', { name: data.name }),
+          type: 'is-success',
+          queue: false,
+        });
+
+        this.form.isVisible = false;
+        this.fetchSnippets();
+      });
+    },
+
+    updateSnippet() {
+      this.$api.updateSQLSnippet(this.form.id, this.form).then((data) => {
+        this.$buefy.toast.open({
+          message: this.$t('globals.messages.updated', { name: data.name }),
+          type: 'is-success',
+          queue: false,
+        });
+
+        this.form.isVisible = false;
+        this.fetchSnippets();
+      });
+    },
+
+    deleteSnippet(snippet) {
+      this.$buefy.dialog.confirm({
+        title: this.$t('globals.terms.confirm'),
+        message: this.$t('globals.messages.confirmDelete', { name: snippet.name }),
+        confirmText: this.$t('globals.buttons.delete'),
+        type: 'is-danger',
+        onConfirm: () => {
+          this.$api.deleteSQLSnippet(snippet.id).then(() => {
+            this.$buefy.toast.open({
+              message: this.$t('globals.messages.deleted', { name: snippet.name }),
+              type: 'is-success',
+              queue: false,
+            });
+
+            this.fetchSnippets();
+          });
+        },
+      });
+    },
+
+    validateQuery() {
+      if (!this.form.query_sql.trim()) {
+        this.validationMessage = {
+          type: 'is-warning',
+          text: this.$t('sqlSnippets.emptyQuery'),
+        };
+        return;
+      }
+
+      this.isValidating = true;
+      this.validationMessage = null;
+
+      this.$api.validateSQLSnippet({ query_sql: this.form.query_sql }).then(() => {
+        this.validationMessage = {
+          type: 'is-success',
+          text: this.$t('sqlSnippets.validQuery'),
+        };
+      }).catch((err) => {
+        this.validationMessage = {
+          type: 'is-danger',
+          text: err.message || this.$t('sqlSnippets.invalidQuery'),
+        };
+      }).finally(() => {
+        this.isValidating = false;
+      });
+    },
+
+    fetchSnippets() {
+      this.$api.getSQLSnippets().then((data) => {
+        this.sqlSnippets = data;
+      });
+    },
+  },
+
+  mounted() {
+    this.fetchSnippets();
+  },
+};
+</script>
+
+<style scoped>
+.actions {
+  text-align: right;
+}
+
+.actions > div {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+</style>

--- a/internal/core/sql_snippets.go
+++ b/internal/core/sql_snippets.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	"github.com/knadh/listmonk/models"
+	"github.com/labstack/echo/v4"
+)
+
+// GetSQLSnippets retrieves SQL snippets based on the given filters.
+func (c *Core) GetSQLSnippets(id int, name string, isActive *bool, offset, limit int) ([]models.SQLSnippet, error) {
+	var out []models.SQLSnippet
+	if err := c.q.GetSQLSnippets.Select(&out, id, name, isActive, offset, limit); err != nil {
+		c.log.Printf("error fetching SQL snippets: %v", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorFetching", "name", "SQL snippets", "error", pqErrMsg(err)))
+	}
+
+	return out, nil
+}
+
+// GetSQLSnippet retrieves a single SQL snippet by ID or name.
+func (c *Core) GetSQLSnippet(id int, name string) (models.SQLSnippet, error) {
+	var out models.SQLSnippet
+	if err := c.q.GetSQLSnippet.Get(&out, id, name); err != nil {
+		c.log.Printf("error fetching SQL snippet: %v", err)
+		return models.SQLSnippet{}, echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorFetching", "name", "SQL snippet", "error", pqErrMsg(err)))
+	}
+
+	return out, nil
+}
+
+// CreateSQLSnippet creates a new SQL snippet.
+func (c *Core) CreateSQLSnippet(s models.SQLSnippet, createdBy int) (models.SQLSnippet, error) {
+	var createdByVal *int
+	if createdBy > 0 {
+		createdByVal = &createdBy
+	}
+
+	var newID int
+	if err := c.q.CreateSQLSnippet.Get(&newID, s.Name, s.Description, s.QuerySQL, createdByVal); err != nil {
+		c.log.Printf("error creating SQL snippet: %v", err)
+		return models.SQLSnippet{}, echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorCreating", "name", "SQL snippet", "error", pqErrMsg(err)))
+	}
+
+	return c.GetSQLSnippet(newID, "")
+}
+
+// UpdateSQLSnippet updates a SQL snippet.
+func (c *Core) UpdateSQLSnippet(id int, s models.SQLSnippet) (models.SQLSnippet, error) {
+	if err := c.q.UpdateSQLSnippet.Exec(s.Name, s.Description, s.QuerySQL, s.IsActive, id); err != nil {
+		c.log.Printf("error updating SQL snippet: %v", err)
+		return models.SQLSnippet{}, echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorUpdating", "name", "SQL snippet", "error", pqErrMsg(err)))
+	}
+
+	return c.GetSQLSnippet(id, "")
+}
+
+// DeleteSQLSnippet deletes a SQL snippet.
+func (c *Core) DeleteSQLSnippet(id int) error {
+	if err := c.q.DeleteSQLSnippet.Exec(id); err != nil {
+		c.log.Printf("error deleting SQL snippet: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorDeleting", "name", "SQL snippet", "error", pqErrMsg(err)))
+	}
+
+	return nil
+}
+
+// ValidateSQLSnippet validates a SQL snippet by attempting to execute it.
+func (c *Core) ValidateSQLSnippet(querySQL string) error {
+	// Create a read-only transaction for validation
+	tx, err := c.db.BeginTxx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorFetching", "name", "database connection", "error", err.Error()))
+	}
+	defer tx.Rollback()
+
+	// Construct a test query to validate the SQL snippet
+	stmt := fmt.Sprintf(`
+		SELECT COUNT(*) FROM subscribers
+		LEFT JOIN subscriber_lists ON (
+			subscriber_lists.subscriber_id = subscribers.id
+		)
+		WHERE %s
+		LIMIT 1
+	`, querySQL)
+
+	// Try to execute the query to validate syntax and permissions
+	var count int
+	if err := tx.Get(&count, stmt); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			c.i18n.Ts("subscribers.errorPreparingQuery", "error", err.Error()))
+	}
+
+	return nil
+}

--- a/internal/migrations/v5.1.0.go
+++ b/internal/migrations/v5.1.0.go
@@ -1,0 +1,52 @@
+package migrations
+
+import (
+	"log"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/koanf/v2"
+	"github.com/knadh/stuffbin"
+)
+
+// V5_1_0 performs the DB migrations for SQL snippets.
+func V5_1_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf, lo *log.Logger) error {
+	// Create SQL snippets table
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS sql_snippets (
+			id SERIAL PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			description TEXT,
+			query_sql TEXT NOT NULL,
+			is_active BOOLEAN DEFAULT true,
+			created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+			updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+		);
+	`); err != nil {
+		return err
+	}
+
+	// Create indexes for SQL snippets
+	if _, err := db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_sql_snippets_name ON sql_snippets(name);
+		CREATE INDEX IF NOT EXISTS idx_sql_snippets_is_active ON sql_snippets(is_active);
+	`); err != nil {
+		return err
+	}
+
+	// Insert default SQL snippets
+	if _, err := db.Exec(`
+		INSERT INTO sql_snippets (name, description, query_sql) VALUES
+		('Active Subscribers', 'Subscribers with confirmed status', 'subscribers.status = ''confirmed'''),
+		('Recent Signups', 'Subscribers who joined in the last 30 days', 'subscribers.created_at >= NOW() - INTERVAL ''30 days'''),
+		('Inactive Subscribers', 'Subscribers who haven''t been active for 90+ days', 'subscribers.updated_at <= NOW() - INTERVAL ''90 days'''),
+		('High Value Subscribers', 'Subscribers over 39 years old', 'EXTRACT(year FROM AGE(NOW(), (subscribers.attribs->>''age'')::date)) > 39'),
+		('Premium Tier', 'Subscribers with premium status', 'subscribers.attribs->>''tier'' = ''premium'''),
+		('Active in Last Week', 'Subscribers with recent activity', 'subscribers.updated_at >= NOW() - INTERVAL ''7 days''')
+		ON CONFLICT (name) DO NOTHING;
+	`); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/models.go
+++ b/models/models.go
@@ -731,3 +731,14 @@ func (h Headers) Value() (driver.Value, error) {
 
 	return "[]", nil
 }
+
+// SQLSnippet represents a SQL snippet for subscriber queries.
+type SQLSnippet struct {
+	Base
+
+	Name        string `db:"name" json:"name"`
+	Description string `db:"description" json:"description"`
+	QuerySQL    string `db:"query_sql" json:"query_sql"`
+	IsActive    bool   `db:"is_active" json:"is_active"`
+	CreatedBy   *int   `db:"created_by" json:"created_by"`
+}

--- a/models/queries.go
+++ b/models/queries.go
@@ -129,6 +129,13 @@ type Queries struct {
 	DeleteRole            *sqlx.Stmt `query:"delete-role"`
 	UpsertListPermissions *sqlx.Stmt `query:"upsert-list-permissions"`
 	DeleteListPermission  *sqlx.Stmt `query:"delete-list-permission"`
+
+	// SQL Snippets.
+	GetSQLSnippets   *sqlx.Stmt `query:"get-sql-snippets"`
+	GetSQLSnippet    *sqlx.Stmt `query:"get-sql-snippet"`
+	CreateSQLSnippet *sqlx.Stmt `query:"create-sql-snippet"`
+	UpdateSQLSnippet *sqlx.Stmt `query:"update-sql-snippet"`
+	DeleteSQLSnippet *sqlx.Stmt `query:"delete-sql-snippet"`
 }
 
 // compileSubscriberQueryTpl takes an arbitrary WHERE expressions

--- a/queries.sql
+++ b/queries.sql
@@ -1319,3 +1319,31 @@ UPDATE roles SET name=$2, permissions=$3 WHERE id=$1 and parent_id IS NULL RETUR
 
 -- name: delete-role
 DELETE FROM roles WHERE id=$1;
+
+-- SQL Snippets queries
+-- name: get-sql-snippets
+SELECT * FROM sql_snippets 
+WHERE ($1 = 0 OR id = $1)
+AND ($2 = '' OR name = $2)
+AND ($3 IS NULL OR is_active = $3)
+ORDER BY name
+OFFSET $4 LIMIT (CASE WHEN $5 = 0 THEN NULL ELSE $5 END);
+
+-- name: get-sql-snippet
+SELECT * FROM sql_snippets WHERE (id = $1 OR name = $2) LIMIT 1;
+
+-- name: create-sql-snippet
+INSERT INTO sql_snippets (name, description, query_sql, created_by) 
+VALUES ($1, $2, $3, $4) RETURNING id;
+
+-- name: update-sql-snippet
+UPDATE sql_snippets SET 
+    name = $1,
+    description = $2,
+    query_sql = $3,
+    is_active = $4,
+    updated_at = NOW()
+WHERE id = $5;
+
+-- name: delete-sql-snippet
+DELETE FROM sql_snippets WHERE id = $1;

--- a/schema.sql
+++ b/schema.sql
@@ -432,3 +432,18 @@ CREATE MATERIALIZED VIEW mat_list_subscriber_stats AS
     UNION ALL
     SELECT NOW() AS updated_at, 0 AS list_id, NULL AS status, COUNT(id) AS subscriber_count FROM subscribers;
 DROP INDEX IF EXISTS mat_list_subscriber_stats_idx; CREATE UNIQUE INDEX mat_list_subscriber_stats_idx ON mat_list_subscriber_stats (list_id, status);
+
+-- SQL snippets for reusable query fragments
+DROP TABLE IF EXISTS sql_snippets CASCADE;
+CREATE TABLE sql_snippets (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    query_sql TEXT NOT NULL,
+    is_active BOOLEAN DEFAULT true,
+    created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+DROP INDEX IF EXISTS idx_sql_snippets_name; CREATE INDEX idx_sql_snippets_name ON sql_snippets(name);
+DROP INDEX IF EXISTS idx_sql_snippets_is_active; CREATE INDEX idx_sql_snippets_is_active ON sql_snippets(is_active);


### PR DESCRIPTION
## Summary

This PR introduces SQL snippets - a feature for managing reusable SQL query fragments that can be used for subscriber segmentation.

**Key Features:**
- CRUD operations for SQL snippets with name, description, and query SQL
- Query validation and syntax highlighting in the UI  
- Permission-based access control (requires `subscribers:sql_query` permission)
- Navigation menu integration under subscribers section
- Database migration with default snippets included

**Backend Changes:**
- New `sql_snippets` table with migration v5.1.0
- Core CRUD operations in `internal/core/sql_snippets.go`
- HTTP handlers in `cmd/sql_snippets.go`
- API endpoints: GET, POST, PUT, DELETE for `/api/sql-snippets`
- Query validation endpoint for testing SQL syntax

**Frontend Changes:**
- New `SqlSnippets.vue` view with full CRUD interface
- Code editor integration for SQL syntax highlighting
- API client methods for all SQL snippets operations
- Navigation menu item with proper permission checks

**Database Schema:**
- `sql_snippets` table with fields: id, name, description, query_sql, is_active, created_by, timestamps
- Includes 6 default snippets for common use cases
- Proper indexes for performance

## Context

This is the first part of a larger feature that was originally combined with dynamic segments. The SQL snippets feature provides the foundation for reusable query fragments, while dynamic segments (which will automatically manage list membership) will be implemented separately in a follow-up PR.

This approach addresses the segmentation needs expressed in issue #250 while keeping the implementation focused and manageable.

## Test Plan

- [ ] Verify database migration creates tables correctly
- [ ] Test CRUD operations via API endpoints  
- [ ] Validate query validation functionality
- [ ] Confirm UI works with permissions
- [ ] Check navigation integration
- [ ] Test with default snippets

🤖 Generated with [Claude Code](https://claude.ai/code)