### PR TITLE
fix: TrackLink Unicode/emoji URLs, bounce multipart infinite loop, opt-in List-Unsubscribe

### DIFF
--- a/cmd/subscribers.go
+++ b/cmd/subscribers.go
@@ -871,11 +871,14 @@ func makeOptinNotifyHook(unsubHeader bool, u *UrlConfig, q *models.Queries, i *i
 		hdr := textproto.MIMEHeader{}
 		hdr.Set(models.EmailHeaderSubscriberUUID, sub.UUID)
 
-		// Attach List-Unsubscribe headers?
+		// Attach List-Unsubscribe header for opt-in emails.
+		// Note: List-Unsubscribe-Post (RFC 8058 one-click) is intentionally
+		// omitted here because opt-in emails use a dummy campaign UUID in the
+		// unsub URL, which the unsubscribe route rejects. The informational
+		// List-Unsubscribe header is still set so that email clients display a
+		// visible unsubscribe link that the subscriber can follow manually.
 		if unsubHeader {
-			unsubURL := fmt.Sprintf(u.UnsubURL, dummyUUID, sub.UUID)
-			hdr.Set("List-Unsubscribe-Post", "List-Unsubscribe=One-Click")
-			hdr.Set("List-Unsubscribe", `<`+unsubURL+`>`)
+			hdr.Set("List-Unsubscribe", "<"+out.UnsubURL+">")
 		}
 
 		// Send the e-mail.

--- a/internal/bounce/mailbox/pop.go
+++ b/internal/bounce/mailbox/pop.go
@@ -130,8 +130,12 @@ func (p *POP) Scan(limit int, ch chan models.Bounce) error {
 				if err == io.EOF {
 					break
 				} else if err != nil {
+					// A non-EOF error means the multipart reader is in a broken
+					// state (e.g. malformed boundary). Continuing the loop would
+					// call NextPart() on the same broken reader forever. Break
+					// and process whatever we have so far.
 					p.lo.Printf("error reading multipart bounce message %d: %v", id, err)
-					continue
+					break
 				}
 				h = part
 			}

--- a/models/common.go
+++ b/models/common.go
@@ -52,10 +52,11 @@ var regTplFuncs = []regTplFunc{
 	// Convert the shorthand https://google.com@TrackLink to {{ TrackLink ... }}.
 	// This is for WYSIWYG editors that encode and break quotes {{ "" }} when inserted
 	// inside <a href="{{ TrackLink "https://these-quotes-break" }}>.
-	// The regex matches all characters that may occur in an URL
-	// (see "2. Characters" in RFC3986: https://www.ietf.org/rfc/rfc3986.txt)
+	// Uses \S+? (lazy non-whitespace) to capture any URL character including Unicode,
+	// emoji (e.g. example.com/path/👍), and IRI characters beyond RFC3986 ASCII.
+	// The lazy quantifier stops at the first @TrackLink suffix, not earlier.
 	{
-		regExp:  regexp.MustCompile(`(https?://[\p{L}\p{N}_\-\.~!#$&'()*+,/:;=?@\[\]%]*)@TrackLink`),
+		regExp:  regexp.MustCompile(`(https?://\S+?)@TrackLink`),
 		replace: `{{ TrackLink "$1" . }}`,
 	},
 


### PR DESCRIPTION
Fixes three reported bugs with no existing open PRs.

  ## Changes
  
  ### Fix #3076 — TrackLink regex drops URLs containing emoji or non-ASCII Unicode
  
  The original regex `[\p{L}\p{N}_\-\.~!#$&'()*+,/:;=?@\[\]%]*` covers Unicode
  letters/numbers but not emoji (Unicode category `So`), so campaign links with
  emoji in query params or fragments were silently truncated.

  **Fix:** replace with `\S+?` (lazy non-whitespace). The `@TrackLink` suffix anchors
  the match, so the lazy quantifier stops at the right boundary and handles any
  non-whitespace URL character including emoji.
  
  ### Fix #3071 — bounce POP processor: infinite loop on broken multipart message
  
  In `internal/bounce/mailbox/pop.go`, the multipart-parse loop used `continue`
  on non-EOF errors from `mr.NextPart()`. A broken reader returns the same error
  forever, spinning the loop indefinitely.

  **Fix:** `break` instead of `continue` on non-EOF errors.
  
  ### Fix #3063 — List-Unsubscribe header non-functional on opt-in (non-campaign) emails
  
  Opt-in emails use `dummyUUID` as the campaign UUID in the unsubscribe URL, which
  the route rejects — so clicking the header link returned a 404/error. The code
  also set `List-Unsubscribe-Post` (RFC 8058 one-click), which requires the URL to
  actually work.

  **Fix:** Remove `List-Unsubscribe-Post` (one-click requires a working endpoint).
  Keep the informational `List-Unsubscribe` header using the already-resolved
  `out.UnsubURL` rather than re-constructing it with `dummyUUID`.

  ## Testing
  - `go build ./...` passes
  - Manually traced each code path against the issue reproduction steps