### PR TITLE
Add listmonk-mcp to SDKs documentation

### DIFF
--- a/docs/docs/content/apis/sdks.md
+++ b/docs/docs/content/apis/sdks.md
@@ -20,3 +20,4 @@ A list of 3rd party client libraries and SDKs that have been written for listmon
 - [listmonk-laravel](https://github.com/theafolayan/listmonk-laravel) — Laravel API Client
 - [nuxt-listmonk](https://github.com/roncallyt/nuxt-listmonk) — Listmonk module for Nuxt.js
 - [listmonk-japi](https://codeberg.org/hlassiege/listmonk-japi) - Listmonk client for Java/kotlin
+- [listmonk-mcp](https://github.com/rhnvrm/listmonk-mcp) — MCP (Model Context Protocol) server for Claude integration


### PR DESCRIPTION
## Summary
- Add listmonk-mcp to the community SDKs documentation page
- MCP (Model Context Protocol) server provides Claude integration for listmonk

## Test plan
- [x] Documentation builds correctly
- [x] Link format matches existing entries