### PR TITLE
Respect SOURCE_DATE_EPOCH when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ LAST_COMMIT := $(or $(shell git rev-parse --short HEAD 2> /dev/null),$(shell hea
 # Try to get the semver from 1) git 2) the VERSION file 3) fallback.
 VERSION := $(or $(LISTMONK_VERSION),$(shell git describe --tags --abbrev=0 2> /dev/null),$(shell grep -oP 'tag: \Kv\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?' VERSION),"v0.0.0")
 
-BUILDSTR := ${VERSION} (\#${LAST_COMMIT} $(shell date -u +"%Y-%m-%dT%H:%M:%S%z"))
+ifdef SOURCE_DATE_EPOCH
+	BUILDSTR := ${VERSION} (\#${LAST_COMMIT})
+else
+	BUILDSTR := ${VERSION} (\#${LAST_COMMIT} $(shell date -u +"%Y-%m-%dT%H:%M:%S%z"))
+endif
 
 YARN ?= yarn
 GOPATH ?= $(HOME)/go


### PR DESCRIPTION
To make the build reproducable (see [0]), respect the SOURCE_DATE_EPOCH variable and don't include a build timestammp in the binary when set.

[0] https://reproducible-builds.org/