### PR TITLE
fix: protect SES cert cache map with sync.RWMutex to prevent concurrent map writes crash

### DIFF
--- a/internal/bounce/webhooks/ses.go
+++ b/internal/bounce/webhooks/ses.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/knadh/listmonk/models"
@@ -65,6 +66,7 @@ type sesMail struct {
 // SES handles SES/SNS webhook notifications including confirming SNS topic subscription
 // requests and bounce notifications.
 type SES struct {
+	mu    sync.RWMutex
 	certs map[string]*x509.Certificate
 }
 
@@ -224,7 +226,10 @@ func (s *SES) getCert(certURL string) (*x509.Certificate, error) {
 	}
 
 	// Return if it's cached.
-	if c, ok := s.certs[u.Path]; ok {
+	s.mu.RLock()
+	c, ok := s.certs[u.Path]
+	s.mu.RUnlock()
+	if ok {
 		return c, nil
 	}
 
@@ -252,7 +257,14 @@ func (s *SES) getCert(certURL string) (*x509.Certificate, error) {
 	cert, err := x509.ParseCertificate(p.Bytes)
 
 	// Cache the cert in-memory.
+	s.mu.Lock()
+	// Check again if another goroutine already cached it while we were fetching.
+	if c2, ok := s.certs[u.Path]; ok {
+		s.mu.Unlock()
+		return c2, err
+	}
 	s.certs[u.Path] = cert
+	s.mu.Unlock()
 
 	return cert, err
 }

--- a/internal/bounce/webhooks/ses.go
+++ b/internal/bounce/webhooks/ses.go
@@ -259,11 +259,15 @@ func (s *SES) getCert(certURL string) (*x509.Certificate, error) {
 	// Cache the cert in-memory.
 	s.mu.Lock()
 	// Check again if another goroutine already cached it while we were fetching.
-	if c2, ok := s.certs[u.Path]; ok {
+	if c2, ok := s.certs[u.Path]; ok && c2 != nil {
 		s.mu.Unlock()
-		return c2, err
+		// Return the cached cert and ignore this goroutine's parse error (if any).
+		return c2, nil
 	}
-	s.certs[u.Path] = cert
+	// Only cache when parsing succeeded (don't cache nil certs from failures).
+	if err == nil {
+		s.certs[u.Path] = cert
+	}
 	s.mu.Unlock()
 
 	return cert, err


### PR DESCRIPTION
## Description

Fixes #3047

The `SES.getCert()` method accesses the `certs` map without any synchronization. When multiple HTTP requests arrive concurrently (via `ProcessBounce` / `ProcessSubscription` handlers on separate goroutines), they can simultaneously read from and write to the map, causing a fatal crash:



## Changes

1. Added a `sync.RWMutex` to the `SES` struct to protect the `certs` map.
2. The read path in `getCert` uses `RLock` / `RUnlock` for concurrent-safe reads.
3. The write path uses `Lock` / `Unlock` and includes a double-check pattern to avoid redundant HTTP fetches if another goroutine cached the certificate during the fetch.

## Testing

- `go build ./internal/bounce/webhooks/` passes successfully.