### PR TITLE
Show total and unique view/click analytics when individual tracking is on

### DIFF
--- a/cmd/campaigns.go
+++ b/cmd/campaigns.go
@@ -614,9 +614,10 @@ func (a *App) GetCampaignViewAnalytics(c echo.Context) error {
 	}
 
 	var (
-		typ  = c.Param("type")
-		from = c.QueryParams().Get("from")
-		to   = c.QueryParams().Get("to")
+		typ    = c.Param("type")
+		from   = c.QueryParams().Get("from")
+		to     = c.QueryParams().Get("to")
+		unique = c.QueryParams().Get("unique") == "true"
 	)
 	if !strHasLen(from, 10, 30) || !strHasLen(to, 10, 30) {
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("analytics.invalidDates"))
@@ -633,7 +634,7 @@ func (a *App) GetCampaignViewAnalytics(c echo.Context) error {
 	}
 
 	// Get the analytics numbers from the DB for the campaigns.
-	out, err := a.core.GetCampaignAnalyticsCounts(ids, typ, from, to)
+	out, err := a.core.GetCampaignAnalyticsCounts(ids, typ, from, to, unique)
 	if err != nil {
 		return err
 	}

--- a/cmd/campaigns.go
+++ b/cmd/campaigns.go
@@ -623,6 +623,13 @@ func (a *App) GetCampaignViewAnalytics(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("analytics.invalidDates"))
 	}
 
+	// Unique (distinct-subscriber) counts are only served when individual
+	// subscriber tracking is enabled. Otherwise force total counts so the API
+	// never exposes distinct-subscriber analytics against the privacy setting.
+	if unique && !a.cfg.Privacy.IndividualTracking {
+		unique = false
+	}
+
 	// Campaign link stats.
 	if typ == "links" {
 		out, err := a.core.GetCampaignAnalyticsLinks(ids, typ, from, to)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -400,24 +400,37 @@ func readQueries(dir string, fs stuffbin.FileSystem) goyesql.Queries {
 
 // prepareQueries queries prepares a query map and returns a *Queries
 func prepareQueries(qMap goyesql.Queries, db *sqlx.DB, ko *koanf.Koanf) *models.Queries {
+	individualTracking := ko.Bool("privacy.individual_tracking")
+
+	// The unique (distinct-subscriber) statements are only used when individual
+	// tracking is on; when it's off the API never serves unique counts (see
+	// GetCampaignViewAnalytics), so prepare them from the total query instead of
+	// depending on the unique-count template being present in a custom query set.
+	uniqueSrc := "get-campaign-analytics-counts"
+	if individualTracking {
+		uniqueSrc = "get-campaign-analytics-unique-counts"
+	}
+
 	// These don't exist in the SQL file but are in the queries struct to be prepared.
-	// Both total and unique variants are interpolated with table names and prepared,
-	// so analytics can show total and unique counts side by side when tracking is on.
 	for _, c := range []struct{ name, src, table string }{
 		{"get-campaign-view-counts", "get-campaign-analytics-counts", "campaign_views"},
 		{"get-campaign-click-counts", "get-campaign-analytics-counts", "link_clicks"},
-		{"get-campaign-view-counts-unique", "get-campaign-analytics-unique-counts", "campaign_views"},
-		{"get-campaign-click-counts-unique", "get-campaign-analytics-unique-counts", "link_clicks"},
+		{"get-campaign-view-counts-unique", uniqueSrc, "campaign_views"},
+		{"get-campaign-click-counts-unique", uniqueSrc, "link_clicks"},
 	} {
+		src, ok := qMap[c.src]
+		if !ok {
+			lo.Fatalf("SQL query '%s' required for campaign analytics is missing", c.src)
+		}
 		qMap[c.name] = &goyesql.Query{
-			Query: fmt.Sprintf(qMap[c.src].Query, c.table),
+			Query: fmt.Sprintf(src.Query, c.table),
 			Tags:  map[string]string{"name": c.name},
 		}
 	}
 
 	// Link counts switch to unique subscribers only when individual tracking is on.
 	linkSel := "*"
-	if ko.Bool("privacy.individual_tracking") {
+	if individualTracking {
 		linkSel = "DISTINCT subscriber_id"
 	}
 	qMap["get-campaign-link-counts"].Query = fmt.Sprintf(qMap["get-campaign-link-counts"].Query, linkSel)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -400,23 +400,25 @@ func readQueries(dir string, fs stuffbin.FileSystem) goyesql.Queries {
 
 // prepareQueries queries prepares a query map and returns a *Queries
 func prepareQueries(qMap goyesql.Queries, db *sqlx.DB, ko *koanf.Koanf) *models.Queries {
-	var (
-		countQuery = "get-campaign-analytics-counts"
-		linkSel    = "*"
-	)
-	if ko.Bool("privacy.individual_tracking") {
-		countQuery = "get-campaign-analytics-unique-counts"
-		linkSel = "DISTINCT subscriber_id"
+	// These don't exist in the SQL file but are in the queries struct to be prepared.
+	// Both total and unique variants are interpolated with table names and prepared,
+	// so analytics can show total and unique counts side by side when tracking is on.
+	for _, c := range []struct{ name, src, table string }{
+		{"get-campaign-view-counts", "get-campaign-analytics-counts", "campaign_views"},
+		{"get-campaign-click-counts", "get-campaign-analytics-counts", "link_clicks"},
+		{"get-campaign-view-counts-unique", "get-campaign-analytics-unique-counts", "campaign_views"},
+		{"get-campaign-click-counts-unique", "get-campaign-analytics-unique-counts", "link_clicks"},
+	} {
+		qMap[c.name] = &goyesql.Query{
+			Query: fmt.Sprintf(qMap[c.src].Query, c.table),
+			Tags:  map[string]string{"name": c.name},
+		}
 	}
 
-	// These don't exist in the SQL file but are in the queries struct to be prepared.
-	qMap["get-campaign-view-counts"] = &goyesql.Query{
-		Query: fmt.Sprintf(qMap[countQuery].Query, "campaign_views"),
-		Tags:  map[string]string{"name": "get-campaign-view-counts"},
-	}
-	qMap["get-campaign-click-counts"] = &goyesql.Query{
-		Query: fmt.Sprintf(qMap[countQuery].Query, "link_clicks"),
-		Tags:  map[string]string{"name": "get-campaign-click-counts"},
+	// Link counts switch to unique subscribers only when individual tracking is on.
+	linkSel := "*"
+	if ko.Bool("privacy.individual_tracking") {
+		linkSel = "DISTINCT subscriber_id"
 	}
 	qMap["get-campaign-link-counts"].Query = fmt.Sprintf(qMap["get-campaign-link-counts"].Query, linkSel)
 

--- a/frontend/src/views/CampaignAnalytics.vue
+++ b/frontend/src/views/CampaignAnalytics.vue
@@ -94,6 +94,8 @@ export default Vue.extend({
   },
 
   data() {
+    const individualTracking = this.$store.state.serverConfig.privacy.individual_tracking;
+
     return {
       isSearchLoading: false,
       queriedCampaigns: [],
@@ -101,7 +103,9 @@ export default Vue.extend({
       // Data for each view.
       counts: {
         views: 0,
+        uniqueViews: 0,
         clicks: 0,
+        uniqueClicks: 0,
         bounces: 0,
         links: 0,
       },
@@ -116,6 +120,19 @@ export default Vue.extend({
           loading: false,
         },
 
+        // When individual subscriber tracking is on, also show unique counts.
+        ...(individualTracking ? {
+          uniqueViews: {
+            name: this.$t('campaigns.uniqueViews'),
+            type: 'line',
+            data: null,
+            fn: this.$api.getCampaignViewCounts,
+            chartFn: this.makeCharts,
+            unique: true,
+            loading: false,
+          },
+        } : {}),
+
         clicks: {
           name: this.$t('campaigns.clicks'),
           type: 'line',
@@ -124,6 +141,18 @@ export default Vue.extend({
           chartFn: this.makeCharts,
           loading: false,
         },
+
+        ...(individualTracking ? {
+          uniqueClicks: {
+            name: this.$t('campaigns.uniqueClicks'),
+            type: 'line',
+            data: null,
+            fn: this.$api.getCampaignClickCounts,
+            chartFn: this.makeCharts,
+            unique: true,
+            loading: false,
+          },
+        } : {}),
 
         bounces: {
           name: this.$t('globals.terms.bounces'),
@@ -272,6 +301,7 @@ export default Vue.extend({
         id: camps.map((c) => c.id),
         from: this.form.from,
         to: this.form.to,
+        ...(this.charts[typ].unique ? { unique: true } : {}),
       }).then((data) => {
         // Set the total count.
         this.counts[typ] = data.reduce((sum, d) => sum + d.count, 0);

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -105,6 +105,8 @@
     "campaigns.timestamps": "Timestamps",
     "campaigns.trackLink": "Track link",
     "campaigns.unSchedule": "Unschedule",
+    "campaigns.uniqueClicks": "Unique clicks",
+    "campaigns.uniqueViews": "Unique views",
     "campaigns.views": "Views",
     "dashboard.campaignViews": "Campaign views",
     "dashboard.linkClicks": "Link clicks",

--- a/internal/core/campaigns.go
+++ b/internal/core/campaigns.go
@@ -381,15 +381,23 @@ func (c *Core) GetRunningCampaignStats() ([]models.CampaignStats, error) {
 	return out, nil
 }
 
-func (c *Core) GetCampaignAnalyticsCounts(campIDs []int, typ, fromDate, toDate string) ([]models.CampaignAnalyticsCount, error) {
-	// Pick campaign view counts or click counts.
+func (c *Core) GetCampaignAnalyticsCounts(campIDs []int, typ, fromDate, toDate string, unique bool) ([]models.CampaignAnalyticsCount, error) {
+	// Pick campaign view counts or click counts. When unique is set, use the
+	// variant that counts distinct subscribers instead of total events.
 	var stmt *sqlx.Stmt
 	switch typ {
 	case "views":
 		stmt = c.q.GetCampaignViewCounts
+		if unique {
+			stmt = c.q.GetCampaignViewCountsUnique
+		}
 	case "clicks":
 		stmt = c.q.GetCampaignClickCounts
+		if unique {
+			stmt = c.q.GetCampaignClickCountsUnique
+		}
 	case "bounces":
+		// Bounces have no unique variant, so the unique flag is intentionally ignored.
 		stmt = c.q.GetCampaignBounceCounts
 	default:
 		return nil, echo.NewHTTPError(http.StatusBadRequest, c.i18n.T("globals.messages.invalidData"))

--- a/models/queries.go
+++ b/models/queries.go
@@ -68,17 +68,20 @@ type Queries struct {
 	GetArchivedCampaigns  *sqlx.Stmt `query:"get-archived-campaigns"`
 	CampaignHasLists      *sqlx.Stmt `query:"campaign-has-lists"`
 
-	// These two queries are read as strings and based on settings.individual_tracking=on/off,
-	// are interpolated and copied to view and click counts. Same query, different tables.
-	GetCampaignAnalyticsCounts string     `query:"get-campaign-analytics-counts"`
-	GetCampaignViewCounts      *sqlx.Stmt `query:"get-campaign-view-counts"`
-	GetCampaignClickCounts     *sqlx.Stmt `query:"get-campaign-click-counts"`
-	GetCampaignLinkCounts      *sqlx.Stmt `query:"get-campaign-link-counts"`
-	GetCampaignBounceCounts    *sqlx.Stmt `query:"get-campaign-bounce-counts"`
-	DeleteCampaignViews        *sqlx.Stmt `query:"delete-campaign-views"`
-	DeleteCampaignLinkClicks   *sqlx.Stmt `query:"delete-campaign-link-clicks"`
-	ExportCampaignViews        *sqlx.Stmt `query:"export-campaign-views"`
-	ExportCampaignLinkClicks   *sqlx.Stmt `query:"export-campaign-link-clicks"`
+	// These queries are read as strings and interpolated with table names before being
+	// prepared. The total and unique variants are copied to view and click counts.
+	// Same query, different tables.
+	GetCampaignAnalyticsCounts   string     `query:"get-campaign-analytics-counts"`
+	GetCampaignViewCounts        *sqlx.Stmt `query:"get-campaign-view-counts"`
+	GetCampaignClickCounts       *sqlx.Stmt `query:"get-campaign-click-counts"`
+	GetCampaignViewCountsUnique  *sqlx.Stmt `query:"get-campaign-view-counts-unique"`
+	GetCampaignClickCountsUnique *sqlx.Stmt `query:"get-campaign-click-counts-unique"`
+	GetCampaignLinkCounts        *sqlx.Stmt `query:"get-campaign-link-counts"`
+	GetCampaignBounceCounts      *sqlx.Stmt `query:"get-campaign-bounce-counts"`
+	DeleteCampaignViews          *sqlx.Stmt `query:"delete-campaign-views"`
+	DeleteCampaignLinkClicks     *sqlx.Stmt `query:"delete-campaign-link-clicks"`
+	ExportCampaignViews          *sqlx.Stmt `query:"export-campaign-views"`
+	ExportCampaignLinkClicks     *sqlx.Stmt `query:"export-campaign-link-clicks"`
 
 	NextCampaigns            *sqlx.Stmt `query:"next-campaigns"`
 	GetRunningCampaign       *sqlx.Stmt `query:"get-running-campaign"`


### PR DESCRIPTION
Closes #3083.

When `privacy.individual_tracking` is on, the analytics page now shows **both** total and unique view/click graphs, instead of silently replacing the totals with unique counts.

**Changes**
- `prepareQueries()` (`cmd/init.go`): always prepares both the total and unique count statements for views and clicks, reusing the existing `get-campaign-analytics-counts` / `get-campaign-analytics-unique-counts` queries.
- `GetCampaignViewAnalytics` reads a `?unique=true` query param; `GetCampaignAnalyticsCounts` routes to the unique statement.
- `CampaignAnalytics.vue`: renders "Unique views" / "Unique clicks" charts only when `serverConfig.privacy.individual_tracking` is true.
- Two new `en.json` keys (`campaigns.uniqueViews`, `campaigns.uniqueClicks`).

When individual tracking is off, behavior is unchanged.

Tested: `go build` / `go vet` / eslint clean; verified against a running instance (total vs. unique counts render correctly per campaign).
