### PR TITLE
Fix dev environment when `$GOPATH` is not set

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - db
     volumes:
       - ../:/app
-      - $GOPATH/pkg/mod/cache:/go/pkg/mod/cache
+      - ${GOPATH:-${HOME}/go}/pkg/mod/cache:/go/pkg/mod/cache
     networks:
       - listmonk-dev
 


### PR DESCRIPTION
We now default to `~/go`, ensuring that we don't try to mount `/pkg/mod/cache` (which isn't allowed)