### PR TITLE
Fixs #2987 - Prevent confirmed subscriber becoming unconfirmed when re-subscribing.

### DIFF
--- a/queries/subscribers.sql
+++ b/queries/subscribers.sql
@@ -189,11 +189,12 @@ INSERT INTO subscriber_lists (subscriber_id, list_id, status)
     SET status = (
         CASE
             WHEN $4='blocklisted' THEN 'unsubscribed'::subscription_status
-            -- When $11 (allow resubscribe) is true, override existing statuses (used by public subscription form).
+            -- When $11 (allow resubscribe) is true, override existing statuses except confirmed (used by
+            -- public subscription form).
+            WHEN subscriber_lists.status = 'confirmed' THEN 'confirmed'
             WHEN $11 = TRUE THEN $8::subscription_status
             -- When subscriber is edited from the admin form, retain the status. Otherwise, a blocklisted
             -- subscriber when being re-enabled, their subscription statuses change.
-            WHEN subscriber_lists.status = 'confirmed' THEN 'confirmed'
             WHEN subscriber_lists.status = 'unsubscribed' THEN 'unsubscribed'::subscription_status
             ELSE $8::subscription_status
         END


### PR DESCRIPTION
This closes #2987 or at least fixes the fix of the regression identified in #2976

A confirmed double opt-in subscriber is no-longer unsubscribed if they re-subscribe to the list (while still subscribed and confirmed).

This doesn't address the discussion point of not leaking information about subscriber status as a confirmed subscriber on a double opt-in list will now get the message "Subscribed successfully." rather than "An e-mail has been sent to you to confirm your subscription(s)." to avoid leaking information about subscription status". 

However this was how things have always been and would be a larger piece of work/ restructuring. A work around is adjusting the messages in the i18n language file to remove the difference between the messages.