### PR TITLE
Fix POP bounce parsing failing on emails with UTF-8 BOM

### DIFF
--- a/internal/bounce/mailbox/pop.go
+++ b/internal/bounce/mailbox/pop.go
@@ -1,6 +1,7 @@
 package mailbox
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,9 @@ import (
 	"github.com/knadh/go-pop3"
 	"github.com/knadh/listmonk/models"
 )
+
+// UTF-8 BOM (Byte Order Mark) that some mail servers/proxies prepend to messages.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 // POP represents a POP mailbox.
 type POP struct {
@@ -114,8 +118,11 @@ func (p *POP) Scan(limit int, ch chan models.Bounce) error {
 			continue
 		}
 
+		// Strip UTF-8 BOM if present (some mail servers/proxies like Office 365 add this).
+		rawBytes := bytes.TrimPrefix(b.Bytes(), utf8BOM)
+
 		// Parse the message.
-		m, err := message.Read(b)
+		m, err := message.Read(bytes.NewReader(rawBytes))
 		if err != nil {
 			p.lo.Printf("error parsing bounce message %d: %v", id, err)
 			continue


### PR DESCRIPTION
Some mail servers and proxies (notably Office 365 via [email-oauth2-proxy](https://github.com/simonrob/email-oauth2-proxy)) prepend a UTF-8 BOM (0xEF 0xBB 0xBF) to email messages. This causes the mail parser to fail with: "malformed MIME header key: ﻿Received"

The BOM bytes are interpreted as part of the first header name and making it invalid.

This fix strips the UTF-8 BOM from the raw message bytes before parsing. The bytes.TrimPrefix function is a no-op if the BOM is not present, so this change should be safe for all mail providers.