### PR TITLE
Convert Dockerfile to multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 **/.dockerignore
 **/.env
 **/.git
-**/.gitignore
 **/.project
 **/.settings
 **/.toolstarget

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,31 @@
+# Build stage
+FROM golang:alpine AS builder
+
+# Install build dependencies
+RUN apk --no-cache add git make nodejs npm yarn
+
+# Set the working directory
+WORKDIR /app
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN go install github.com/knadh/stuffbin/... && \
+    make dist
+
+# Runtime stage
 FROM alpine:latest
 
-# Install dependencies
+# Install runtime dependencies
 RUN apk --no-cache add ca-certificates tzdata shadow su-exec
 
 # Set the working directory
 WORKDIR /listmonk
 
-# Copy only the necessary files
-COPY listmonk .
-COPY config.toml.sample config.toml
+# Copy only the necessary files from builder
+COPY --from=builder /app/listmonk .
+COPY --from=builder /app/config.toml.sample config.toml
 
 # Copy the entrypoint script
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
This PR converts the Dockerfile to use a multi-stage build, enabling fully self-contained Docker builds without requiring local Go installation.

## Changes
- Add build stage using `golang:alpine` to compile the binary and frontend
- Install `stuffbin` and run `make dist` in the build stage
- Copy only the compiled binary to the runtime stage
- Remove `.gitignore` from `.dockerignore` (required for frontend eslint)

## Benefits
- Users can build the Docker image without installing Go locally
- Smaller final image size (excludes build tools and dependencies)
- Reproducible builds in CI/CD environments
- Follows Docker best practices for multi-stage builds

## Testing
Tested successfully with:
```bash
docker build -t listmonk:latest .
```

The build completes successfully and produces a working image.