### PR TITLE
Run regTplFuncs on MJML campaign body

### DIFF
--- a/models/campaigns.go
+++ b/models/campaigns.go
@@ -172,7 +172,11 @@ func (c *Campaign) CompileTemplate(f template.FuncMap) error {
 	// the campaign body for the `{{ template "content" . }}` placeholder in
 	// the base, then run mjml.Render once.
 	if c.ContentType == CampaignContentTypeMJML {
-		b := regexpTplTag.ReplaceAllLiteralString(body, c.Body)
+		campBody := c.Body
+		for _, r := range regTplFuncs {
+			campBody = r.regExp.ReplaceAllString(campBody, r.replace)
+		}
+		b := regexpTplTag.ReplaceAllLiteralString(body, campBody)
 		htmlBody, err := mjml.Render(b)
 		if err != nil {
 			return fmt.Errorf("error compiling MJML: %v", err)


### PR DESCRIPTION
This fixes the issue Hodor raised in https://github.com/knadh/listmonk/pull/2643#pullrequestreview-4540013359

> * **[P1] Apply template-func normalization to MJML body before mjml.Render** (`models/campaigns.go:171-188`)
>     * In `CompileTemplate()` the MJML path substitutes `c.Body` into the base and runs `mjml.Render()` before the campaign body ever goes through `regTplFuncs` rewriting (and the `content` sub-template is later set to `""`). This means shorthand template helper calls inside the campaign body (eg `{{ TrackLink "..." }}`, `{{ TrackView }}` etc.) won't be rewritten to include dot context and can fail at render/send time even though non-MJML bodies get this normalization.

