### PR TITLE
Show the "Links" chart heading on the campaign analytics page

### DIFF
--- a/frontend/src/views/CampaignAnalytics.vue
+++ b/frontend/src/views/CampaignAnalytics.vue
@@ -54,9 +54,9 @@
         <div class="columns">
           <div class="column is-9">
             <b-loading v-if="v.loading" :active="v.loading" :is-full-page="false" />
-            <h4 v-if="v.chart !== null">
+            <h4>
               {{ v.name }}
-              <span class="has-text-grey-light">({{ $utils.niceNumber(counts[k]) }})</span>
+              <span v-if="v.type !== 'bar'" class="has-text-grey-light">({{ $utils.niceNumber(counts[k]) }})</span>
             </h4>
             <chart :type="v.type" v-if="!v.loading" :data="v.data" :on-click="v.onClick" />
           </div>
@@ -139,7 +139,6 @@ export default Vue.extend({
           name: this.$t('analytics.links'),
           type: 'bar',
           data: null,
-          chart: null,
           loading: false,
           fn: this.$api.getCampaignLinkCounts,
           chartFn: this.makeLinksChart,


### PR DESCRIPTION
Fixes #3089.

The Links bar chart was the only analytics chart without a heading because its config still carried `chart: null` purely to gate the `<h4>` — a leftover from the c3.js→chart.js migration. This drops the dead property and renders the heading like the other charts.

The count parenthetical is omitted for the Links (bar) chart: its only available total is the sum of per-link clicks, which duplicates the Clicks chart's total, and the per-link counts are already shown on the bars.
