### PR TITLE
Minimal implementation of a PATCH endpoint for subscribers.

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -121,6 +121,7 @@ func initHTTPHandlers(e *echo.Echo, a *App) {
 		g.GET("/api/subscribers/:id/bounces", pm(hasID(a.GetSubscriberBounces), "bounces:get"))
 		g.DELETE("/api/subscribers/:id/bounces", pm(hasID(a.DeleteSubscriberBounces), "bounces:manage"))
 		g.POST("/api/subscribers", pm(a.CreateSubscriber, "subscribers:manage"))
+		g.PATCH("/api/subscribers/:id", pm(hasID(a.PatchSubscriber), "subscribers:manage"))
 		g.PUT("/api/subscribers/:id", pm(hasID(a.UpdateSubscriber), "subscribers:manage"))
 		g.POST("/api/subscribers/:id/optin", pm(hasID(a.SubscriberSendOptin), "subscribers:manage"))
 		g.PUT("/api/subscribers/blocklist", pm(a.BlocklistSubscribers, "subscribers:manage"))

--- a/cmd/subscribers.go
+++ b/cmd/subscribers.go
@@ -244,6 +244,35 @@ func (a *App) CreateSubscriber(c echo.Context) error {
 	return c.JSON(http.StatusOK, okResp{sub})
 }
 
+// PatchSubscriber handles patching of a subscriber
+// Currently only supports changing the email address.
+func (a *App) PatchSubscriber(c echo.Context) error {
+
+	// Get and validate fields.
+	req := struct {
+		models.Subscriber
+	}{}
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	// Sanitize and validate the email field.
+	if em, err := a.importer.SanitizeEmail(req.Email); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	} else {
+		req.Email = em
+	}
+
+	// Update the subscriber in the DB.
+	id := getID(c)
+	out, err := a.core.PatchSubscriber(id, req.Subscriber)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, okResp{out})
+}
+
 // UpdateSubscriber handles modification of a subscriber.
 func (a *App) UpdateSubscriber(c echo.Context) error {
 	// Get the authenticated user.

--- a/docs/docs/content/apis/subscribers.md
+++ b/docs/docs/content/apis/subscribers.md
@@ -1,7 +1,7 @@
 # API / Subscribers
 
 | Method | Endpoint                                                                                | Description                                    |
-| ------ | --------------------------------------------------------------------------------------- | ---------------------------------------------- |
+|--------|-----------------------------------------------------------------------------------------|------------------------------------------------|
 | GET    | [/api/subscribers](#get-apisubscribers)                                                 | Query and retrieve subscribers.                |
 | GET    | [/api/subscribers/{subscriber_id}](#get-apisubscriberssubscriber_id)                    | Retrieve a specific subscriber.                |
 | GET    | [/api/subscribers/{subscriber_id}/export](#get-apisubscriberssubscriber_idexport)       | Export a specific subscriber.                  |
@@ -11,6 +11,7 @@
 | POST   | [/api/public/subscription](#post-apipublicsubscription)                                 | Create a public subscription.                  |
 | PUT    | [/api/subscribers/lists](#put-apisubscriberslists)                                      | Modify subscriber list memberships.            |
 | PUT    | [/api/subscribers/{subscriber_id}](#put-apisubscriberssubscriber_id)                    | Update a specific subscriber.                  |
+| PATCH  | [/api/subscribers/{subscriber_id}](#patch-apisubscriberssubscriber_id)                  | Patch a specific subscriber.                   |
 | PUT    | [/api/subscribers/{subscriber_id}/blocklist](#put-apisubscriberssubscriber_idblocklist) | Blocklist a specific subscriber.               |
 | PUT    | [/api/subscribers/blocklist](#put-apisubscribersblocklist)                              | Blocklist one or many subscribers.             |
 | PUT    | [/api/subscribers/query/blocklist](#put-apisubscribersqueryblocklist)                   | Blocklist subscribers based on SQL expression. |
@@ -434,6 +435,21 @@ ______________________________________________________________________
 Update a specific subscriber.
 
 > Refer to parameters from [POST /api/subscribers](#post-apisubscribers). Note: All parameters must be set, if not, the subscriber will be removed from all previously assigned lists.
+
+______________________________________________________________________
+
+#### PATCH /api/subscribers/{subscriber_id}
+
+Patch a specific subscriber.
+It is only possible to change the subscriber's email address at this time.
+
+##### Parameters
+
+| Name  | Type   | Required | Description                 |
+|:------|:-------|:---------|:----------------------------|
+| email | string | Yes      | Subscriber's email address. |
+
+_________________________________________________________________
 
 ______________________________________________________________________
 

--- a/internal/core/subscribers.go
+++ b/internal/core/subscribers.go
@@ -382,6 +382,26 @@ func (c *Core) UpdateSubscriber(id int, sub models.Subscriber) (models.Subscribe
 	return out, nil
 }
 
+// PatchSubscriber patches a subscriber's properties.
+// Currently only supports changing the email address.
+func (c *Core) PatchSubscriber(id int, sub models.Subscriber) (models.Subscriber, error) {
+
+	_, err := c.q.PatchSubscriber.Exec(id,
+		sub.Email)
+	if err != nil {
+		c.log.Printf("error patching subscriber: %v", err)
+		return models.Subscriber{}, echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorUpdating", "name", "{globals.terms.subscriber}", "error", pqErrMsg(err)))
+	}
+
+	out, err := c.GetSubscriber(sub.ID, "", sub.Email)
+	if err != nil {
+		return models.Subscriber{}, err
+	}
+
+	return out, nil
+}
+
 // UpdateSubscriberWithLists updates a subscriber's properties.
 // If deleteLists is set to true, all existing subscriptions are deleted and only
 // the ones provided are added or retained.

--- a/models/queries.go
+++ b/models/queries.go
@@ -23,6 +23,7 @@ type Queries struct {
 	GetSubscriberLists              *sqlx.Stmt `query:"get-subscriber-lists"`
 	GetSubscriptions                *sqlx.Stmt `query:"get-subscriptions"`
 	GetSubscriberListsLazy          *sqlx.Stmt `query:"get-subscriber-lists-lazy"`
+	PatchSubscriber                 *sqlx.Stmt `query:"patch-subscriber"`
 	UpdateSubscriber                *sqlx.Stmt `query:"update-subscriber"`
 	UpdateSubscriberWithLists       *sqlx.Stmt `query:"update-subscriber-with-lists"`
 	BlocklistSubscribers            *sqlx.Stmt `query:"blocklist-subscribers"`

--- a/queries/subscribers.sql
+++ b/queries/subscribers.sql
@@ -157,6 +157,13 @@ UPDATE subscribers SET
     updated_at=NOW()
 WHERE id = $1;
 
+-- name: patch-subscriber
+-- Patches a subscriber's data
+UPDATE subscribers SET
+    email=(CASE WHEN $2 != '' THEN $2 ELSE email END),
+    updated_at=NOW()
+WHERE id = $1 RETURNING id;
+
 -- name: update-subscriber-with-lists
 -- Updates a subscriber's data, and given a list of list_ids, inserts subscriptions
 -- for them while deleting existing subscriptions not in the list.


### PR DESCRIPTION
This minimal implementation focused on a common scenario where a subscriber updates their email address in an external system and that change must be reflected in ListMonk.

I think this endpoint is sorely needed as a safer alternative to the existing `PUT` endpoint which has the ability to destroy `List` associations.

Please see related issue https://github.com/knadh/listmonk/issues/2893.