### PR TITLE
Forever Loading (In Settings)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     container_name: listmonk_db
     restart: unless-stopped
     ports:
-      - "127.0.0.1:5432:5432"                                 # Only bind on the local interface. To connect to Postgres externally, change this to 0.0.0.0
+      - "127.0.0.1:5433:5432"                                 # Only bind on the local interface. To connect to Postgres externally, change this to 0.0.0.0
     networks:
       - listmonk
     environment:

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -226,6 +226,9 @@ export default Vue.extend({
     },
 
     getSettings() {
+      if (this.isLoading) {
+        return; // Prevent multiple simultaneous loading requests
+      }
       this.isLoading = true;
       this.$api.getSettings().then((data) => {
         let d = {};
@@ -285,7 +288,20 @@ export default Vue.extend({
 
   mounted() {
     this.tab = this.$utils.getPref('settings.tab') || 0;
-    this.getSettings();
+    // Wait for server config to be loaded before getting settings
+    if (this.serverConfig) {
+      this.getSettings();
+    } else {
+      // If serverConfig is not loaded yet, wait for it
+      this.$store.watch(
+        (state) => state.serverConfig,
+        (newValue) => {
+          if (newValue) {
+            this.getSettings();
+          }
+        }
+      );
+    }
   },
 
   watch: {


### PR DESCRIPTION
Fixed the forever loading issue when logged in using the Admin credentials. Race Condition in Config Loading: The issue might be happening because of a race condition between loading server config and settings.