### PR TITLE
Fix: ZIP Slip path traversal in CSV import

### DIFF
--- a/internal/subimporter/importer.go
+++ b/internal/subimporter/importer.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -410,6 +411,9 @@ func (s *Session) ExtractZIP(srcPath string, maxCSVs int) (string, []string, err
 			s.log.Printf("skipping non .csv file '%s'", fName)
 			continue
 		}
+
+		// Sanitize the file name to prevent ZIP slip path traversal.
+		fName = filepath.Base(fName)
 
 		s.log.Printf("extracting '%s'", fName)
 		src, err := f.Open()


### PR DESCRIPTION
## Summary
- Fixes a ZIP Slip (CWE-22) path traversal vulnerability in the CSV import feature
- A malicious ZIP file with entries containing `../` sequences could write files outside the intended extraction directory
- The fix sanitizes ZIP entry filenames using `filepath.Base()` to strip any directory traversal components before file extraction

## Details
- **File**: `internal/subimporter/importer.go`
- **Vulnerability**: `f.FileInfo().Name()` returns the raw ZIP entry name, which was used unsanitized in `os.OpenFile(dir+"/"+fName, ...)`
- **CVSS**: 7.8 (HIGH)
- **Fix**: Added `fName = filepath.Base(fName)` to strip path components before file creation