### PR TITLE
Hodor: require hodor-review label to trigger

### DIFF
--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -2,7 +2,7 @@ name: Hodor AI Code Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [labeled, synchronize]
     paths-ignore:
       - 'i18n/**'
       - '*.md'
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   review:
-    if: github.actor != 'dependabot[bot]'
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'hodor-review') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'hodor-review'))
     runs-on: ubuntu-latest
     steps:
       - name: Run Hodor review
@@ -23,7 +25,7 @@ jobs:
           docker run --rm \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e LLM_API_KEY=${{ secrets.LLM_API_KEY }} \
-            ghcr.io/mr-karan/hodor:0.3.2 \
+            ghcr.io/mr-karan/hodor:0.3.3 \
             "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
             --model "${{ vars.HODOR_MODEL || 'gpt-5.2' }}" \
             --post


### PR DESCRIPTION
Only run Hodor when the `hodor-review` label is added to a PR. Subsequent pushes to that PR will re-run automatically as long as the label is present.

Prevents unwanted LLM costs from random/spam PRs.