### PR TITLE
feat: add Lettermint SMTP preset

### DIFF
--- a/frontend/src/views/settings/smtp.vue
+++ b/frontend/src/views/settings/smtp.vue
@@ -74,6 +74,7 @@
               <a href="#" @click.prevent="() => fillSettings(n, 'sendgrid')">Sendgrid</a>
               <a href="#" @click.prevent="() => fillSettings(n, 'postmark')">Postmark</a>
               <a href="#" @click.prevent="() => fillSettings(n, 'forwardemail')">Forward Email</a>
+              <a href="#" @click.prevent="() => fillSettings(n, 'lettermint')">Lettermint</a>
             </div>
             <hr />
 
@@ -235,6 +236,9 @@ const smtpTemplates = {
   },
   postmark: {
     host: 'smtp.postmarkapp.com', port: 587, auth_protocol: 'cram', tls_type: 'STARTTLS',
+  },
+  lettermint: {
+    host: 'smtp.lettermint.co', port: 465, auth_protocol: 'login', tls_type: 'TLS',
   },
 };
 


### PR DESCRIPTION
Adds [Lettermint](https://lettermint.co) (European provider) as an SMTP provider shortcut in the settings page.

Preset: `smtp.lettermint.co`, port 465, LOGIN auth, SSL/TLS.

<img width="1497" height="725" alt="Screenshot 2026-03-03 at 19 00 39" src="https://github.com/user-attachments/assets/fb7540a9-20b3-4146-a0bd-114cf425577e" />