### PR TITLE
Add option to exclude SMTP servers from the default 'email' pool

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -680,7 +680,16 @@ func initSMTPMessengers() []manager.Messenger {
 			lo.Fatalf("error reading SMTP config: %v", err)
 		}
 
-		servers = append(servers, s)
+		// If the server is excluded from the default pool, it won't be part of the
+		// aggregated 'email' messenger. It must then have a Name to remain reachable
+		// as a standalone `email / $name` messenger.
+		if item.Bool("exclude_from_pool") {
+			if s.Name == "" {
+				lo.Printf("warning: SMTP server %s@%s is excluded from the default pool but has no name, it will be unreachable", item.String("username"), item.String("host"))
+			}
+		} else {
+			servers = append(servers, s)
+		}
 		lo.Printf("initialized email (SMTP) messenger: %s@%s", item.String("username"), item.String("host"))
 
 		// If the server has a name, initialize it as a standalone e-mail messenger
@@ -694,18 +703,30 @@ func initSMTPMessengers() []manager.Messenger {
 		}
 	}
 
-	// Initialize the 'email' messenger with all SMTP servers.
+	// If every server is excluded from the default pool, don't register the
+	// aggregated 'email' messenger at all (an empty pool would panic on Push).
+	// Sending without an explicit messenger will then fail cleanly via HasMessenger.
+	if len(servers) == 0 {
+		if len(out) == 0 {
+			lo.Println("warning: no SMTP servers available for the default 'email' messenger")
+		} else {
+			lo.Println("warning: all SMTP servers are excluded from the default pool; the 'email' messenger is unavailable, only named messengers can be used")
+		}
+		return out
+	}
+
+	// Initialize the 'email' messenger with the eligible SMTP servers.
 	msgr, err := email.New(email.MessengerName, servers...)
 	if err != nil {
 		lo.Fatalf("error initializing e-mail messenger: %v", err)
 	}
 
-	// If it's just one server, return the default "email" messenger.
-	if len(servers) == 1 {
+	// If only one eligible server and no named messengers, return just the default.
+	if len(servers) == 1 && len(out) == 0 {
 		return []manager.Messenger{msgr}
 	}
 
-	// If there are multiple servers, prepend the group "email" to be the first one.
+	// Prepend the group "email" so it appears first in the UI.
 	out = append([]manager.Messenger{msgr}, out...)
 
 	return out

--- a/frontend/src/views/settings/smtp.vue
+++ b/frontend/src/views/settings/smtp.vue
@@ -161,6 +161,12 @@
                   <b-input v-model="item.name" name="name" placeholder="email-primary" :maxlength="100" />
                 </b-field>
               </div>
+              <div class="column">
+                <b-field :label="$t('settings.mailserver.excludeFromPool')"
+                  :message="$t('settings.mailserver.excludeFromPoolHelp')">
+                  <b-switch v-model="item.exclude_from_pool" name="exclude_from_pool" />
+                </b-field>
+              </div>
             </div>
 
             <div class="columns">
@@ -295,6 +301,7 @@ export default Vue.extend({
         wait_timeout: '5s',
         tls_type: 'STARTTLS',
         tls_skip_verify: false,
+        exclude_from_pool: false,
       });
 
       this.$nextTick(() => {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -442,6 +442,8 @@
     "settings.general.siteName": "Site name",
     "settings.invalidMessengerName": "Invalid messenger name.",
     "settings.mailserver.authProtocol": "Auth protocol",
+    "settings.mailserver.excludeFromPool": "Exclude from default pool",
+    "settings.mailserver.excludeFromPoolHelp": "When enabled, this server is not used by the default \"email\" messenger. It remains usable only via its named identifier (set a unique Name nearby).",
     "settings.mailserver.host": "Host",
     "settings.mailserver.hostHelp": "SMTP server's host address.",
     "settings.mailserver.idleTimeout": "Idle timeout",

--- a/models/settings.go
+++ b/models/settings.go
@@ -81,23 +81,24 @@ type Settings struct {
 	UploadS3Expiry             string   `json:"upload.s3.expiry"`
 
 	SMTP []struct {
-		Name              string              `json:"name"`
-		UUID              string              `json:"uuid"`
-		Enabled           bool                `json:"enabled"`
-		Host              string              `json:"host"`
-		HelloHostname     string              `json:"hello_hostname"`
-		Port              int                 `json:"port"`
-		AuthProtocol      string              `json:"auth_protocol"`
-		Username          string              `json:"username"`
-		Password          string              `json:"password,omitempty"`
-		EmailHeaders      []map[string]string `json:"email_headers"`
-		MaxConns          int                 `json:"max_conns"`
-		MaxMsgRetries     int                 `json:"max_msg_retries"`
-		MsgRetryDelay     string              `json:"msg_retry_delay"`
-		IdleTimeout       string              `json:"idle_timeout"`
-		WaitTimeout       string              `json:"wait_timeout"`
-		TLSType           string              `json:"tls_type"`
-		TLSSkipVerify     bool                `json:"tls_skip_verify"`
+		Name            string              `json:"name"`
+		UUID            string              `json:"uuid"`
+		Enabled         bool                `json:"enabled"`
+		Host            string              `json:"host"`
+		HelloHostname   string              `json:"hello_hostname"`
+		Port            int                 `json:"port"`
+		AuthProtocol    string              `json:"auth_protocol"`
+		Username        string              `json:"username"`
+		Password        string              `json:"password,omitempty"`
+		EmailHeaders    []map[string]string `json:"email_headers"`
+		MaxConns        int                 `json:"max_conns"`
+		MaxMsgRetries   int                 `json:"max_msg_retries"`
+		MsgRetryDelay   string              `json:"msg_retry_delay"`
+		IdleTimeout     string              `json:"idle_timeout"`
+		WaitTimeout     string              `json:"wait_timeout"`
+		TLSType         string              `json:"tls_type"`
+		TLSSkipVerify   bool                `json:"tls_skip_verify"`
+		ExcludeFromPool bool                `json:"exclude_from_pool"`
 	} `json:"smtp"`
 
 	Messengers []struct {


### PR DESCRIPTION
When multiple SMTP servers are configured, the default "email" pool is constitued from all the active SMTP servers.

Some SMTP servers are sometime used only for specific things: for some campaigns, or for transactional emails, ...
Relates to https://github.com/knadh/listmonk/issues/2547

My pull request introduce a new option "Exclude from default pool" in the settings:
<img width="1127" height="263" alt="Exclude from default pool" src="https://github.com/user-attachments/assets/6717c91a-ae8e-462e-85b9-2411ff0e2fc6" />

When enabled, the server is never used by default. It should be specifically selected.