### PR TITLE
Standardize spelling of "opt-in" in docs.

### DIFF
--- a/docs/docs/content/apis/subscribers.md
+++ b/docs/docs/content/apis/subscribers.md
@@ -301,13 +301,13 @@ Create a new subscriber.
 ##### Parameters
 
 | Name                     | Type       | Required | Description                                                                                                                   |
-| :----------------------- | :--------- | :------- | :---------------------------------------------------------------------------------------------------------------------------- |
+|:-------------------------|:-----------|:---------|:------------------------------------------------------------------------------------------------------------------------------|
 | email                    | string     | Yes      | Subscriber's email address.                                                                                                   |
 | name                     | string     | Yes      | Subscriber's name.                                                                                                            |
 | status                   | string     | Yes      | Subscriber's status: `enabled`, `blocklisted`.                                                                                |
 | lists                    | number\[\] |          | List of list IDs to subscribe to.                                                                                             |
 | attribs                  | JSON       |          | Optional JSON object attributes for the subscriber that can be used in message templates. Example `{"location": "Somewhere"}` |
-| preconfirm_subscriptions | bool       |          | If true, subscriptions are marked as confirmed and no-optin emails are sent for double opt-in lists.                          |
+| preconfirm_subscriptions | bool       |          | If true, subscriptions are marked as confirmed and no opt-in emails are sent for double opt-in lists.                         |
 
 ##### Example Request
 
@@ -342,7 +342,7 @@ ______________________________________________________________________
 
 #### POST /api/subscribers/{subscribers_id}/optin
 
-Sends optin confirmation email to subscribers.
+Sends opt-in confirmation email to subscribers.
 
 ##### Example Request
 

--- a/docs/docs/content/concepts.md
+++ b/docs/docs/content/concepts.md
@@ -26,12 +26,11 @@ Attributes are arbitrary properties attached to a subscriber in addition to thei
 
 A subscriber can be added to one or more lists, and each such relationship can have one of these statuses.
 
-| Status        | Description                                                                       |
-| ------------- | --------------------------------------------------------------------------------- |
-| `unconfirmed` | The subscriber was added to the list directly without their explicit confirmation. Nonetheless, the subscriber will receive campaign messages sent to single optin campaigns. |
-| `confirmed`   | The subscriber confirmed their subscription by clicking on 'accept' in the confirmation e-mail. Only confirmed subscribers in opt-in lists will receive campaign messages send to the list.                                       |
-| `unsubscribed` | The subscriber is unsubscribed from the list and will not receive any campaign messages sent to the list.
-
+| Status         | Description                                                                                                                                                                                 |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `unconfirmed`  | The subscriber was added to the list directly without their explicit confirmation. Nonetheless, the subscriber will receive campaign messages sent to single opt-in campaigns.              |
+| `confirmed`    | The subscriber confirmed their subscription by clicking on 'accept' in the confirmation e-mail. Only confirmed subscribers in opt-in lists will receive campaign messages send to the list. |
+| `unsubscribed` | The subscriber is unsubscribed from the list and will not receive any campaign messages sent to the list.                                                                                   |
 
 ### Segmentation
 
@@ -39,7 +38,7 @@ Segmentation is the process of filtering a large list of subscribers into a smal
 
 ## List
 
-A list (or a _mailing list_) is a collection of subscribers grouped under a name, for instance, _clients_. Lists are used to organise subscribers and send e-mails to specific groups. A list can be single optin or double optin. Subscribers added to double optin lists have to explicitly accept the subscription by clicking on the confirmation e-mail they receive. Until then, they do not receive campaign messages.
+A list (or a _mailing list_) is a collection of subscribers grouped under a name, for instance, _clients_. Lists are used to organise subscribers and send e-mails to specific groups. A list can be single opt-in or double opt-in. Subscribers added to double opt-in lists have to explicitly accept the subscription by clicking on the confirmation e-mail they receive. Until then, they do not receive campaign messages.
 
 ## Campaign
 

--- a/docs/docs/content/templating.md
+++ b/docs/docs/content/templating.md
@@ -42,16 +42,16 @@ There are several template functions and expressions that can be used in campaig
 
 ### Functions
 
-| Function                                    | Description                                                                                                                                                    |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{{ Date "2006-01-01" }}`                   | Prints the current datetime for the given format expressed as a [Go date layout](https://yourbasic.org/golang/format-parse-string-time-date-example/) |
-| `{{ TrackLink "https://link.com" }}` | Takes a URL and generates a tracking URL over it. For use in campaign bodies and templates.                                                                    |
-| `https://link.com@TrackLink`         | Shorthand for `TrackLink`. Eg: `<a href="https://link.com@TrackLink">Link</a>`                                                                       |
-| `{{ TrackView }}`                           | Inserts a single tracking pixel. Should only be used once, ideally in the template footer.                                                                     |
-| `{{ UnsubscribeURL }}`                      | Unsubscription and Manage preferences URL. Ideal for use in the template footer.                                                                                                      |
-| `{{ MessageURL }}`                          | URL to view the hosted version of an e-mail message.                                                                                                           |
-| `{{ OptinURL }}`                            | URL to the double-optin confirmation page.                                                                                                                     |
-| `{{ Safe "<!-- comment -->" }}`             | Add any HTML code as it is.                                                                                                                                   |
+| Function                             | Description                                                                                                                                           |
+|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `{{ Date "2006-01-01" }}`            | Prints the current datetime for the given format expressed as a [Go date layout](https://yourbasic.org/golang/format-parse-string-time-date-example/) |
+| `{{ TrackLink "https://link.com" }}` | Takes a URL and generates a tracking URL over it. For use in campaign bodies and templates.                                                           |
+| `https://link.com@TrackLink`         | Shorthand for `TrackLink`. Eg: `<a href="https://link.com@TrackLink">Link</a>`                                                                        |
+| `{{ TrackView }}`                    | Inserts a single tracking pixel. Should only be used once, ideally in the template footer.                                                            |
+| `{{ UnsubscribeURL }}`               | Unsubscription and Manage preferences URL. Ideal for use in the template footer.                                                                      |
+| `{{ MessageURL }}`                   | URL to view the hosted version of an e-mail message.                                                                                                  |
+| `{{ OptinURL }}`                     | URL to the double opt-in confirmation page.                                                                                                           |
+| `{{ Safe "<!-- comment -->" }}`      | Add any HTML code as it is.                                                                                                                           |
 
 ### Sprig functions
 listmonk integrates the Sprig library that offers 100+ utility functions for working with strings, numbers, dates etc. that can be used in templating. Refer to the [Sprig documentation](https://masterminds.github.io/sprig/) for the full list of functions.


### PR DESCRIPTION
Always "opt-in".
Always "double opt-in".
Never "optin".
Never "double-optin".

Doesn't apply to code because of many edge cases (e.g. `optinType` and "optin type")