### PR TITLE
fix: prevent nil pointer crash in BounceWebhook when bounce processing disabled

### DIFF
--- a/cmd/bounce.go
+++ b/cmd/bounce.go
@@ -113,8 +113,15 @@ func (a *App) BlocklistBouncedSubscribers(c echo.Context) error {
 	return c.JSON(http.StatusOK, okResp{true})
 }
 
-// BounceWebhook renders the HTML preview of a template.
+// BounceWebhook handles incoming bounce webhook notifications from various providers.
 func (a *App) BounceWebhook(c echo.Context) error {
+	// If bounce processing is disabled, a.bounce will be nil.
+	// Return early to prevent nil pointer dereference.
+	if a.bounce == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable,
+			a.i18n.Ts("globals.messages.internalError"))
+	}
+
 	// Read the request body instead of using c.Bind() to read to save the entire raw request as meta.
 	rawReq, err := io.ReadAll(c.Request().Body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds nil check for `a.bounce` at the start of `BounceWebhook`
- Returns HTTP 503 with error message instead of crashing
- Prevents nil pointer dereference for all providers (SES, SendGrid, Postmark, ForwardEmail, Lettermint)

Fixes #2983

## Root Cause
Commit f1649b3 changed validation from config booleans to nil checks on bounce manager fields. When `bounce.enabled` is false, `a.bounce` is never instantiated, causing a nil pointer crash on any webhook request to `/api/webhooks/bounce/:service`.

## Changes
- Added nil check for `a.bounce` at the beginning of `BounceWebhook` in `cmd/bounce.go`
- Returns `http.StatusServiceUnavailable` (503) with an appropriate error message when bounce processing is not enabled
- Fixed misleading comment on the function (was referencing template preview)

## Testing
- When `bounce.enabled = false`: webhook requests return 503 instead of crashing
- When `bounce.enabled = true`: no behavioral change, existing flow unchanged