### PR TITLE
fix: Update dev Dockerfile to use Go 1.24.1 to match go.mod

### DIFF
--- a/dev/app.Dockerfile
+++ b/dev/app.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS go
+FROM golang:1.24.1 AS go
 
 FROM node:16 AS node
 


### PR DESCRIPTION
Fixes the mismatch between go.mod (Go 1.24.1) and dev/app.Dockerfile (Go 1.20).

The commit f310131 updated go.mod and GitHub Actions workflows to Go 1.24.1, but missed updating the dev Dockerfile. This caused Docker-based local development to fail with:

```
go: errors parsing go.mod:
/app/go.mod:3: invalid go version '1.24.1': must match format 1.23
```

This PR updates dev/app.Dockerfile to use golang:1.24.1 to match the Go version specified in go.mod.