### PR TITLE
Fix right-aligned 'Link Clicks' heading on dashboard.

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -127,7 +127,7 @@
                   <chart type="line" v-if="campaignViews" :data="campaignViews" />
                 </div>
                 <div class="column is-6">
-                  <h3 class="title is-size-6 has-text-right">
+                  <h3 class="title is-size-6">
                     {{ $t('dashboard.linkClicks') }}
                   </h3><br />
                   <chart type="line" v-if="campaignClicks" :data="campaignClicks" />


### PR DESCRIPTION
Removes the `has-text-right` class from the second chart heading so it aligns consistently with the 'Campaign Views' heading on the left.