### PR TITLE
Fix Hodor workflow: use pull_request_target for fork PR secret access

### DIFF
--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -1,7 +1,7 @@
 name: Hodor AI Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     paths-ignore:
       - 'i18n/**'
@@ -15,12 +15,13 @@ permissions:
 
 jobs:
   review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Run Hodor review
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/mr-karan/hodor:0.2.14
+          image: ghcr.io/mr-karan/hodor:0.3.2
           options: >-
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             -e LLM_API_KEY=${{ secrets.LLM_API_KEY }}


### PR DESCRIPTION
## Problem

The Hodor workflow merged in #2923 uses `pull_request` as the trigger. Since all PRs to this repo come from forks, GitHub does not expose repository secrets (`LLM_API_KEY`) to `pull_request` workflows — the secret resolves to an empty string and Hodor fails with "No LLM API key found."

Ref: https://github.com/knadh/listmonk/actions/runs/22636648455/job/65601159553

## Fix

- Switch trigger from `pull_request` to `pull_request_target`. This runs the workflow in the context of the base branch (master), which has access to repo secrets. Since the workflow never checks out or executes code from the PR (Hodor clones the repo itself inside a Docker container), this is safe.
- Skip Dependabot PRs (`github.actor != 'dependabot[bot]'`) — Dependabot has its own secret store and doesn't need AI code review.
- Upgrade Hodor from `0.2.14` to `0.3.2`.