### PR TITLE
Add Hodor AI code review workflow

### DIFF
--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -1,0 +1,30 @@
+name: Hodor AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - 'i18n/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitignore'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Hodor review
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/mr-karan/hodor:0.2.14
+          options: >-
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            -e LLM_API_KEY=${{ secrets.LLM_API_KEY }}
+          run: |
+            hodor "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
+              --model "${{ vars.HODOR_MODEL || 'gpt-5.2' }}" \
+              --post


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs [Hodor](https://github.com/mr-karan/hodor), an agentic AI code reviewer, on pull requests.

- Runs automatically on PR open/push, skips i18n-only and docs-only changes via `paths-ignore`.
- Model is configurable via the `HODOR_MODEL` repository variable (e.g. `openrouter/google/gemini-3.1-pro-preview`, `anthropic/claude-sonnet-4-5-20250929`). Defaults to `gpt-5.2`.
- Posts review as a PR comment.

## Setup required

@knadh — one secret needs to be added in repo Settings > Secrets and variables > Actions:

- **`LLM_API_KEY`**: API key for the LLM provider (OpenAI, Anthropic, Google, OpenRouter, etc.)

Optionally set the `HODOR_MODEL` repository **variable** to override the default model.

## Test plan

- [x] Tested on https://github.com/mr-karan/listmonk/pull/1