### PR TITLE
Updated Danish translation

### DIFF
--- a/i18n/da.json
+++ b/i18n/da.json
@@ -5,7 +5,7 @@
     "analytics.count": "Tæl",
     "analytics.fromDate": "Fra",
     "analytics.invalidDates": "Ugyldig `fra`- eller `til`-dato.",
-    "analytics.isUnique": "Antal er er unikt pr. abonnent.",
+    "analytics.isUnique": "Antal er unikt pr. abonnent.",
     "analytics.links": "Links",
     "analytics.nonUnique": "Antallet er ikke unikt da sporing af individuelle abonnenter er deaktiveret.",
     "analytics.title": "Statistik",


### PR DESCRIPTION
There was a lot of spelling- and space-errors, a number of wrong translations and sub-optimal choices of translation.