### PR TITLE
Update Lettermint webhook documentation link

### DIFF
--- a/docs/docs/content/bounces.md
+++ b/docs/docs/content/bounces.md
@@ -51,7 +51,7 @@ listmonk supports receiving bounce webhook events from the following SMTP provid
 | `https://listmonk.yoursite.com/webhooks/service/sendgrid`     | Sendgrid / Twilio Signed event webhook | [More info](https://docs.sendgrid.com/for-developers/tracking-events/getting-started-event-webhook-security-features) |
 | `https://listmonk.yoursite.com/webhooks/service/postmark`     | Postmark webhook                       | [More info](https://postmarkapp.com/developer/webhooks/webhooks-overview)                                             |
 | `https://listmonk.yoursite.com/webhooks/service/forwardemail` | Forward Email webhook                  | [More info](https://forwardemail.net/en/faq#do-you-support-bounce-webhooks)                                           |
-| `https://listmonk.yoursite.com/webhooks/service/lettermint`   | Lettermint webhook                     | [More info](https://docs.lettermint.co/platform/webhooks/introduction)                                                |
+| `https://listmonk.yoursite.com/webhooks/service/lettermint`   | Lettermint webhook                     | [More info](https://lettermint.co/knowledge-base/guides/send-newsletter-with-listmonk)                                                |
 
 ## Amazon Simple Email Service (SES)
 


### PR DESCRIPTION
Updated Lettermint webhook link (More info) to point to the listmonk integration guide instead of a generic webhooks introduction page.