### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       <<: *db-credentials
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U listmonk"]
+      test: ["CMD-SHELL", "pg_isready -U \"$POSTGRES_USER\""]
       interval: 10s
       timeout: 5s
       retries: 6


### PR DESCRIPTION
include the POSTGRES_USER instead of hardcoded listmonk user in the healthcheck

As proposed some time ago, forgot to open a PR in time.

**still needs a test tho**

closes #2410 