### PR TITLE
Change wrapper min-height to 100%

### DIFF
--- a/frontend/src/assets/style.scss
+++ b/frontend/src/assets/style.scss
@@ -203,7 +203,7 @@ section {
   .wrapper {
     display: flex;
     flex-direction: row;
-    min-height: 100vh;
+    min-height: 100%;
     margin-top: 0px;
   }
 


### PR DESCRIPTION
there was an annoying scrolling on the pages where the content was not long enough to cause the scroll.