### PR TITLE
Fix duplicate operationId in OpenAPI spec

### DIFF
--- a/docs/swagger/collections.yaml
+++ b/docs/swagger/collections.yaml
@@ -1942,7 +1942,7 @@ paths:
   "/templates/{id}/default":
     put:
       description: handles template modification.
-      operationId: updateTemplateById
+      operationId: setDefaultTemplateById
       tags:
         - Templates
       parameters:


### PR DESCRIPTION
Resolves issue #2729 where duplicate operationIds caused TypeScript type generation failures

- Changed the `operationId` for the `PUT /templates/{id}/default` endpoint from `updateTemplateById` to `setDefaultTemplateById` in `docs/swagger/collections.yaml`
- Both template endpoints now have unique operationIds as required by OpenAPI spec
