### PR TITLE
Add a client-side "Save as PDF" button to the campaign preview

### DIFF
--- a/frontend/src/components/CampaignPreview.vue
+++ b/frontend/src/components/CampaignPreview.vue
@@ -21,6 +21,10 @@
             @load="onLoaded" sandbox="allow-scripts" />
         </section>
         <footer class="modal-card-foot has-text-right">
+          <b-button v-if="type === 'campaign'" icon-left="cloud-download-outline"
+            :loading="isDownloading" :disabled="isDownloading" @click="downloadPDF">
+            {{ $t('campaigns.downloadPDF') }}
+          </b-button>
           <b-button @click="close">
             {{ $t('globals.buttons.close') }}
           </b-button>
@@ -62,10 +66,102 @@ export default {
       isVisible: true,
       isLoading: true,
       formSubmitted: false,
+      isDownloading: false,
     };
   },
 
   methods: {
+    // Client-side "Save as PDF": render the campaign preview into a hidden iframe and open
+    // the browser's print dialog (no backend or dependency). A dedicated frame keeps the
+    // visible preview's sandbox intact and prints the full email; it is sandboxed
+    // allow-same-origin + allow-modals (so the parent can call print()) without
+    // allow-scripts. GET previews load previewURL; POST previews (editor/archive) re-submit
+    // the existing preview form into the frame.
+    downloadPDF() {
+      if (this.isDownloading) {
+        return;
+      }
+      this.isDownloading = true;
+
+      // Browsers derive the print job's PDF title / suggested file name from the TOP
+      // document's title (not the printed iframe's), so it's set below and restored on cleanup.
+      const prevDocTitle = document.title;
+
+      const frame = document.createElement('iframe');
+      frame.style.display = 'none';
+      frame.name = 'lm-pdf-frame';
+      frame.sandbox = 'allow-same-origin allow-modals';
+
+      // The fallback timer also cleans up if onload never fires or afterprint isn't emitted.
+      let removed = false;
+      let fallbackTimer = null;
+      let printed = false;
+      const cleanup = () => {
+        if (removed) {
+          return;
+        }
+        removed = true;
+        clearTimeout(fallbackTimer);
+        if (frame.parentNode) {
+          frame.parentNode.removeChild(frame);
+        }
+        // Restore only if the title is still the one we set, so a title changed elsewhere
+        // (e.g. by the router) while the print dialog was open isn't clobbered.
+        if (document.title === this.title) {
+          document.title = prevDocTitle;
+        }
+        this.isDownloading = false;
+      };
+      fallbackTimer = setTimeout(cleanup, 60000);
+
+      frame.onload = () => {
+        // A freshly created frame fires an initial about:blank load (and the POST form
+        // submission adds another); wait for the real, non-empty content, then print once.
+        const { contentDocument } = frame;
+        if (!contentDocument || !contentDocument.body || contentDocument.body.children.length === 0) {
+          return;
+        }
+        if (printed) {
+          return;
+        }
+        printed = true;
+
+        // Defer a tick before print(); a synchronous print() in onload can yield a blank page.
+        setTimeout(() => {
+          try {
+            // Set the document title so the browser proposes the campaign name as the PDF
+            // file name; restored in cleanup() once the print dialog closes.
+            if (this.title) {
+              document.title = this.title;
+            }
+            // Keep background colours/images in the print output (browsers drop them by
+            // default). print-color-adjust is inherited, so setting it on <html> covers all.
+            contentDocument.documentElement.style.setProperty('print-color-adjust', 'exact');
+            contentDocument.documentElement.style.setProperty('-webkit-print-color-adjust', 'exact');
+            frame.contentWindow.onafterprint = cleanup;
+            frame.contentWindow.focus();
+            frame.contentWindow.print();
+          } catch (e) {
+            this.$utils.toast(e.toString(), 'is-danger');
+            cleanup();
+          }
+        }, 0);
+      };
+
+      document.body.appendChild(frame);
+
+      if (this.isPost) {
+        // Re-submit the existing preview form (body/template overrides) into the frame.
+        const { form } = this.$refs;
+        const prevTarget = form.target;
+        form.target = 'lm-pdf-frame';
+        form.submit();
+        form.target = prevTarget;
+      } else {
+        frame.src = this.previewURL;
+      }
+    },
+
     close() {
       this.$emit('close');
       this.isVisible = false;

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "نسخة من {name}",
     "campaigns.customHeadersHelp": "مصفوفة ترويسات مخصصة. مثال: [{\"X-Custom\": \"value\"}]",
     "campaigns.dateAndTime": "التاريخ والوقت",
+    "campaigns.downloadPDF": "حفظ بصيغة PDF",
     "campaigns.ended": "انتهت",
     "campaigns.errorSendTest": "خطأ في إرسال الاختبار: {error}",
     "campaigns.fieldInvalidBody": "خطأ في تجميع محتوى الحملة: {error}",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Копие на {name}",
     "campaigns.customHeadersHelp": "Масив от персонализирани хедъри, които да се прикачат към изходящите съобщения. Напр.: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Дата и час",
+    "campaigns.downloadPDF": "Запазване като PDF",
     "campaigns.ended": "Приключила",
     "campaigns.errorSendTest": "Грешка при изпращане на тест: {error}",
     "campaigns.fieldInvalidBody": "Грешка при съставяне на тялото на кампанията: {error}",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Còpia de {name}",
     "campaigns.customHeadersHelp": "Matriu de capçaleres personalitzades per adjuntar als missatges de sortida. p. ex.: [{\"X-Custom\": \"valor\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Data i hora",
+    "campaigns.downloadPDF": "Desa com a PDF",
     "campaigns.ended": "Finalitzada",
     "campaigns.errorSendTest": "S'ha produit un error en enviar la prova: {error}",
     "campaigns.fieldInvalidBody": "S'ha produït un error en compilar el cos de la campanya: {error}",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopie {name}",
     "campaigns.customHeadersHelp": "Pole volitelných hlaviček k odchozím zprávám, například: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Datum a čas",
+    "campaigns.downloadPDF": "Uložit jako PDF",
     "campaigns.ended": "Ukončeno",
     "campaigns.errorSendTest": "Chyba při odesílání testu: {error}",
     "campaigns.fieldInvalidBody": "Chyba při kompilaci těla kampaně: {error}",

--- a/i18n/cy.json
+++ b/i18n/cy.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Copi o {name}",
     "campaigns.customHeadersHelp": "Ystod eang o benynnau i'w hatodi i negeseuon. ee: [{\"\"X-Custom\"\": \"\"gwerth\"\"}",
     "campaigns.dateAndTime": "Dyddiad ac amser",
+    "campaigns.downloadPDF": "Cadw fel PDF",
     "campaigns.ended": "Wedi gorffen",
     "campaigns.errorSendTest": "Gwall wrth geisio anfon: {error}",
     "campaigns.fieldInvalidBody": "Gwall wrth lunio corff yr ymgyrch: {error}",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopi af {name}",
     "campaigns.customHeadersHelp": "Række af tilpassede headere der tilføjes nyheder der udsendes. F.eks: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Dato og tid",
+    "campaigns.downloadPDF": "Gem som PDF",
     "campaigns.ended": "Afslutet",
     "campaigns.errorSendTest": "Fejl under udsendelse af test: {error}",
     "campaigns.fieldInvalidBody": "Fejl under samling af udsendelsesindholdet: {error}",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopie von {name}",
     "campaigns.customHeadersHelp": "Liste von benutzerdefinierten Headern, welche in ausgehenden Nachrichten gesetzt werden sollen . Beispiel: [{\"X-Header\": \"wert\"}, {\"X-Header2\": \"wert\"}]",
     "campaigns.dateAndTime": "Datum und Zeit",
+    "campaigns.downloadPDF": "Als PDF speichern",
     "campaigns.ended": "Abgeschlossen",
     "campaigns.errorSendTest": "Fehler beim Senden der Testmail: {error}",
     "campaigns.fieldInvalidBody": "Fehler beim Erstellen des Kampagneninhalts: {error}",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Αντίγραφο του {name}",
     "campaigns.customHeadersHelp": "Πίνακας με προσαρμοσμένες κεφαλίδες που θα προστεθούν στα εξερχόμενα μηνύματα. Π.χ.: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Ημερομηνία και ώρα",
+    "campaigns.downloadPDF": "Αποθήκευση ως PDF",
     "campaigns.ended": "Ολοκληρώθηκε",
     "campaigns.errorSendTest": "Σφάλμα κατά την αποστολή του δοκιμαστικού μηνύματος: {error}",
     "campaigns.fieldInvalidBody": "Σφάλμα κατά τη σύνταξη του περιεχομένου της εκστρατείας: {error}",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -40,6 +40,7 @@
     "campaigns.copyOf": "Copy of {name}",
     "campaigns.customHeadersHelp": "Array of custom headers to attach to outgoing messages. Supports template expressions (e.g., {{ .Subscriber.Attribs.city }}). eg: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"{{ .Subscriber.UUID }}\"}]",
     "campaigns.dateAndTime": "Date and time",
+    "campaigns.downloadPDF": "Save as PDF",
     "campaigns.ended": "Ended",
     "campaigns.errorSendTest": "Error sending test: {error}",
     "campaigns.fieldInvalidBody": "Error compiling campaign body: {error}",

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopio de {name}",
     "campaigns.customHeadersHelp": "Matriu de capçaleres personalitzades per adjuntar als missatges de sortida. p. ex.: [{\"X-Custom\": \"valor\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Data i hora",
+    "campaigns.downloadPDF": "Konservi kiel PDF",
     "campaigns.ended": "Finalitzada",
     "campaigns.errorSendTest": "S'ha produit un error en enviar la prova: {error}",
     "campaigns.fieldInvalidBody": "S'ha produït un error en compilar el cos de la campanya: {error}",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Copia de {name}",
     "campaigns.customHeadersHelp": "Lista de encabezados adicionales a incluir en los mensajes salientes. ej: [{\"X-Custom\": \"valor\"}, {\"X-Custom2\": \"valor\"}]",
     "campaigns.dateAndTime": "Fecha y hora",
+    "campaigns.downloadPDF": "Guardar como PDF",
     "campaigns.ended": "Finalizado",
     "campaigns.errorSendTest": "Error al enviar la prueba: {error}",
     "campaigns.fieldInvalidBody": "Error al compilar el cuerpo de la campaña: {error}",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopio kampanjasta {name}",
     "campaigns.customHeadersHelp": "Taulukko mukautettuja otsakkeita lähtevissä viesteissä. esim: [{\"X-Custom\": \"arvo\"}, {\"X-Custom2\": \"arvo\"}]",
     "campaigns.dateAndTime": "Päiväys ja aika",
+    "campaigns.downloadPDF": "Tallenna PDF-tiedostona",
     "campaigns.ended": "Päättynyt",
     "campaigns.errorSendTest": "Virhe lähetettäessä testiä: {error}",
     "campaigns.fieldInvalidBody": "Virhe koostaessa kampanjan sisältöä: {error}",

--- a/i18n/fr-CA.json
+++ b/i18n/fr-CA.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Copie de {name}",
     "campaigns.customHeadersHelp": "Array d'en-têtes personnalisés à joindre aux messages sortants. eg: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Date et heure",
+    "campaigns.downloadPDF": "Enregistrer en PDF",
     "campaigns.ended": "Terminée",
     "campaigns.errorSendTest": "Erreur lors de l'envoi du test : {error}",
     "campaigns.fieldInvalidBody": "Erreur lors de la compilation du corps de la campagne : {error}",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Copie de {name}",
     "campaigns.customHeadersHelp": "Array d'en-têtes personnalisés à joindre aux messages sortants. eg: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Date et heure",
+    "campaigns.downloadPDF": "Enregistrer en PDF",
     "campaigns.ended": "Terminée",
     "campaigns.errorSendTest": "Erreur lors de l'envoi du test : {error}",
     "campaigns.fieldInvalidBody": "Erreur lors de la compilation du corps de la campagne : {error}",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "עותק של {name}",
     "campaigns.customHeadersHelp": "מערך כותרות מותאמות אישית לצירוף להודעות. דוגמא: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "תאריך ושעה",
+    "campaigns.downloadPDF": "שמירה כ-PDF",
     "campaigns.ended": "הסתיים",
     "campaigns.errorSendTest": "שגיאה בשליחת הבדיקה: {error}",
     "campaigns.fieldInvalidBody": "שגיאה בקימפול גוף הקמפיין: {error}",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "{name} másolata",
     "campaigns.customHeadersHelp": "Kimenő üzenetek extra fejlécei. Például: [{\"X-K1\": \"V1\"}, {\"X-K2\": \"V2\"}]",
     "campaigns.dateAndTime": "Dátum és idő",
+    "campaigns.downloadPDF": "Mentés PDF-ként",
     "campaigns.ended": "Vége",
     "campaigns.errorSendTest": "Hiba a teszt küldésekor: {error}",
     "campaigns.fieldInvalidBody": "Hibás tartalom: {error}",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -40,6 +40,7 @@
     "campaigns.copyOf": "Salinan {name}",
     "campaigns.customHeadersHelp": "Kumpulan header kustom untuk dilampirkan ke pesan keluar. Mendukung ekspresi templat (cth: {{ .Subscriber.Attribs.city }}). cth: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"{{ .Subscriber.UUID }}\"}]",
     "campaigns.dateAndTime": "Tanggal dan waktu",
+    "campaigns.downloadPDF": "Simpan sebagai PDF",
     "campaigns.ended": "Berakhir",
     "campaigns.errorSendTest": "Gagal mengirim tes: {error}",
     "campaigns.fieldInvalidBody": "Gagal menyusun badan kampanye: {error}",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Copie di {name}",
     "campaigns.customHeadersHelp": "Lista di header personalizzati da allegare ai messaggi in uscita. eg: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Data e ora",
+    "campaigns.downloadPDF": "Salva come PDF",
     "campaigns.ended": "Terminata",
     "campaigns.errorSendTest": "Errore durante il test di invio: {error}",
     "campaigns.fieldInvalidBody": "Errore durante la compilazione del contenuto della campagna: {error}",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": " {name}をコピー",
     "campaigns.customHeadersHelp": "送信メッセージに添付するカスタムヘッダーの配列。 例: [{\"X-Custom\": \"Value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "日時",
+    "campaigns.downloadPDF": "PDFとして保存",
     "campaigns.ended": "終了",
     "campaigns.errorSendTest": "テスト送信エラー: {error}",
     "campaigns.fieldInvalidBody": "キャンペーン本体コンパイルエラー: {error}",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "{name}의 복사본",
     "campaigns.customHeadersHelp": "발송 메시지에 첨부할 커스텀 헤더 배열. 예: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "날짜 및 시간",
+    "campaigns.downloadPDF": "PDF로 저장",
     "campaigns.ended": "종료됨",
     "campaigns.errorSendTest": "테스트 발송 오류: {error}",
     "campaigns.fieldInvalidBody": "캠페인 본문 컴파일 오류: {error}",

--- a/i18n/ml.json
+++ b/i18n/ml.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "{name} ന്റെ പകർപ്പ്",
     "campaigns.customHeadersHelp": "അയക്കുന്ന സന്ദേശങ്ങളിൽ ചെ‍ർക്കാനുള്ള ഇഷ്‌ടാനുസൃത തലക്കെട്ടുകളുടെ ഒരു നിര. ഉദാ: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "തിയതിയും സമയവും",
+    "campaigns.downloadPDF": "PDF ആയി സംരക്ഷിക്കുക",
     "campaigns.ended": "അവസാനിച്ചു",
     "campaigns.errorSendTest": "ടെസ്റ്റ് അയയ്ക്കുന്നത് പരാജയപ്പെട്ടു: {error}",
     "campaigns.fieldInvalidBody": "ക്യാമ്പേയ്ന്റെ ചട്ടക്കൂട് തയ്യാറാക്കുന്നതിൽ പരാജയപ്പെട്ടു : {error}",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopie van {name}",
     "campaigns.customHeadersHelp": "Array van aangepaste headers om toe te voegen aan uitgaande berichten. bv: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Datum en tijd",
+    "campaigns.downloadPDF": "Opslaan als PDF",
     "campaigns.ended": "Beëindigd",
     "campaigns.errorSendTest": "Fout bij verzenden test: {error}",
     "campaigns.fieldInvalidBody": "Fout bij het compileren van campagne-inhoud: {error}",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopi av {name}",
     "campaigns.customHeadersHelp": "Array av egendefinerte overskrifter som skal legges til utgående meldinger, f.eks.: [{\"X-Custom\": \"verdi\"}, {\"X-Custom2\": \"verdi\"}]",
     "campaigns.dateAndTime": "Dato og tid",
+    "campaigns.downloadPDF": "Lagre som PDF",
     "campaigns.ended": "Avsluttet",
     "campaigns.errorSendTest": "Feil ved sending av test: {error}",
     "campaigns.fieldInvalidBody": "Feil ved kompilering av kampanjeinnhold: {error}",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopia {name}",
     "campaigns.customHeadersHelp": "Tablica niestandardowych nagłówków do dołączenia do wiadomości wychodzących. np: [{\"X-Custom\": \"wartosc\"}, {\"X-Custom2\": \"wartosc\"}]",
     "campaigns.dateAndTime": "Data i czas",
+    "campaigns.downloadPDF": "Zapisz jako PDF",
     "campaigns.ended": "Zakończona",
     "campaigns.errorSendTest": "Błąd wysyłania testu: {error}",
     "campaigns.fieldInvalidBody": "Błąd kompilacji treści kampanii: {error}",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Cópia de {name}",
     "campaigns.customHeadersHelp": "Array de cabeçalhos personalizados para anexar nas mensagens. eg: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Data e hora",
+    "campaigns.downloadPDF": "Salvar como PDF",
     "campaigns.ended": "Finalizada",
     "campaigns.errorSendTest": "Erro ao enviar o teste: {error}",
     "campaigns.fieldInvalidBody": "Erro ao compilar corpo da campanha: {error}",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Cópia de {name}",
     "campaigns.customHeadersHelp": "Lista de headers customizados para anexar às mensagens de saída, e.g.: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Dia e hora",
+    "campaigns.downloadPDF": "Guardar como PDF",
     "campaigns.ended": "Terminada",
     "campaigns.errorSendTest": "Erro ao enviar teste: {error}",
     "campaigns.fieldInvalidBody": "Erro ao compilar corpo da campanha: {error}",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Copie a {name}",
     "campaigns.customHeadersHelp": "Matrice de antete personalizate care să fie atașate la mesajele trimise. ex: [{\"X-Custom\": \"valoare\"}, {\"X-Custom2\": \"valoare\"}]",
     "campaigns.dateAndTime": "Data și ora",
+    "campaigns.downloadPDF": "Salvează ca PDF",
     "campaigns.ended": "Terminat",
     "campaigns.errorSendTest": "Test de trimitere a erorilor: {error}",
     "campaigns.fieldInvalidBody": "Eroare la compilarea corpului campaniei: {error}",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Копия {name}",
     "campaigns.customHeadersHelp": "Массив пользовательских заголовков для добавления к исходящим сообщениям. Например: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Дата и время",
+    "campaigns.downloadPDF": "Сохранить как PDF",
     "campaigns.ended": "Завершена",
     "campaigns.errorSendTest": "Ошибка отправки тестового сообщения: {error}",
     "campaigns.fieldInvalidBody": "Ошибка компиляции тела кампании: {error}",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kópia {name}",
     "campaigns.customHeadersHelp": "Pole voliteľných hlavičiek odosielaných správ, ako: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Dátum a čas",
+    "campaigns.downloadPDF": "Uložiť ako PDF",
     "campaigns.ended": "Ukončená",
     "campaigns.errorSendTest": "Chyba pri odosielaní testu: {error}",
     "campaigns.fieldInvalidBody": "Chyba pri kompilácii tela kampane: {error}",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopija {name}",
     "campaigns.customHeadersHelp": "Dodatne glave [Headers], ki se pošljejo pri vseh sporočilih poslenih s tega strežnika. Npr.: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"vrednost\" }]",
     "campaigns.dateAndTime": "Datum in ura",
+    "campaigns.downloadPDF": "Shrani kot PDF",
     "campaigns.ended": "Končano",
     "campaigns.errorSendTest": "Napaka pri pošiljanju testa: {error}",
     "campaigns.fieldInvalidBody": "Napaka pri prevajanju telesa akcije: {error}",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Kopia av {name}",
     "campaigns.customHeadersHelp": "Array av anpassade header-filer att bifoga i utgående meddelanden. t.ex: [{\"X-Anpassad\": \"värde\"}, {\"X-Anpassad2\": \"värde\"}]",
     "campaigns.dateAndTime": "Datum och tid",
+    "campaigns.downloadPDF": "Spara som PDF",
     "campaigns.ended": "Avslutad",
     "campaigns.errorSendTest": "Fel vid sändning av test: {error}",
     "campaigns.fieldInvalidBody": "Fel vid kompilering av kampanjtext: {error}",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "{name} - Kopyası",
     "campaigns.customHeadersHelp": "Giden iletilere eklenecek özel başlıkların dizisi. örn: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Tarih ve saat",
+    "campaigns.downloadPDF": "PDF olarak kaydet",
     "campaigns.ended": "Bitti",
     "campaigns.errorSendTest": "Test gönderirken hata: {error}",
     "campaigns.fieldInvalidBody": "Kampanya gövdesini oluşturma hatası: {error}",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Копія {name}",
     "campaigns.customHeadersHelp": "Масив власних заголовків, які слід додавати до вихідних листів, наприклад: [{\"X-Custom\": \"значення\"}, {\"X-Custom2\": \"тощо\"}]",
     "campaigns.dateAndTime": "Дата й час",
+    "campaigns.downloadPDF": "Зберегти як PDF",
     "campaigns.ended": "Завершено",
     "campaigns.errorSendTest": "Помилка пробного надсилання: {error}",
     "campaigns.fieldInvalidBody": "Помилка побудови тексту кампанії: {error}",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "Bản sao của {name}",
     "campaigns.customHeadersHelp": "Mảng tiêu đề tùy chỉnh để đính kèm vào thư gửi đi. ví dụ: [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "Ngày và giờ",
+    "campaigns.downloadPDF": "Lưu dưới dạng PDF",
     "campaigns.ended": "Kết thúc",
     "campaigns.errorSendTest": "Lỗi khi gửi email thử nghiệm: {error}",
     "campaigns.fieldInvalidBody": "Lỗi khi biên dịch nội dung chiến dịch: {error}",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "{name}的副本",
     "campaigns.customHeadersHelp": "要附加到传出消息的自定义标头数组。例如： [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "日期和时间",
+    "campaigns.downloadPDF": "保存为 PDF",
     "campaigns.ended": "结束",
     "campaigns.errorSendTest": "发送测试时出错：{error}",
     "campaigns.fieldInvalidBody": "编译营销活动正文时出错：{error}",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -39,6 +39,7 @@
     "campaigns.copyOf": "{name}的副本",
     "campaigns.customHeadersHelp": "要附加到傳出電子郵件的自定義 headers。例如： [{\"X-Custom\": \"value\"}, {\"X-Custom2\": \"value\"}]",
     "campaigns.dateAndTime": "日期和時間",
+    "campaigns.downloadPDF": "另存為 PDF",
     "campaigns.ended": "結束",
     "campaigns.errorSendTest": "發送測試時出現錯誤：{error}",
     "campaigns.fieldInvalidBody": "編譯廣告 body 時出現錯誤：{error}",


### PR DESCRIPTION
Closes #3084.

Adds a "Save as PDF" button to the campaign preview. It renders the campaign in a hidden iframe and opens the browser's native print dialog, from which the user chooses "Save as PDF". Purely client-side — **no backend changes and no new dependencies**.

**Changes**
- `CampaignPreview.vue`: a "Save as PDF" button (shown for campaign previews) creates a hidden iframe sandboxed `allow-same-origin allow-modals` (no `allow-scripts`, so scripts in the campaign body can't run), loads the existing preview (`previewURL` for saved-campaign GET previews, or re-submits the existing preview form for editor/archive POST previews), and calls `print()`. The visible preview iframe's sandbox is left untouched.
- One `en.json` key (`campaigns.downloadPDF`).

Output fidelity depends on the browser's print engine — a deliberate trade-off against a heavy server-side renderer (e.g. headless Chrome).

Tested: `go build` / eslint clean; the button opens the print dialog for both saved-campaign (GET) and editor/archive (POST) previews.
