### PR TITLE
Initialize `dev-docker` automatically

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,5 @@
   "dockerComposeFile": "../dev/docker-compose.yml",
   "service": "backend",
   "workspaceFolder": "/app",
-  "forwardPorts": [9000],
-  "postStartCommand": "make dist && ./listmonk --install --idempotent --yes --config dev/config.toml"
+  "forwardPorts": [9000]
 }

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,13 @@ dev-docker: build-dev-docker ## Build and spawns docker containers for the entir
 run-backend-docker:
 	CGO_ENABLED=0 go run -ldflags="-s -w -X 'main.buildString=${BUILDSTR}' -X 'main.versionString=${VERSION}' -X 'main.frontendDir=frontend/dist'" ./cmd --config=dev/config.toml
 
+# Build assets and install the DB schema for the docker dev suite.
+.PHONY: init-docker
+init-docker:
+	@test -d frontend/dist || $(MAKE) build-frontend
+	@test -f $(BIN) || $(MAKE) build
+	./listmonk --install --idempotent --yes --config dev/config.toml
+
 # Tear down the complete local development docker suite.
 .PHONY: rm-dev-docker
 rm-dev-docker: build ## Delete the docker containers including DB volumes.
@@ -144,6 +151,6 @@ rm-dev-docker: build ## Delete the docker containers including DB volumes.
 
 # Setup the db for local dev docker suite.
 .PHONY: init-dev-docker
-init-dev-docker: build-dev-docker ## Delete the docker containers including DB volumes.
+init-dev-docker: build-dev-docker ## Build assets and install the DB schema in docker.
 	cd dev; \
-	docker compose run --rm backend sh -c "make dist && ./listmonk --install --idempotent --yes --config dev/config.toml"
+	docker compose run --rm init

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -33,6 +33,21 @@ services:
         source: listmonk-dev-db
         target: /var/lib/postgresql/data
 
+  init:
+    build:
+      context: ../
+      dockerfile: dev/app.Dockerfile
+    command: ["make", "init-docker"]
+    depends_on:
+      db:
+        condition: service_started
+    volumes:
+      - ../:/app
+      - ${GOPATH:-${HOME}/go}/pkg/mod/cache:/go/pkg/mod/cache
+    networks:
+      - listmonk-dev
+    restart: "no"
+
   front:
     build:
       context: ../
@@ -57,7 +72,10 @@ services:
     ports:
       - "9000:9000"
     depends_on:
-      - db
+      db:
+        condition: service_started
+      init:
+        condition: service_completed_successfully
     volumes:
       - ../:/app
       - ${GOPATH:-${HOME}/go}/pkg/mod/cache:/go/pkg/mod/cache

--- a/docs/docs/content/developer-setup.md
+++ b/docs/docs/content/developer-setup.md
@@ -30,8 +30,7 @@ After setting up the dev environment, you can visit `http://localhost:8080`.
 
 2. Inside containers (Using Makefile)
 
-    - Run `make init-dev-docker` to setup container for db.
-    - Run `make dev-docker` to setup docker container suite.
+    - Run `make dev-docker` to build and start the docker container suite.
     - Run `make rm-dev-docker` to clean up docker container suite.
 
 3. Inside containers (Using devcontainer)


### PR DESCRIPTION
`init-dev-docker` ran `make dist && ./listmonk --install`, and was an explicit manual step that users would have to do to get the `dev-docker` environment up and running.

For users of the `dev-docker` development environment, this commit simplifies setup; users just have to `make dev-docker` without having to remember to `make init-dev-docker`.

But, more importantly, this fixes the broken `devcontainer.json`, which gave users no opportunity to `init-dev-docker` before it automatically tries to start the `backend` container.

Now, `backend` depends on a new `init` container, which runs `make init-docker` and exits. `make init-docker` runs `make build-frontend` (we never needed a production `make dist` build for development), builds `listmonk`, and runs `./listmonk --install --idempotent`.

On my machine, this imperceptibly slows down `dev-docker` startup, running `./listmonk --install --idempotent` before starting the `backend`.

Fixes #3101

(Note: `devcontainer.json` requires PR #3102 to merge before it will actually work, because it's also blocked by bug #3099.)