### PR TITLE
Update simples3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/paulbellamy/ratecounter v0.2.0
 	github.com/pquerna/otp v1.5.0
-	github.com/rhnvrm/simples3 v0.9.1
+	github.com/rhnvrm/simples3 v0.11.1
 	github.com/spf13/pflag v1.0.6
 	github.com/yuin/goldmark v1.7.12
 	github.com/zerodha/easyjson v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/rhnvrm/simples3 v0.9.1 h1:pYfEe2wTjx8B2zFzUdy4kZn3I3Otd9ZvzIhHkFR85kE=
-github.com/rhnvrm/simples3 v0.9.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
+github.com/rhnvrm/simples3 v0.11.1 h1:/IU3Jz7R3oSJfafPvXemwSZvh0wZ1nFcc2CceMmloU4=
+github.com/rhnvrm/simples3 v0.11.1/go.mod h1:c2xW30bukipkBlWNnXG1wDjq3gykQ6ww2AB/9NHMLMY=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=


### PR DESCRIPTION
When using a private S3 bucket as media source, uploading files and sending campaigns with attachments works correctly, but previewing/opening media from the media tab sometimes fails with S3 SignatureDoesNotMatch error.

This happens because simples3 v0.9.1 writes the ObjectKey raw (unencoded) into both the canonical request and the presigned URL. When the browser fetches the URL, it URL-encodes reserved characters, so the path S3 receives doesn't match the path that was signed.
