### PR TITLE
Handle Postmark spam complaints.

### DIFF
--- a/internal/bounce/webhooks/postmark.go
+++ b/internal/bounce/webhooks/postmark.go
@@ -60,8 +60,8 @@ func (p *Postmark) ProcessBounce(b []byte, c echo.Context) ([]models.Bounce, err
 		return nil, fmt.Errorf("error unmarshalling postmark notification: %v", err)
 	}
 
-	// Ignore non-bounce messages.
-	if n.RecordType != "Bounce" {
+	// Ignore irrelevant messages.
+	if n.RecordType != "Bounce" && n.RecordType != "SpamComplaint" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
The code attempts to do this by handling the `SpamComplaint` `Type` however this is sent with a `RecordType` of `SpamComplaint` rather than `Bounce` so is ignored. Accepting this additional `RecordType` solves the issue.

This behaviour is described in Postmark's documentation.

> Note that that spam complaints, unsubscribes/subscribes, or manual deactivations have their own webhooks and are not trigged via the Bounce webhook.
>
> https://postmarkapp.com/developer/webhooks/bounce-webhook

https://postmarkapp.com/developer/webhooks/spam-complaint-webhook#spam-complaint-webhook-data