### PR TITLE
Change LISTMONK_db__host from 'listmonk_db' to 'db'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       LISTMONK_db__user: *db-user
       LISTMONK_db__password: *db-password
       LISTMONK_db__database: *db-name
-      LISTMONK_db__host: listmonk_db
+      LISTMONK_db__host: db
       LISTMONK_db__port: 5432
       LISTMONK_db__ssl_mode: disable
       LISTMONK_db__max_open: 25


### PR DESCRIPTION
As the db host is in the same network the  service db is just fine,  using teh container name  works but when using docker-dompose.yml in  Coolify, coolify automatically  rewrites the container names when setting up reverse proxy.  By makingthis small change simplifies deploymnet in Coolify.