### PR TITLE
Bump Hodor to 0.3.4

### DIFF
--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -25,7 +25,7 @@ jobs:
           docker run --rm \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e LLM_API_KEY=${{ secrets.LLM_API_KEY }} \
-            ghcr.io/mr-karan/hodor:0.3.3 \
+            ghcr.io/mr-karan/hodor:0.3.4 \
             "https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
             --model "${{ vars.HODOR_MODEL || 'gpt-5.2' }}" \
             --post


### PR DESCRIPTION
Adds python3, shellcheck, file, and diffstat to the review container. Fixes agent failures when it tries to use these tools during review.