### PR TITLE
fix(analytics): correct per-campaign unique view counting

### DIFF
--- a/queries/campaigns.sql
+++ b/queries/campaigns.sql
@@ -237,10 +237,10 @@ WITH intval AS (
     SELECT CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END
 ),
 uniqIDs AS (
-    SELECT DISTINCT ON(subscriber_id) subscriber_id, campaign_id, DATE_TRUNC((SELECT * FROM intval), created_at) AS "timestamp"
+    SELECT DISTINCT ON(subscriber_id, campaign_id) subscriber_id, campaign_id, DATE_TRUNC((SELECT * FROM intval), created_at) AS "timestamp"
     FROM %s
     WHERE campaign_id=ANY($1) AND created_at >= $2 AND created_at <= $3
-    ORDER BY subscriber_id, "timestamp"
+    ORDER BY subscriber_id, campaign_id, "timestamp"
 )
 SELECT COUNT(*) AS "count", campaign_id, "timestamp"
     FROM uniqIDs GROUP BY campaign_id, "timestamp" ORDER BY "timestamp" ASC;


### PR DESCRIPTION
Fixes #3023

## Bug
When `privacy.individual_tracking` is enabled, requesting analytics for
multiple campaigns at once via `/api/campaigns/analytics/views?id=X&id=Y&id=Z`
returns incorrect results. Campaigns are missing from the response if the
same subscriber has viewed more than one of the queried campaigns.

## Root Cause
The `get-campaign-analytics-unique-counts` query in `queries/campaigns.sql`
uses `DISTINCT ON(subscriber_id)` which deduplicates across ALL campaigns
globally, instead of per-campaign. This means if subscriber A viewed both
campaign 1 and campaign 2, only the oldest event survives, and campaign 2
disappears from the results entirely.

## Fix
Change `DISTINCT ON(subscriber_id)` to `DISTINCT ON(subscriber_id, campaign_id)`
and update `ORDER BY` to include `campaign_id`. This preserves one event per
subscriber per campaign, which is the correct behavior for unique tracking.
