### PR TITLE
Update 3rd party instructions re Fly.io install

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -134,4 +134,4 @@ $ helm upgrade \
 * [*Docker on Rocky Linux 8* (nginx, Let's Encrypt SSL)](https://wiki.crowncloud.net/?How_to_Install_Listmonk_with_Docker_on_Rocky_Linux_8)
 * [*Docker* with nginx reverse proxy, certbot SSL, and Gmail SMTP](https://www.maketecheasier.com/create-own-newsletter-with-listmonk/)
 * [Install Listmonk on Self-hosting with *Pre-Configured AMI Package at AWS* by Single Click](https://meetrix.io/articles/how-to-install-llama-2-on-aws-with-pre-configured-ami-package/)
-* [Tutorial for deploying on *Fly.io*](https://github.com/paulrudy/listmonk-on-fly) -- Currently [not working](https://github.com/knadh/listmonk/issues/984#issuecomment-1694545255)
+* [*Fly.io* working example](https://gitlab.com/votelog/apps/newsletter)


### PR DESCRIPTION
My tutorial hasn't worked since 2023 (I haven't been using Listmonk since 2022).

Based on [this comment thread](https://github.com/knadh/listmonk/issues/984) where the problem was reported, I'm proposing that the docs instead point to the [repo](https://gitlab.com/votelog/apps/newsletter) that @salim-b shared in [this comment](https://github.com/knadh/listmonk/issues/984#issuecomment-1758843501) on the same thread.