### PR TITLE
feat: add Northflank deploy button

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -111,6 +111,8 @@ $ helm upgrade \
 <br />
 <a href="https://www.pikapods.com/pods?run=listmonk"><img src="https://www.pikapods.com/static/run-button.svg" alt="Deploy on PikaPod" style="max-width: 150px;" /></a>
 <br />
+<a href="https://northflank.com/stacks/deploy-listmonk"><img src="https://assets.northflank.com/deploy_to_northflank_smm_36700fb050.svg" alt="One-click deploy on Northflank" height="35" style="max-width: 150px; border-radius: 6px; object-fit: contain;" /></a>
+<br />
 <a href="https://railway.app/new/template/listmonk"><img src="https://railway.app/button.svg" alt="One-click deploy on Railway" style="max-width: 150px;" /></a>
 <br />
 <a href="https://repocloud.io/details/?app_id=217"><img src="https://d16t0pc4846x52.cloudfront.net/deploy.png" alt="Deploy at RepoCloud" style="max-width: 150px;"/></a>

--- a/docs/site/layouts/index.html
+++ b/docs/site/layouts/index.html
@@ -87,6 +87,7 @@ docker compose up -d
     <div>
       <a href="https://www.nodion.com/en/deploy/listmonk/"><img src="https://nodion-static.nodioncdn.com/nodion-button-s.svg" alt="Deploy to Nodion" style="max-height: 32px;" /></a>
       <a href="https://www.kloudbean.com/listmonk-self-hosted"><img src="https://storage-basic.kloudbean.com/opensource/deploy_on_kloudbean_listmonk.svg" alt="One-click deploy on Kloudbean" style="max-height: 32px;" /></a>
+      <a href="https://northflank.com/stacks/deploy-listmonk"><img src="https://assets.northflank.com/deploy_to_northflank_smm_36700fb050.svg" alt="One-click deploy on Northflank" style="height: 32px; width: 150px; border-radius: 6px; object-fit: contain;" /></a>
       <a href="https://railway.app/new/template/listmonk"><img src="https://railway.app/button.svg" alt="One-click deploy on Railway" style="max-height: 32px;" /></a>
       <a href="https://www.pikapods.com/pods?run=listmonk"><img src="https://www.pikapods.com/static/run-button.svg" alt="Deploy on PikaPod" /></a>
       <a href="https://elest.io/open-source/listmonk"><img height="33" src="https://raw.githubusercontent.com/elestio-examples/reactjs/refs/heads/master/src/deploy-on-elestio.png" alt="Deploy on Elestio" /></a>


### PR DESCRIPTION
This PR adds a Northflank one-click deploy button to both the landing page and the 3rd-party hosting list.


<img width="1713" height="923" alt="image (113)" src="https://github.com/user-attachments/assets/e2d705e5-5e7d-4da6-9193-9248fabf5435" />
<img width="1710" height="929" alt="image (114)" src="https://github.com/user-attachments/assets/caba6e03-9d21-4be1-9494-7f0e97b3732e" />
