### PR TITLE
Attach newly created lists to the creating user's list role

### DIFF
--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -108,6 +108,17 @@ func (a *App) CreateList(c echo.Context) error {
 		return err
 	}
 
+	// Attach the new list to the creating user's list role (if any) with get and
+	// manage permissions so that they can immediately see and manage the list they
+	// created. Super admins and users with lists:get_all / lists:manage_all can
+	// already access all lists, so this is moot for them.
+	user := auth.GetUser(c)
+	if user.UserRole.ID != auth.SuperAdminRoleID && user.ListRoleID != nil {
+		if err := a.core.AddListPermission(*user.ListRoleID, out.ID, []string{auth.PermListGet, auth.PermListManage}); err != nil {
+			return err
+		}
+	}
+
 	return c.JSON(http.StatusOK, okResp{out})
 }
 

--- a/internal/core/roles.go
+++ b/internal/core/roles.go
@@ -116,6 +116,17 @@ func (c *Core) UpsertListPermissions(roleID int, lp []auth.ListPermission) error
 	return nil
 }
 
+// AddListPermission grants a single list's permissions to a role without
+// affecting the role's other list permissions.
+func (c *Core) AddListPermission(roleID, listID int, perms []string) error {
+	if _, err := c.q.AddListPermission.Exec(roleID, listID, pq.Array(perms)); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError,
+			c.i18n.Ts("globals.messages.errorUpdating", "name", "{users.role}", "error", pqErrMsg(err)))
+	}
+
+	return nil
+}
+
 // DeleteListPermission deletes a list permission entry from a role.
 func (c *Core) DeleteListPermission(roleID, listID int) error {
 	if _, err := c.q.DeleteListPermission.Exec(roleID, listID); err != nil {

--- a/models/queries.go
+++ b/models/queries.go
@@ -137,6 +137,7 @@ type Queries struct {
 	UpdateRole            *sqlx.Stmt `query:"update-role"`
 	DeleteRole            *sqlx.Stmt `query:"delete-role"`
 	UpsertListPermissions *sqlx.Stmt `query:"upsert-list-permissions"`
+	AddListPermission     *sqlx.Stmt `query:"add-list-permission"`
 	DeleteListPermission  *sqlx.Stmt `query:"delete-list-permission"`
 }
 

--- a/queries/roles.sql
+++ b/queries/roles.sql
@@ -42,6 +42,11 @@ INSERT INTO roles (parent_id, list_id, permissions, type)
     SELECT $1, list_id, ARRAY_REMOVE(ARRAY(SELECT JSONB_ARRAY_ELEMENTS_TEXT(perms)), ''), 'list' FROM p
     ON CONFLICT (parent_id, list_id) DO UPDATE SET permissions = EXCLUDED.permissions;
 
+-- name: add-list-permission
+-- Grants a single list's permissions to a role, leaving the role's other list permissions intact.
+INSERT INTO roles (parent_id, list_id, permissions, type) VALUES($1, $2, $3, 'list')
+    ON CONFLICT (parent_id, list_id) DO UPDATE SET permissions = EXCLUDED.permissions;
+
 -- name: delete-list-permission
 DELETE FROM roles WHERE parent_id=$1 AND list_id=$2;
 


### PR DESCRIPTION
A non-super-admin user who creates a list (with the `lists:manage_all` permission) could not see or manage it afterwards. New lists were not attached to any list role, so the creator had no `list:get` grant on them and they stayed invisible on the Lists page until an admin manually assigned them.

On creation, attach the new list to the creator's list role (if they have one) with get and manage permissions, so it is immediately visible and manageable. Super admins and users with `lists:get_all` / `lists:manage_all` already see all lists and are unaffected.

Backend-only (respects the frontend freeze). Verified with `go build` + `go vet`; the repo has no Go test harness for this path.

Fixes #2798