### PR TITLE
Fix campaign analytics donut percentage and surface it in a legend

### DIFF
--- a/frontend/src/assets/style.scss
+++ b/frontend/src/assets/style.scss
@@ -942,6 +942,42 @@ section.analytics {
 
   .donut-container {
     position: relative;
+
+    // Center the square donut and its legend vertically in the tall chart row.
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    .chart {
+      margin-bottom: 0;
+    }
+
+    .chart canvas {
+      height: auto;
+    }
+  }
+
+  .donut-legend {
+    margin-top: 12px;
+    text-align: center;
+
+    .legend-item {
+      margin-bottom: 4px;
+      line-height: 1.4;
+    }
+
+    .dot {
+      display: inline-block;
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      margin-right: 6px;
+    }
+
+    // Wrap "(x% of sent)" as a unit, not mid-phrase.
+    .legend-rate {
+      white-space: nowrap;
+    }
   }
 }
 

--- a/frontend/src/components/Chart.vue
+++ b/frontend/src/components/Chart.vue
@@ -37,7 +37,7 @@ const DEFAULT_DONUT = {
             // Rate against messages sent if the dataset carries `sent`, else the slice share.
             if (data.sent) {
               const sent = data.sent[item.dataIndex];
-              return sent > 0 ? `${val} (${((val / sent) * 100).toFixed(2)}% of ${sent} sent)` : `${val}`;
+              return sent > 0 ? `${val} (${((val / sent) * 100).toFixed(2)}%)` : `${val}`;
             }
             const total = data.data.reduce((acc, v) => acc + v, 0);
             return `${val} (${((val / total) * 100).toFixed(2)}%)`;

--- a/frontend/src/components/Chart.vue
+++ b/frontend/src/components/Chart.vue
@@ -32,10 +32,14 @@ const DEFAULT_DONUT = {
         callbacks: {
           label: (item) => {
             const data = item.chart.data.datasets[item.datasetIndex];
-            const total = data.data.reduce((acc, val) => acc + val, 0);
             const val = data.data[item.dataIndex];
-            const percentage = ((val / total) * 100).toFixed(2);
-            return `${val} (${percentage}%)`;
+            // Rate against messages sent if the dataset carries `sent`, else the slice share.
+            if (data.sent) {
+              const sent = data.sent[item.dataIndex];
+              return sent > 0 ? `${val} (${((val / sent) * 100).toFixed(2)}% of ${sent} sent)` : `${val}`;
+            }
+            const total = data.data.reduce((acc, v) => acc + v, 0);
+            return `${val} (${((val / total) * 100).toFixed(2)}%)`;
           },
         },
       },

--- a/frontend/src/components/Chart.vue
+++ b/frontend/src/components/Chart.vue
@@ -34,13 +34,14 @@ const DEFAULT_DONUT = {
           label: (item) => {
             const data = item.chart.data.datasets[item.datasetIndex];
             const val = data.data[item.dataIndex];
-            // Rate against messages sent if the dataset carries `sent`, else the slice share.
-            if (data.sent) {
-              const sent = data.sent[item.dataIndex];
-              return sent > 0 ? `${val} (${((val / sent) * 100).toFixed(2)}%)` : `${val}`;
+            // Rate against messages sent when a per-slice `sent` count is available;
+            // otherwise fall back to the slice's share of the selected total.
+            const sent = data.sent ? data.sent[item.dataIndex] : 0;
+            if (sent > 0) {
+              return `${val} (${((val / sent) * 100).toFixed(2)}%)`;
             }
             const total = data.data.reduce((acc, v) => acc + v, 0);
-            return `${val} (${((val / total) * 100).toFixed(2)}%)`;
+            return total > 0 ? `${val} (${((val / total) * 100).toFixed(2)}%)` : `${val}`;
           },
         },
       },

--- a/frontend/src/components/Chart.vue
+++ b/frontend/src/components/Chart.vue
@@ -13,7 +13,8 @@ const DEFAULT_DONUT = {
   options: {
     responsive: true,
     cutout: '70%',
-    maintainAspectRatio: false,
+    // Square donut so it fills the column width instead of a tall canvas.
+    aspectRatio: 1,
     plugins: {
       legend: {
         display: false,

--- a/frontend/src/views/CampaignAnalytics.vue
+++ b/frontend/src/views/CampaignAnalytics.vue
@@ -234,10 +234,11 @@ export default Vue.extend({
         return sum;
       });
 
+      const sent = campIDs.map((id) => camps[id].sent || 0);
       const donut = {
         labels,
         datasets: [{
-          data: points, backgroundColor: chartColors, borderWidth: 6,
+          data: points, sent, backgroundColor: chartColors, borderWidth: 6,
         }],
       };
       return { points: { datasets: lines }, donut };

--- a/frontend/src/views/CampaignAnalytics.vue
+++ b/frontend/src/views/CampaignAnalytics.vue
@@ -62,6 +62,12 @@
           </div>
           <div class="column is-2 donut-container">
             <chart type="donut" v-if="!v.loading" :data="v.donutData" />
+            <div v-if="v.legend && counts[k] > 0" class="donut-legend is-size-7">
+              <div v-for="(r, i) in v.legend" :key="i" class="legend-item">
+                <span class="dot" :style="{ backgroundColor: r.color }" />{{ r.name }}: {{ $utils.niceNumber(r.count) }} <span
+                  v-if="r.rate" class="legend-rate has-text-grey">({{ $t('analytics.percentOfSent', { percent: r.rate }) }})</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -241,7 +247,13 @@ export default Vue.extend({
           data: points, sent, backgroundColor: chartColors, borderWidth: 6,
         }],
       };
-      return { points: { datasets: lines }, donut };
+      const legend = campIDs.map((id, i) => ({
+        name: camps[id].name,
+        count: points[i],
+        rate: sent[i] > 0 ? ((points[i] / sent[i]) * 100).toFixed(1) : null,
+        color: chartColors[i % chartColors.length],
+      }));
+      return { points: { datasets: lines }, donut, legend };
     },
 
     onSubmit() {
@@ -276,9 +288,10 @@ export default Vue.extend({
         // Set the total count.
         this.counts[typ] = data.reduce((sum, d) => sum + d.count, 0);
 
-        const { points, donut } = this.charts[typ].chartFn(typ, camps, data);
+        const { points, donut, legend } = this.charts[typ].chartFn(typ, camps, data);
         this.charts[typ].data = points;
         this.charts[typ].donutData = donut;
+        this.charts[typ].legend = legend;
         this.charts[typ].loading = false;
       });
     },

--- a/frontend/src/views/CampaignAnalytics.vue
+++ b/frontend/src/views/CampaignAnalytics.vue
@@ -65,7 +65,7 @@
             <div v-if="v.legend && counts[k] > 0" class="donut-legend is-size-7">
               <div v-for="(r, i) in v.legend" :key="i" class="legend-item">
                 <span class="dot" :style="{ backgroundColor: r.color }" />{{ r.name }}: {{ $utils.niceNumber(r.count) }} <span
-                  v-if="r.rate" class="legend-rate has-text-grey">({{ $t('analytics.percentOfSent', { percent: r.rate }) }})</span>
+                  v-if="r.rate" class="legend-rate has-text-grey">({{ $t('analytics.percentOfSent', { percent: r.rate, sent: $utils.niceNumber(r.sent) }) }})</span>
               </div>
             </div>
           </div>
@@ -241,17 +241,21 @@ export default Vue.extend({
       });
 
       const sent = campIDs.map((id) => camps[id].sent || 0);
+      // One color per slice (wrapping like the line chart) so the donut and the
+      // legend stay in sync even with more campaigns than colors.
+      const sliceColors = campIDs.map((id, i) => chartColors[i % chartColors.length]);
       const donut = {
         labels,
         datasets: [{
-          data: points, sent, backgroundColor: chartColors, borderWidth: 6,
+          data: points, sent, backgroundColor: sliceColors, borderWidth: 6,
         }],
       };
       const legend = campIDs.map((id, i) => ({
         name: camps[id].name,
         count: points[i],
+        sent: sent[i],
         rate: sent[i] > 0 ? ((points[i] / sent[i]) * 100).toFixed(1) : null,
-        color: chartColors[i % chartColors.length],
+        color: sliceColors[i],
       }));
       return { points: { datasets: lines }, donut, legend };
     },

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "تواريخ غير صالحة.",
     "analytics.links": "الروابط",
     "analytics.nonIndividualTracking": "الأرقام غير فريدة لأن تتبع المشتركين الفردي معطّل.",
-    "analytics.percentOfSent": "{percent}% من المرسلة",
+    "analytics.percentOfSent": "{percent}% من {sent} مُرسَلة",
     "analytics.title": "التحليلات",
     "analytics.toDate": "إلى",
     "analytics.trackingDisabled": "تتبع البريد معطّل. لا يتم تسجيل مشاهدات أو نقرات جديدة.",

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "تواريخ غير صالحة.",
     "analytics.links": "الروابط",
     "analytics.nonIndividualTracking": "الأرقام غير فريدة لأن تتبع المشتركين الفردي معطّل.",
+    "analytics.percentOfSent": "{percent}% من المرسلة",
     "analytics.title": "التحليلات",
     "analytics.toDate": "إلى",
     "analytics.trackingDisabled": "تتبع البريد معطّل. لا يتم تسجيل مشاهدات أو نقرات جديدة.",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Невалидни дати `от` или `до`.",
     "analytics.links": "Връзки",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% от изпратените",
     "analytics.title": "Анализи",
     "analytics.toDate": "До",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Невалидни дати `от` или `до`.",
     "analytics.links": "Връзки",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% от изпратените",
+    "analytics.percentOfSent": "{percent}% от {sent} изпратени",
     "analytics.title": "Анализи",
     "analytics.toDate": "До",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Dates  `des de` o `fins a` Invàlides.",
     "analytics.links": "Enllaços",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% dels enviats",
     "analytics.title": "Indicadors",
     "analytics.toDate": "Fins a",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Dates  `des de` o `fins a` Invàlides.",
     "analytics.links": "Enllaços",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% dels enviats",
+    "analytics.percentOfSent": "{percent}% de {sent} enviats",
     "analytics.title": "Indicadors",
     "analytics.toDate": "Fins a",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Neplatné datum `od` nebo `do`.",
     "analytics.links": "Odkazy",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent} % z odeslaných",
+    "analytics.percentOfSent": "{percent} % z {sent} odeslaných",
     "analytics.title": "Analytika",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Neplatné datum `od` nebo `do`.",
     "analytics.links": "Odkazy",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent} % z odeslaných",
     "analytics.title": "Analytika",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/cy.json
+++ b/i18n/cy.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Dyddiadau 'o' neu 'i' annilys",
     "analytics.links": "Dolenni",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% o'r rhai a anfonwyd",
+    "analytics.percentOfSent": "{percent}% o {sent} a anfonwyd",
     "analytics.title": "Dadansoddeg",
     "analytics.toDate": "At",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/cy.json
+++ b/i18n/cy.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Dyddiadau 'o' neu 'i' annilys",
     "analytics.links": "Dolenni",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% o'r rhai a anfonwyd",
     "analytics.title": "Dadansoddeg",
     "analytics.toDate": "At",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Ugyldig `fra`- eller `til`-dato.",
     "analytics.links": "Links",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% af sendte",
     "analytics.title": "Statistik",
     "analytics.toDate": "Til",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Ugyldig `fra`- eller `til`-dato.",
     "analytics.links": "Links",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% af sendte",
+    "analytics.percentOfSent": "{percent}% af {sent} sendte",
     "analytics.title": "Statistik",
     "analytics.toDate": "Til",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Ungültiges Datum in `von` oder `bis`.",
     "analytics.links": "Verweise",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent} % der gesendeten",
+    "analytics.percentOfSent": "{percent} % von {sent} gesendeten",
     "analytics.title": "Statistiken",
     "analytics.toDate": "Bis",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Ungültiges Datum in `von` oder `bis`.",
     "analytics.links": "Verweise",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent} % der gesendeten",
     "analytics.title": "Statistiken",
     "analytics.toDate": "Bis",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Μή έγκυρη ημερομηνία `από` ή `έως`.",
     "analytics.links": "Σύνδεσμοι",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% των απεσταλμένων",
+    "analytics.percentOfSent": "{percent}% από {sent} απεσταλμένα",
     "analytics.title": "Στατιστικά",
     "analytics.toDate": "Έως",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Μή έγκυρη ημερομηνία `από` ή `έως`.",
     "analytics.links": "Σύνδεσμοι",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% των απεσταλμένων",
     "analytics.title": "Στατιστικά",
     "analytics.toDate": "Έως",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Invalid `from` or `to` dates.",
     "analytics.links": "Links",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% of sent",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",
     "analytics.title": "Analytics",
     "analytics.toDate": "To",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Invalid `from` or `to` dates.",
     "analytics.links": "Links",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% of sent",
+    "analytics.percentOfSent": "{percent}% of {sent} sent",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",
     "analytics.title": "Analytics",
     "analytics.toDate": "To",

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Datoj  `de` aŭ `ĝis` nevalidaj.",
     "analytics.links": "Ligiloj",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% el la senditaj",
     "analytics.title": "Indikiloj",
     "analytics.toDate": "Ĝis",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Datoj  `de` aŭ `ĝis` nevalidaj.",
     "analytics.links": "Ligiloj",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% el la senditaj",
+    "analytics.percentOfSent": "{percent}% el {sent} senditaj",
     "analytics.title": "Indikiloj",
     "analytics.toDate": "Ĝis",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "La fecha `desde` o `hasta` no es válida.",
     "analytics.links": "Enlaces",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% de los enviados",
     "analytics.title": "Analíticas",
     "analytics.toDate": "Hasta",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "La fecha `desde` o `hasta` no es válida.",
     "analytics.links": "Enlaces",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% de los enviados",
+    "analytics.percentOfSent": "{percent}% de {sent} enviados",
     "analytics.title": "Analíticas",
     "analytics.toDate": "Hasta",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Virheellinen `alkaen` tai `päättyen` päivämäärä.",
     "analytics.links": "Linkit",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% lähetetyistä",
     "analytics.title": "Tilastot",
     "analytics.toDate": "Päättyen",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Virheellinen `alkaen` tai `päättyen` päivämäärä.",
     "analytics.links": "Linkit",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% lähetetyistä",
+    "analytics.percentOfSent": "{percent}% / {sent} lähetetystä",
     "analytics.title": "Tilastot",
     "analytics.toDate": "Päättyen",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/fr-CA.json
+++ b/i18n/fr-CA.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Dates invalides `depuis` ou `au`.",
     "analytics.links": "Liens",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent} % des envoyés",
+    "analytics.percentOfSent": "{percent} % de {sent} envoyés",
     "analytics.title": "Analyses",
     "analytics.toDate": "Au",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/fr-CA.json
+++ b/i18n/fr-CA.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Dates invalides `depuis` ou `au`.",
     "analytics.links": "Liens",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent} % des envoyés",
     "analytics.title": "Analyses",
     "analytics.toDate": "Au",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Dates invalides `depuis` ou `au`.",
     "analytics.links": "Liens",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent} % des envoyés",
+    "analytics.percentOfSent": "{percent} % de {sent} envoyés",
     "analytics.title": "Analyses",
     "analytics.toDate": "Au",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Dates invalides `depuis` ou `au`.",
     "analytics.links": "Liens",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent} % des envoyés",
     "analytics.title": "Analyses",
     "analytics.toDate": "Au",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "טווח תאריכים לא חוקי.",
     "analytics.links": "קישורים",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% מתוך הנשלחים",
     "analytics.title": "סטטיסטיקות",
     "analytics.toDate": "ל",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "טווח תאריכים לא חוקי.",
     "analytics.links": "קישורים",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% מתוך הנשלחים",
+    "analytics.percentOfSent": "{percent}% מתוך {sent} שנשלחו",
     "analytics.title": "סטטיסטיקות",
     "analytics.toDate": "ל",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Érvénytelen kezdő vagy végdátum.",
     "analytics.links": "Hivatkozások",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% az elküldöttekből",
+    "analytics.percentOfSent": "{percent}% / {sent} elküldöttből",
     "analytics.title": "Kimutatások",
     "analytics.toDate": "Eddig",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Érvénytelen kezdő vagy végdátum.",
     "analytics.links": "Hivatkozások",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% az elküldöttekből",
     "analytics.title": "Kimutatások",
     "analytics.toDate": "Eddig",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Tanggal `dari` atau `ke` tidak valid.",
     "analytics.links": "Tautan",
     "analytics.nonIndividualTracking": "Jumlah tidak unik karena pelacakan pelanggan individu dimatikan.",
-    "analytics.percentOfSent": "{percent}% dari yang terkirim",
+    "analytics.percentOfSent": "{percent}% dari {sent} terkirim",
     "analytics.trackingDisabled": "Pelacakan e-mail dinonaktifkan secara global. Tidak ada tayangan atau klik baru yang direkam.",
     "analytics.title": "Analitik",
     "analytics.toDate": "Ke",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Tanggal `dari` atau `ke` tidak valid.",
     "analytics.links": "Tautan",
     "analytics.nonIndividualTracking": "Jumlah tidak unik karena pelacakan pelanggan individu dimatikan.",
+    "analytics.percentOfSent": "{percent}% dari yang terkirim",
     "analytics.trackingDisabled": "Pelacakan e-mail dinonaktifkan secara global. Tidak ada tayangan atau klik baru yang direkam.",
     "analytics.title": "Analitik",
     "analytics.toDate": "Ke",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Date `da` o `fino` non valide.",
     "analytics.links": "Link",
     "analytics.nonIndividualTracking": "I conteggi non sono univoci poiché il tracciamento dei singoli abbonati è disattivato.",
+    "analytics.percentOfSent": "{percent}% degli inviati",
     "analytics.title": "Analitiche",
     "analytics.toDate": "a",
     "analytics.trackingDisabled": "Il tracciamento delle email è disabilitato a livello globale. Non vengono registrate nuove visualizzazioni o clic.",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Date `da` o `fino` non valide.",
     "analytics.links": "Link",
     "analytics.nonIndividualTracking": "I conteggi non sono univoci poiché il tracciamento dei singoli abbonati è disattivato.",
-    "analytics.percentOfSent": "{percent}% degli inviati",
+    "analytics.percentOfSent": "{percent}% di {sent} inviati",
     "analytics.title": "Analitiche",
     "analytics.toDate": "a",
     "analytics.trackingDisabled": "Il tracciamento delle email è disabilitato a livello globale. Non vengono registrate nuove visualizzazioni o clic.",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "無効な `から` 又は `まで` の日付.",
     "analytics.links": "リンク",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "送信数の{percent}%",
     "analytics.title": "分析",
     "analytics.toDate": "まで",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "無効な `から` 又は `まで` の日付.",
     "analytics.links": "リンク",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "送信数の{percent}%",
+    "analytics.percentOfSent": "{sent} 件中 {percent}%",
     "analytics.title": "分析",
     "analytics.toDate": "まで",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "잘못된 `시작일` 또는 `종료일` 날짜입니다.",
     "analytics.links": "링크",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "발송 대비 {percent}%",
+    "analytics.percentOfSent": "{sent}건 중 {percent}%",
     "analytics.title": "분석",
     "analytics.toDate": "종료일",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "잘못된 `시작일` 또는 `종료일` 날짜입니다.",
     "analytics.links": "링크",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "발송 대비 {percent}%",
     "analytics.title": "분석",
     "analytics.toDate": "종료일",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ml.json
+++ b/i18n/ml.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "തെറ്റായ തിയതികൾ",
     "analytics.links": "ലിങ്കുകൾ",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "അയച്ചതിന്റെ {percent}%",
+    "analytics.percentOfSent": "അയച്ച {sent}-ൽ {percent}%",
     "analytics.title": "അനലിറ്റിക്സ്",
     "analytics.toDate": "വരെ",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ml.json
+++ b/i18n/ml.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "തെറ്റായ തിയതികൾ",
     "analytics.links": "ലിങ്കുകൾ",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "അയച്ചതിന്റെ {percent}%",
     "analytics.title": "അനലിറ്റിക്സ്",
     "analytics.toDate": "വരെ",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Ongeldige `van` of `tot` datums.",
     "analytics.links": "Koppelingen",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% van verzonden",
     "analytics.title": "Analyse",
     "analytics.toDate": "Tot",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Ongeldige `van` of `tot` datums.",
     "analytics.links": "Koppelingen",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% van verzonden",
+    "analytics.percentOfSent": "{percent}% van {sent} verzonden",
     "analytics.title": "Analyse",
     "analytics.toDate": "Tot",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Ugyldige `fra`- eller `til`-datoer.",
     "analytics.links": "Lenker",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% av sendte",
     "analytics.title": "Analyse",
     "analytics.toDate": "Til",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Ugyldige `fra`- eller `til`-datoer.",
     "analytics.links": "Lenker",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% av sendte",
+    "analytics.percentOfSent": "{percent}% av {sent} sendte",
     "analytics.title": "Analyse",
     "analytics.toDate": "Til",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Nieprawidłowe daty `from` lub `to`.",
     "analytics.links": "Linki",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% wysłanych",
+    "analytics.percentOfSent": "{percent}% z {sent} wysłanych",
     "analytics.title": "Analityka",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Nieprawidłowe daty `from` lub `to`.",
     "analytics.links": "Linki",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% wysłanych",
     "analytics.title": "Analityka",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Data `from` ou `to` inválidas.",
     "analytics.links": "Links",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% dos enviados",
+    "analytics.percentOfSent": "{percent}% de {sent} enviados",
     "analytics.title": "Análises",
     "analytics.toDate": "Para",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Data `from` ou `to` inválidas.",
     "analytics.links": "Links",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% dos enviados",
     "analytics.title": "Análises",
     "analytics.toDate": "Para",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Datas `desde` e `até` inválidas.",
     "analytics.links": "Endereços",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% dos enviados",
+    "analytics.percentOfSent": "{percent}% de {sent} enviados",
     "analytics.title": "Analítica",
     "analytics.toDate": "Até",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Datas `desde` e `até` inválidas.",
     "analytics.links": "Endereços",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% dos enviados",
     "analytics.title": "Analítica",
     "analytics.toDate": "Até",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Invalid `de la` sau `la` dată.",
     "analytics.links": "Linkuri",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% din cele trimise",
+    "analytics.percentOfSent": "{percent}% din {sent} trimise",
     "analytics.title": "Analitice",
     "analytics.toDate": "Către",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Invalid `de la` sau `la` dată.",
     "analytics.links": "Linkuri",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% din cele trimise",
     "analytics.title": "Analitice",
     "analytics.toDate": "Către",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Неверно указаны даты `from` или `to`.",
     "analytics.links": "Ссылки",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% от отправленных",
     "analytics.title": "Аналитика",
     "analytics.toDate": "По",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Неверно указаны даты `from` или `to`.",
     "analytics.links": "Ссылки",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% от отправленных",
+    "analytics.percentOfSent": "{percent}% из {sent} отправленных",
     "analytics.title": "Аналитика",
     "analytics.toDate": "По",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Neplatný dátum `od` alebo `do`.",
     "analytics.links": "Odkazy",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent} % z odoslaných",
+    "analytics.percentOfSent": "{percent} % z {sent} odoslaných",
     "analytics.title": "Analytika",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Neplatný dátum `od` alebo `do`.",
     "analytics.links": "Odkazy",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent} % z odoslaných",
     "analytics.title": "Analytika",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Neveljavni datumi `od` ali `do`.",
     "analytics.links": "Povezave",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% poslanih",
+    "analytics.percentOfSent": "{percent}% od {sent} poslanih",
     "analytics.title": "Analitika",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Neveljavni datumi `od` ali `do`.",
     "analytics.links": "Povezave",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% poslanih",
     "analytics.title": "Analitika",
     "analytics.toDate": "Do",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Ogiltiga `från` eller `till` datum.",
     "analytics.links": "Länkar",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% av skickade",
+    "analytics.percentOfSent": "{percent}% av {sent} skickade",
     "analytics.title": "Analys",
     "analytics.toDate": "Till",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Ogiltiga `från` eller `till` datum.",
     "analytics.links": "Länkar",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% av skickade",
     "analytics.title": "Analys",
     "analytics.toDate": "Till",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Geçersiz `başlangıç' veya `bitiş' tarihleri.",
     "analytics.links": "Bağlantılar",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "gönderilenlerin %{percent}'i",
     "analytics.title": "Analitik",
     "analytics.toDate": "Bitiş Tarihi",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Geçersiz `başlangıç' veya `bitiş' tarihleri.",
     "analytics.links": "Bağlantılar",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "gönderilenlerin %{percent}'i",
+    "analytics.percentOfSent": "gönderilenlerin {percent}%'i",
     "analytics.title": "Analitik",
     "analytics.toDate": "Bitiş Tarihi",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Geçersiz `başlangıç' veya `bitiş' tarihleri.",
     "analytics.links": "Bağlantılar",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "gönderilenlerin {percent}%'i",
+    "analytics.percentOfSent": "{sent} gönderilenin {percent}%'i",
     "analytics.title": "Analitik",
     "analytics.toDate": "Bitiş Tarihi",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Хибна дата `from` чи `to`.",
     "analytics.links": "Посилання",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% від надісланих",
+    "analytics.percentOfSent": "{percent}% з {sent} надісланих",
     "analytics.title": "Аналітика",
     "analytics.toDate": "До",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Хибна дата `from` чи `to`.",
     "analytics.links": "Посилання",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% від надісланих",
     "analytics.title": "Аналітика",
     "analytics.toDate": "До",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "Ngày không hợp lệ.",
     "analytics.links": "Đường dẫn",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "{percent}% đã gửi",
     "analytics.title": "Phân tích",
     "analytics.toDate": "Đến",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "Ngày không hợp lệ.",
     "analytics.links": "Đường dẫn",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "{percent}% đã gửi",
+    "analytics.percentOfSent": "{percent}% trong số {sent} đã gửi",
     "analytics.title": "Phân tích",
     "analytics.toDate": "Đến",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "无效的 `from` 或 `to` 日期。",
     "analytics.links": "链接",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "已发送的{percent}%",
     "analytics.title": "统计信息",
     "analytics.toDate": "至",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "无效的 `from` 或 `to` 日期。",
     "analytics.links": "链接",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "已发送的{percent}%",
+    "analytics.percentOfSent": "已发送 {sent} 封中的 {percent}%",
     "analytics.title": "统计信息",
     "analytics.toDate": "至",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -7,6 +7,7 @@
     "analytics.invalidDates": "無效的`開始` 或`結束` 日期。",
     "analytics.links": "連結",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
+    "analytics.percentOfSent": "已傳送的{percent}%",
     "analytics.title": "分析",
     "analytics.toDate": "至",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -7,7 +7,7 @@
     "analytics.invalidDates": "無效的`開始` 或`結束` 日期。",
     "analytics.links": "連結",
     "analytics.nonIndividualTracking": "The counts are non-unique as individual subscriber tracking is turned off.",
-    "analytics.percentOfSent": "已傳送的{percent}%",
+    "analytics.percentOfSent": "已傳送 {sent} 封中的 {percent}%",
     "analytics.title": "分析",
     "analytics.toDate": "至",
     "analytics.trackingDisabled": "E-mail tracking is globally disabled. No new views or clicks are being recorded.",


### PR DESCRIPTION
Addresses the donut issues in #1728: the donut shows a wrong percentage, and the counts/percentages the pre-3.0 UI displayed are no longer visible on the page.

**1. Percentage relative to sent.** The tooltip computes each slice as its share of the *selected campaigns' total*, so one selected campaign always reads 100% and two show the ratio between them — as @MaximilianKohler diagnosed (531 for a 2000-sent campaign, https://github.com/knadh/listmonk/issues/1728#issuecomment-4380857084) and as @Bowrna noted earlier in the thread. It now carries per-slice `sent` counts in the donut dataset and computes the rate against them — `531 (26.55% of 2000 sent)` — falling back to the inter-slice share when `sent` is unavailable.

**2. Visible numbers.** @knadh found the chart.js labels plugin couldn't be made to work (https://github.com/knadh/listmonk/issues/1728#issuecomment-2017314683). Rather than add a dependency, this puts a small legend beneath each donut listing every campaign with its count and rate, readable without hovering — restoring what the old half-gauge showed (https://github.com/knadh/listmonk/issues/1728#issuecomment-1987235485). The donut is made square so it fills its column width with no empty space, and it and the legend are centred against the line chart. The legend is hidden for chart types with no data.

Requested by @MaximilianKohler, who also outlined this approach (pass `sent` into the calc, fix the tooltip, show the values without a new dependency): https://github.com/knadh/listmonk/pull/3085#issuecomment-4712824940

Two focused commits: (1) the percentage fix, (2) the legend.

Fixes #1728.
