### PR TITLE
Fix Hodor workflow for v0.3.2

### DIFF
--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -19,13 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Hodor review
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ghcr.io/mr-karan/hodor:0.3.2
-          options: >-
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            -e LLM_API_KEY=${{ secrets.LLM_API_KEY }}
-          run: |
-            hodor "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
-              --model "${{ vars.HODOR_MODEL || 'gpt-5.2' }}" \
-              --post
+        run: |
+          docker run --rm \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e LLM_API_KEY=${{ secrets.LLM_API_KEY }} \
+            ghcr.io/mr-karan/hodor:0.3.2 \
+            "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
+            --model "${{ vars.HODOR_MODEL || 'gpt-5.2' }}" \
+            --post


### PR DESCRIPTION
Hodor v0.3.2 changed its entrypoint from a Python CLI to `bun run dist/cli.js`. The `addnab/docker-run-action` overrides the entrypoint with `sh -c`, causing `hodor: not found`.

Switch to `docker run` directly which preserves the container's entrypoint.

Tested: https://github.com/mr-karan/listmonk/pull/2