### PR TITLE
feat: add Anypost as a bounce webhook provider

### DIFF
--- a/cmd/bounce.go
+++ b/cmd/bounce.go
@@ -273,6 +273,20 @@ func (a *App) BounceWebhook(c echo.Context) error {
 		}
 		bounces = append(bounces, bs...)
 
+	// Anypost.
+	case service == "anypost" && a.bounce.Anypost != nil:
+		sig := c.Request().Header.Get("Anypost-Signature")
+		bs, err := a.bounce.Anypost.ProcessBounce(sig, rawReq)
+		if err != nil {
+			a.log.Printf("error processing anypost notification: %v", err)
+			if _, ok := err.(*echo.HTTPError); ok {
+				return err
+			}
+
+			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
+		}
+		bounces = append(bounces, bs...)
+
 	default:
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("bounces.unknownService"))
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -150,6 +150,7 @@ type Config struct {
 	BouncePostmarkEnabled     bool
 	BounceForwardemailEnabled bool
 	BounceLettermintEnabled   bool
+	BounceAnypostEnabled      bool
 
 	PermissionsRaw json.RawMessage
 	Permissions    map[string]struct{}
@@ -517,6 +518,7 @@ func initConstConfig(ko *koanf.Koanf) *Config {
 	c.BouncePostmarkEnabled = ko.Bool("bounce.postmark.enabled")
 	c.BounceForwardemailEnabled = ko.Bool("bounce.forwardemail.enabled")
 	c.BounceLettermintEnabled = ko.Bool("bounce.lettermint.enabled")
+	c.BounceAnypostEnabled = ko.Bool("bounce.anypost.enabled")
 	c.HasLegacyUser = ko.Exists("app.admin_username") || ko.Exists("app.admin_password")
 
 	b := md5.Sum([]byte(time.Now().String()))
@@ -850,6 +852,13 @@ func initBounceManager(cb func(models.Bounce) error, stmt *sqlx.Stmt, lo *log.Lo
 		}{
 			ko.Bool("bounce.lettermint.enabled"),
 			ko.String("bounce.lettermint.key"),
+		},
+		Anypost: struct {
+			Enabled bool
+			Key     string
+		}{
+			ko.Bool("bounce.anypost.enabled"),
+			ko.String("bounce.anypost.key"),
 		},
 		RecordBounceCB: cb,
 	}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -78,6 +78,7 @@ func (a *App) GetSettings(c echo.Context) error {
 	s.BouncePostmark.Password = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BouncePostmark.Password))
 	s.BounceForwardEmail.Key = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceForwardEmail.Key))
 	s.BounceLettermint.Key = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceLettermint.Key))
+	s.BounceAnypost.Key = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceAnypost.Key))
 	s.SecurityCaptcha.HCaptcha.Secret = strings.Repeat(pwdMask, utf8.RuneCountInString(s.SecurityCaptcha.HCaptcha.Secret))
 	s.OIDC.ClientSecret = strings.Repeat(pwdMask, utf8.RuneCountInString(s.OIDC.ClientSecret))
 
@@ -246,6 +247,11 @@ func (a *App) UpdateSettings(c echo.Context) error {
 	}
 	if set.BounceLettermint.Key == "" {
 		set.BounceLettermint.Key = cur.BounceLettermint.Key
+	}
+	// With no Anypost settings UI to blank the mask (until v7), a save can
+	// round-trip the placeholder back, so treat an all-mask key as unchanged too.
+	if set.BounceAnypost.Key == "" || strings.Trim(set.BounceAnypost.Key, pwdMask) == "" {
+		set.BounceAnypost.Key = cur.BounceAnypost.Key
 	}
 	if set.SecurityCaptcha.HCaptcha.Secret == "" {
 		set.SecurityCaptcha.HCaptcha.Secret = cur.SecurityCaptcha.HCaptcha.Secret

--- a/docs/docs/content/bounces.md
+++ b/docs/docs/content/bounces.md
@@ -53,6 +53,7 @@ listmonk supports receiving bounce webhook events from the following SMTP provid
 | `https://listmonk.yoursite.com/webhooks/service/postmark`     | Postmark webhook                       | [More info](https://postmarkapp.com/developer/webhooks/webhooks-overview)                                             |
 | `https://listmonk.yoursite.com/webhooks/service/forwardemail` | Forward Email webhook                  | [More info](https://forwardemail.net/en/faq#do-you-support-bounce-webhooks)                                           |
 | `https://listmonk.yoursite.com/webhooks/service/lettermint`   | Lettermint webhook                     | [More info](https://lettermint.co/knowledge-base/guides/send-newsletter-with-listmonk)                                                |
+| `https://listmonk.yoursite.com/webhooks/service/anypost`      | Anypost webhook                        | [More info](https://anypost.com/docs/webhooks)                                                                        |
 
 ## Amazon Simple Email Service (SES)
 
@@ -111,6 +112,29 @@ If you use Azure Communication Services Email, listmonk can receive delivery rep
 4. During subscription creation, Event Grid sends a subscription validation event. listmonk automatically returns `validationResponse` for this handshake.
 5. Subscribe to `Microsoft.Communication.EmailDeliveryReportReceived` events. listmonk maps relevant statuses to bounce records.
 6. Send test mail and verify bounces in listmonk.
+
+## Anypost
+
+If you use [Anypost](https://anypost.com) as your SMTP provider, listmonk can receive its webhook events and turn them into bounces. listmonk maps `email.bounced` to hard bounces (soft when the failure is transient) and `email.complained` to complaints. It also maps `email.suppressed` (a send Anypost dropped because the address was already on your suppression list): those carrying `data.suppression.reason` of `permanent_bounce` become hard bounces and `complaint` become complaints, keeping listmonk in sync even if it never saw the original event. Suppressions for `unsubscribed` and `manual` reasons are opt-outs, not bounces, and are ignored. Bounces are attributed to campaigns automatically: Anypost echoes the `X-Listmonk-Campaign` header on its events. Complaints arriving via feedback loops and out-of-band bounces carry no headers, so those are recorded against the subscriber without a campaign.
+
+1. In the [Anypost dashboard](https://anypost.com), create a webhook endpoint with:
+    - URL: `https://listmonk.yoursite.com/webhooks/service/anypost`
+    - Events: `email.bounced`, `email.complained`, `email.suppressed`
+2. Copy the webhook's signing secret (`whsec_...`), shown once at creation.
+3. Enable the integration via the listmonk [settings API](https://listmonk.app/docs/apis/apis/) (the admin UI does not have fields for it yet). The API takes the full settings object, so fetch it, blank out the masked secrets (listmonk preserves secrets submitted as empty strings), set the Anypost keys, and PUT it back:
+
+```shell
+curl -su 'api_username:access_token' 'http://localhost:9000/api/settings' \
+	| jq '.data
+		| walk(if type == "string" and test("^•+$") then "" else . end)
+		| .["bounce.enabled"] = true
+		| .["bounce.webhooks_enabled"] = true
+		| .["bounce.anypost"] = {"enabled": true, "key": "whsec_..."}' \
+	| curl -u 'api_username:access_token' -X PUT 'http://localhost:9000/api/settings' \
+		-H 'Content-Type: application/json' --data @-
+```
+
+4. Send test mail and verify bounces in listmonk.
 
 ## Exporting bounces
 

--- a/docs/swagger/collections.yaml
+++ b/docs/swagger/collections.yaml
@@ -3583,6 +3583,10 @@ components:
           type: string
         bounce.postmark_password:
           type: string
+        bounce.anypost.enabled:
+          type: boolean
+        bounce.anypost.key:
+          type: string
         bounce.mailboxes:
           type: array
           items:

--- a/internal/bounce/bounce.go
+++ b/internal/bounce/bounce.go
@@ -42,6 +42,10 @@ type Opt struct {
 		Enabled bool
 		Key     string
 	}
+	Anypost struct {
+		Enabled bool
+		Key     string
+	}
 
 	RecordBounceCB func(models.Bounce) error
 }
@@ -56,6 +60,7 @@ type Manager struct {
 	Postmark     *webhooks.Postmark
 	Forwardemail *webhooks.Forwardemail
 	Lettermint   *webhooks.Lettermint
+	Anypost      *webhooks.Anypost
 	queries      *Queries
 	opt          Opt
 	log          *log.Logger
@@ -114,6 +119,10 @@ func New(opt Opt, q *Queries, lo *log.Logger) (*Manager, error) {
 
 		if opt.Lettermint.Enabled {
 			m.Lettermint = webhooks.NewLettermint([]byte(opt.Lettermint.Key))
+		}
+
+		if opt.Anypost.Enabled {
+			m.Anypost = webhooks.NewAnypost([]byte(opt.Anypost.Key))
 		}
 	}
 

--- a/internal/bounce/webhooks/anypost.go
+++ b/internal/bounce/webhooks/anypost.go
@@ -1,0 +1,188 @@
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/knadh/listmonk/models"
+)
+
+// Events are kept as raw JSON so each bounce's meta carries the event verbatim.
+type anypostBatch struct {
+	Events []json.RawMessage `json:"events"`
+}
+
+type anypostEvent struct {
+	Type       string `json:"type"`
+	OccurredAt string `json:"occurred_at"`
+	Data       struct {
+		Recipient string            `json:"recipient"`
+		Headers   map[string]string `json:"headers"`
+		Bounce    *struct {
+			Type string `json:"type"`
+		} `json:"bounce"`
+		Suppression *struct {
+			Reason string `json:"reason"`
+		} `json:"suppression"`
+	} `json:"data"`
+}
+
+// Anypost echoes customer X-headers with names lowercased and hyphens as
+// underscores, so the campaign header arrives under this transformed key.
+var anypostCampaignHeaderKey = strings.ReplaceAll(strings.ToLower(models.EmailHeaderCampaignUUID), "-", "_")
+
+// Anypost handles bounce webhook notifications from Anypost.
+type Anypost struct {
+	hmacKey []byte
+}
+
+// NewAnypost returns a new Anypost webhook handler.
+func NewAnypost(key []byte) *Anypost {
+	return &Anypost{hmacKey: key}
+}
+
+// ProcessBounce processes an incoming Anypost webhook payload and returns
+// bounce objects. A payload is a batch that may carry multiple events.
+func (a *Anypost) ProcessBounce(sig string, body []byte) ([]models.Bounce, error) {
+	if len(a.hmacKey) == 0 {
+		return nil, fmt.Errorf("webhook key is not configured")
+	}
+
+	// Parse the signature header: t={timestamp},v1={hex}. One v1 per active
+	// signing secret (two mid-rotation); a match on any one passes.
+	ts, sigs, err := parseAnypostSignature(sig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify timestamp tolerance (300 seconds).
+	if math.Abs(float64(time.Now().Unix()-ts)) > 300 {
+		return nil, fmt.Errorf("signature timestamp expired")
+	}
+
+	// Compute HMAC-SHA256 of "{timestamp}.{body}" and compare against each
+	// v1 component.
+	mac := hmac.New(sha256.New, a.hmacKey)
+	mac.Write([]byte(fmt.Sprintf("%d.%s", ts, body)))
+	expected := mac.Sum(nil)
+
+	matched := false
+	for _, s := range sigs {
+		sigB, err := hex.DecodeString(strings.TrimSpace(s))
+		if err != nil {
+			continue
+		}
+		if hmac.Equal(expected, sigB) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("invalid signature")
+	}
+
+	var batch anypostBatch
+	if err := json.Unmarshal(body, &batch); err != nil {
+		return nil, fmt.Errorf("error unmarshalling Anypost notification: %v", err)
+	}
+
+	out := make([]models.Bounce, 0, len(batch.Events))
+	for _, raw := range batch.Events {
+		var ev anypostEvent
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			// Signature already verified, so a parse failure is contract
+			// drift: fail the batch (logged + retried) rather than ack and
+			// silently drop the event.
+			return nil, fmt.Errorf("error unmarshalling Anypost event: %v", err)
+		}
+
+		// Map event to bounce type.
+		var typ string
+		switch ev.Type {
+		case "email.bounced":
+			typ = models.BounceTypeHard
+			if ev.Data.Bounce != nil && ev.Data.Bounce.Type == "transient" {
+				typ = models.BounceTypeSoft
+			}
+		case "email.complained":
+			typ = models.BounceTypeComplaint
+		case "email.suppressed":
+			// Anypost dropped this send because the address was already
+			// suppressed. Map only the bounce-like reasons; unsubscribed and
+			// manual are opt-outs, not bounces, so skip them.
+			if ev.Data.Suppression == nil {
+				continue
+			}
+			switch ev.Data.Suppression.Reason {
+			case "permanent_bounce":
+				typ = models.BounceTypeHard
+			case "complaint":
+				typ = models.BounceTypeComplaint
+			default:
+				continue
+			}
+		default:
+			// Ignore irrelevant events (deliveries, opens, clicks etc.).
+			continue
+		}
+
+		if ev.Data.Recipient == "" {
+			continue
+		}
+
+		campUUID := ev.Data.Headers[anypostCampaignHeaderKey]
+
+		t, _ := time.Parse(time.RFC3339, ev.OccurredAt)
+		if t.IsZero() {
+			t = time.Now()
+		}
+
+		out = append(out, models.Bounce{
+			Email:        strings.ToLower(ev.Data.Recipient),
+			CampaignUUID: campUUID,
+			Type:         typ,
+			Source:       "anypost",
+			Meta:         raw,
+			CreatedAt:    t,
+		})
+	}
+
+	return out, nil
+}
+
+// parseAnypostSignature parses a signature header of the form
+// "t={timestamp},v1={hex}[,v1={hex}]" and returns the timestamp and all
+// v1 components.
+func parseAnypostSignature(sig string) (int64, []string, error) {
+	var (
+		ts     int64
+		hashes []string
+	)
+
+	for _, part := range strings.Split(sig, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "t":
+			if _, err := fmt.Sscanf(kv[1], "%d", &ts); err != nil {
+				return 0, nil, fmt.Errorf("invalid timestamp in signature: %v", err)
+			}
+		case "v1":
+			hashes = append(hashes, kv[1])
+		}
+	}
+
+	if ts == 0 || len(hashes) == 0 {
+		return 0, nil, fmt.Errorf("invalid signature format")
+	}
+
+	return ts, hashes, nil
+}

--- a/internal/migrations/v6.2.0.go
+++ b/internal/migrations/v6.2.0.go
@@ -67,6 +67,11 @@ func V6_2_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf, lo *log.Logger
 		return err
 	}
 
+	// Add `bounce.anypost` for Anypost bounce webhook handling.
+	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES('bounce.anypost', '{"enabled": false, "key": ""}') ON CONFLICT DO NOTHING;`); err != nil {
+		return err
+	}
+
 	// Rename `security.cors_origins` to `security.trusted_urls`.
 	if _, err := db.Exec(`UPDATE settings SET key = 'security.trusted_urls'
 		WHERE key = 'security.cors_origins'

--- a/models/settings.go
+++ b/models/settings.go
@@ -141,6 +141,10 @@ type Settings struct {
 		Enabled bool   `json:"enabled"`
 		Key     string `json:"key"`
 	} `json:"bounce.lettermint"`
+	BounceAnypost struct {
+		Enabled bool   `json:"enabled"`
+		Key     string `json:"key"`
+	} `json:"bounce.anypost"`
 	BounceBoxes []struct {
 		UUID          string `json:"uuid"`
 		Enabled       bool   `json:"enabled"`

--- a/schema.sql
+++ b/schema.sql
@@ -292,6 +292,7 @@ INSERT INTO settings (key, value) VALUES
     ('bounce.postmark', '{"enabled": false, "username": "", "password": ""}'),
     ('bounce.forwardemail', '{"enabled": false, "key": ""}'),
     ('bounce.lettermint', '{"enabled": false, "key": ""}'),
+    ('bounce.anypost', '{"enabled": false, "key": ""}'),
     ('bounce.mailboxes',
         '[{"enabled":false, "type": "pop", "host":"pop.yoursite.com","port":995,"auth_protocol":"userpass","username":"username","password":"password","return_path": "bounce@listmonk.yoursite.com","scan_interval":"15m","tls_enabled":true,"tls_skip_verify":false}]'),
     ('appearance.admin.custom_css', '""'),


### PR DESCRIPTION
Adds [Anypost](https://anypost.com) as a native bounce webhook provider at `/webhooks/service/anypost`, following the pattern of the existing providers.

## What it does

Anypost POSTs batches of events (`{"batch_id", "timestamp", "events": [...]}`) signed with a Stripe-style header:

```
Anypost-Signature: t={unix},v1={hex_hmac}[,v1={hex_hmac}]
```

The handler verifies HMAC-SHA256 over `{t}.{raw_body}` with a 300s timestamp tolerance. The header carries one `v1` per active signing secret (two during a secret rotation), and a match on any one passes — so verification keeps working through rotations.

Event mapping:

| Anypost event | listmonk bounce |
|---|---|
| `email.bounced` (`bounce.type: permanent`) | `hard` |
| `email.bounced` (`bounce.type: transient`) | `soft` |
| `email.complained` | `complaint` |
| `email.suppressed` (`suppression.reason: permanent_bounce`) | `hard` |
| `email.suppressed` (`suppression.reason: complaint`) | `complaint` |
| `email.suppressed` (`suppression.reason: unsubscribed` / `manual`) | ignored |
| anything else | ignored |

`email.suppressed` fires when Anypost drops a send because the address was already on the account's suppression list. Its `data.suppression.reason` says why, which is what lets us map it safely: `permanent_bounce` and `complaint` are bounce-like and record a bounce, so listmonk converges with Anypost's state even if it never saw the original event; `unsubscribed` and `manual` are opt-outs and are ignored (recording them as bounces would blocklist recipients who merely opted out). A suppressed event with no `suppression` block is skipped.

Campaign attribution rides on these events: Anypost echoes customer-set X-headers back, so the `X-Listmonk-Campaign` header listmonk already sets on campaign mail comes back as `data.headers.x_listmonk_campaign` and resolves to the campaign. Feedback-loop complaints and out-of-band bounces carry no headers, so those record against the subscriber without a campaign.

## Deliberately no admin UI changes

Per the v7 frontend freeze in CONTRIBUTING.md / #3073, this PR touches no frontend files. The settings live under `bounce.anypost` (`{"enabled": bool, "key": string}`) and are configurable via the settings API; `docs/content/bounces.md` documents the exact steps. Because the settings form has no Anypost fields to strip the masked dummy key, `UpdateSettings` treats an all-mask key as unchanged, so UI settings saves can't clobber a stored secret.

I've kept this backend-only per the freeze. I also have the admin-UI additions (Bounces-tab fields + an `smtp.anypost.com` SMTP preset) prototyped against the current Vue UI — happy to contribute the equivalent to the new SSR admin UI once v7 lands, or to fold the Vue version into this PR now if you'd prefer it before the migration.

## Testing

- Verified end-to-end against a running instance: signed batches from Anypost's actual webhook worker are accepted (200), hard/soft/complaint rows recorded with campaign attribution resolved, bounce actions (blocklist) fire, tampered bodies and expired timestamps are rejected (400).
- `email.suppressed` mapping covered per reason: `permanent_bounce` → hard, `complaint` → complaint, `unsubscribed`/`manual`/no-block → skipped, with campaign attribution from the echoed header.
- Cross-checked the verifier against payloads produced by Anypost's production signing code, including the dual-`v1` rotation case.
- Fresh `--install` runs with the new `schema.sql` row; the `v6.2.0` migration inserts the setting idempotently for upgrades (appended to the pending v6.2.0 migration, mirroring how the Azure ACS setting was added).