### PR TITLE
fix confusing formatting issue in dev setup docs

### DIFF
--- a/docs/docs/content/developer-setup.md
+++ b/docs/docs/content/developer-setup.md
@@ -24,16 +24,19 @@ After setting up the dev environment, you can visit `http://localhost:8080`.
 
 
 1. Locally
-- Run `make run` to start the listmonk dev server on `:9000`.
-- Run `make run-frontend` to start the Vue frontend in dev mode using yarn on `:8080`. All `/api/*` calls are proxied to the app running on `:9000`. Refer to the [frontend README](https://github.com/knadh/listmonk/blob/master/frontend/README.md) for an overview on how the frontend is structured.
+
+    - Run `make run` to start the listmonk dev server on `:9000`.
+    - Run `make run-frontend` to start the Vue frontend in dev mode using yarn on `:8080`. All `/api/*` calls are proxied to the app running on `:9000`. Refer to the [frontend README](https://github.com/knadh/listmonk/blob/master/frontend/README.md) for an overview on how the frontend is structured.
 
 2. Inside containers (Using Makefile)
-- Run `make init-dev-docker` to setup container for db.
-- Run `make dev-docker` to setup docker container suite.
-- Run `make rm-dev-docker` to clean up docker container suite.
+
+    - Run `make init-dev-docker` to setup container for db.
+    - Run `make dev-docker` to setup docker container suite.
+    - Run `make rm-dev-docker` to clean up docker container suite.
 
 3. Inside containers (Using devcontainer)
-- Open repo in vscode, open command palette, and select "Dev Containers: Rebuild and Reopen in Container".
+
+    - Open repo in vscode, open command palette, and select "Dev Containers: Rebuild and Reopen in Container".
 
 It will set up db, and start frontend/backend for you.
 


### PR DESCRIPTION
Before:
<img width="916" height="594" alt="image" src="https://github.com/user-attachments/assets/17efddad-5afe-4c9c-8e01-d808511a458b" />


After:
<img width="879" height="598" alt="image" src="https://github.com/user-attachments/assets/b0bed7a3-eb5c-4a2d-8baf-77023a078b65" />
