### PR TITLE
ignore docker compose override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ static/public/static/altcha.umd.js
 .vscode/
 
 config.toml
+docker-compose.override.yml
 node_modules
 listmonk
 dist/*


### PR DESCRIPTION
docker-compose.override.yml is the official solution to environment-specific and intended for local customization (ports, volumes, debug flags, credentials, experimental services).

Reasons to ignore it:
- Prevent committing machine-specific 
- Avoid leaking local paths.
- Keep the base docker-compose.yml reproducible across environments.
- Allow each developer to override services without affecting others.
- Reduce merge conflicts from personal adjustments.

The base compose file stays versioned. Overrides remain local.