### PR TITLE
refactor: improve settings and bounce webhook code quality

### DIFF
--- a/cmd/bounce.go
+++ b/cmd/bounce.go
@@ -120,6 +120,17 @@ func (a *App) BlocklistBouncedSubscribers(c echo.Context) error {
 	return c.JSON(http.StatusOK, okResp{true})
 }
 
+// bounceWebhookResult contains the outcome of processing a webhook request.
+// Most providers return bounce records, while subscription validation endpoints
+// may return an immediate response body instead.
+type bounceWebhookResult struct {
+	bounces     []models.Bounce
+	response    []byte
+	hasResponse bool
+}
+
+type bounceWebhookHandler func(echo.Context, []byte) (bounceWebhookResult, error)
+
 // BounceWebhook handles incoming bounce webhook notifications from various providers.
 func (a *App) BounceWebhook(c echo.Context) error {
 	// If bounce processing is disabled, a.bounce will be nil.
@@ -129,162 +140,208 @@ func (a *App) BounceWebhook(c echo.Context) error {
 			a.i18n.Ts("globals.messages.internalError"))
 	}
 
-	// Read the request body instead of using c.Bind() to read to save the entire raw request as meta.
+	// Read the request body instead of using c.Bind() to save the entire raw request as meta.
 	rawReq, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		a.log.Printf("error reading ses notification body: %v", err)
+		a.log.Printf("error reading bounce notification body: %v", err)
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("globals.messages.internalError"))
 	}
 
-	var (
-		service = c.Param("service")
-
-		bounces []models.Bounce
-	)
-	switch true {
-	// Native internal webhook.
-	case service == "":
-		var b models.Bounce
-		if err := json.Unmarshal(rawReq, &b); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("globals.messages.invalidData")+":"+err.Error())
-		}
-
-		if bv, err := a.validateBounceFields(b); err != nil {
-			return err
-		} else {
-			b = bv
-		}
-
-		if len(b.Meta) == 0 {
-			b.Meta = json.RawMessage("{}")
-		}
-
-		if b.CreatedAt.Year() == 0 {
-			b.CreatedAt = time.Now()
-		}
-
-		bounces = append(bounces, b)
-
-	// Amazon SES.
-	case service == "ses" && a.bounce.SES != nil:
-		switch c.Request().Header.Get("X-Amz-Sns-Message-Type") {
-		// SNS webhook registration confirmation. Only after these are processed will the endpoint
-		// start getting bounce notifications.
-		case "SubscriptionConfirmation", "UnsubscribeConfirmation":
-			if err := a.bounce.SES.ProcessSubscription(rawReq); err != nil {
-				a.log.Printf("error processing SNS (SES) subscription: %v", err)
-				return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-			}
-
-		// Bounce notification.
-		case "Notification":
-			b, err := a.bounce.SES.ProcessBounce(rawReq)
-			if err != nil {
-				a.log.Printf("error processing SES notification: %v", err)
-				return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-			}
-			bounces = append(bounces, b)
-
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-		}
-
-	// Azure ACS through Event Grid.
-	case service == "azure" && a.bounce.Azure != nil:
-		switch c.Request().Header.Get("aeg-event-type") {
-		// Event Grid webhook registration validation.
-		case "SubscriptionValidation", "SubscriptionValidationEvent":
-			res, err := a.bounce.Azure.ProcessSubscription(rawReq)
-			if err != nil {
-				a.log.Printf("error processing Azure Event Grid subscription validation: %v", err)
-				return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-			}
-			return c.JSONBlob(http.StatusOK, res)
-
-		// Regular event delivery.
-		case "", "Notification":
-			bs, err := a.bounce.Azure.ProcessBounce(c.Request(), rawReq)
-			if err != nil {
-				a.log.Printf("error processing Azure Event Grid notification: %v", err)
-				return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-			}
-			bounces = append(bounces, bs...)
-
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-		}
-
-	// SendGrid.
-	case service == "sendgrid" && a.bounce.Sendgrid != nil:
-		var (
-			sig = c.Request().Header.Get("X-Twilio-Email-Event-Webhook-Signature")
-			ts  = c.Request().Header.Get("X-Twilio-Email-Event-Webhook-Timestamp")
-		)
-
-		// Sendgrid sends multiple bounces.
-		bs, err := a.bounce.Sendgrid.ProcessBounce(sig, ts, rawReq)
-		if err != nil {
-			a.log.Printf("error processing sendgrid notification: %v", err)
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-		}
-		bounces = append(bounces, bs...)
-
-	// Postmark.
-	case service == "postmark" && a.bounce.Postmark != nil:
-		bs, err := a.bounce.Postmark.ProcessBounce(rawReq, c)
-		if err != nil {
-			a.log.Printf("error processing postmark notification: %v", err)
-			if _, ok := err.(*echo.HTTPError); ok {
-				return err
-			}
-
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-		}
-		bounces = append(bounces, bs...)
-
-	// ForwardEmail.
-	case service == "forwardemail" && a.bounce.Forwardemail != nil:
-		var (
-			sig = c.Request().Header.Get("X-Webhook-Signature")
-		)
-
-		bs, err := a.bounce.Forwardemail.ProcessBounce(sig, rawReq)
-		if err != nil {
-			a.log.Printf("error processing forwardemail notification: %v", err)
-			if _, ok := err.(*echo.HTTPError); ok {
-				return err
-			}
-
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-		}
-		bounces = append(bounces, bs...)
-
-	// Lettermint.
-	case service == "lettermint" && a.bounce.Lettermint != nil:
-		sig := c.Request().Header.Get("X-Lettermint-Signature")
-		bs, err := a.bounce.Lettermint.ProcessBounce(sig, rawReq)
-		if err != nil {
-			a.log.Printf("error processing lettermint notification: %v", err)
-			if _, ok := err.(*echo.HTTPError); ok {
-				return err
-			}
-
-			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
-		}
-		bounces = append(bounces, bs...)
-
-	default:
+	handler, ok := a.bounceWebhookHandlers()[c.Param("service")]
+	if !ok {
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("bounces.unknownService"))
 	}
 
+	result, err := handler(c, rawReq)
+	if err != nil {
+		return err
+	}
+
+	if result.hasResponse {
+		return c.JSONBlob(http.StatusOK, result.response)
+	}
+
 	// Insert bounces into the DB.
-	for _, b := range bounces {
+	for _, b := range result.bounces {
 		if err := a.bounce.Record(b); err != nil {
 			a.log.Printf("error recording bounce: %v", err)
 		}
 	}
 
 	return c.JSON(http.StatusOK, okResp{true})
+}
+
+// bounceWebhookHandlers registers only the webhook providers that are enabled.
+// Each handler encapsulates the processing rules for a single provider.
+func (a *App) bounceWebhookHandlers() map[string]bounceWebhookHandler {
+	handlers := map[string]bounceWebhookHandler{
+		"": a.processNativeBounceWebhook,
+	}
+
+	if a.bounce.SES != nil {
+		handlers["ses"] = a.processSESBounceWebhook
+	}
+	if a.bounce.Azure != nil {
+		handlers["azure"] = a.processAzureBounceWebhook
+	}
+	if a.bounce.Sendgrid != nil {
+		handlers["sendgrid"] = a.processSendgridBounceWebhook
+	}
+	if a.bounce.Postmark != nil {
+		handlers["postmark"] = a.processPostmarkBounceWebhook
+	}
+	if a.bounce.Forwardemail != nil {
+		handlers["forwardemail"] = a.processForwardEmailBounceWebhook
+	}
+	if a.bounce.Lettermint != nil {
+		handlers["lettermint"] = a.processLettermintBounceWebhook
+	}
+
+	return handlers
+}
+
+func (a *App) processNativeBounceWebhook(_ echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	var b models.Bounce
+	if err := json.Unmarshal(rawReq, &b); err != nil {
+		return bounceWebhookResult{}, echo.NewHTTPError(
+			http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidData")+":"+err.Error(),
+		)
+	}
+
+	validatedBounce, err := a.validateBounceFields(b)
+	if err != nil {
+		return bounceWebhookResult{}, err
+	}
+	b = validatedBounce
+
+	if len(b.Meta) == 0 {
+		b.Meta = json.RawMessage("{}")
+	}
+	if b.CreatedAt.Year() == 0 {
+		b.CreatedAt = time.Now()
+	}
+
+	return bounceWebhookResult{bounces: []models.Bounce{b}}, nil
+}
+
+func (a *App) processSESBounceWebhook(c echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	switch c.Request().Header.Get("X-Amz-Sns-Message-Type") {
+	case "SubscriptionConfirmation", "UnsubscribeConfirmation":
+		if err := a.bounce.SES.ProcessSubscription(rawReq); err != nil {
+			a.log.Printf("error processing SNS (SES) subscription: %v", err)
+			return bounceWebhookResult{}, echo.NewHTTPError(
+				http.StatusBadRequest,
+				a.i18n.T("globals.messages.invalidData"),
+			)
+		}
+		return bounceWebhookResult{}, nil
+
+	case "Notification":
+		b, err := a.bounce.SES.ProcessBounce(rawReq)
+		if err != nil {
+			a.log.Printf("error processing SES notification: %v", err)
+			return bounceWebhookResult{}, echo.NewHTTPError(
+				http.StatusBadRequest,
+				a.i18n.T("globals.messages.invalidData"),
+			)
+		}
+		return bounceWebhookResult{bounces: []models.Bounce{b}}, nil
+
+	default:
+		return bounceWebhookResult{}, echo.NewHTTPError(
+			http.StatusBadRequest,
+			a.i18n.T("globals.messages.invalidData"),
+		)
+	}
+}
+
+func (a *App) processAzureBounceWebhook(c echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	switch c.Request().Header.Get("aeg-event-type") {
+	case "SubscriptionValidation", "SubscriptionValidationEvent":
+		res, err := a.bounce.Azure.ProcessSubscription(rawReq)
+		if err != nil {
+			a.log.Printf("error processing Azure Event Grid subscription validation: %v", err)
+			return bounceWebhookResult{}, echo.NewHTTPError(
+				http.StatusBadRequest,
+				a.i18n.T("globals.messages.invalidData"),
+			)
+		}
+		return bounceWebhookResult{response: res, hasResponse: true}, nil
+
+	case "", "Notification":
+		bounces, err := a.bounce.Azure.ProcessBounce(c.Request(), rawReq)
+		if err != nil {
+			a.log.Printf("error processing Azure Event Grid notification: %v", err)
+			return bounceWebhookResult{}, echo.NewHTTPError(
+				http.StatusBadRequest,
+				a.i18n.T("globals.messages.invalidData"),
+			)
+		}
+		return bounceWebhookResult{bounces: bounces}, nil
+
+	default:
+		return bounceWebhookResult{}, echo.NewHTTPError(
+			http.StatusBadRequest,
+			a.i18n.T("globals.messages.invalidData"),
+		)
+	}
+}
+
+func (a *App) processSendgridBounceWebhook(c echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	signature := c.Request().Header.Get("X-Twilio-Email-Event-Webhook-Signature")
+	timestamp := c.Request().Header.Get("X-Twilio-Email-Event-Webhook-Timestamp")
+
+	bounces, err := a.bounce.Sendgrid.ProcessBounce(signature, timestamp, rawReq)
+	if err != nil {
+		a.log.Printf("error processing sendgrid notification: %v", err)
+		return bounceWebhookResult{}, echo.NewHTTPError(
+			http.StatusBadRequest,
+			a.i18n.T("globals.messages.invalidData"),
+		)
+	}
+
+	return bounceWebhookResult{bounces: bounces}, nil
+}
+
+func (a *App) processPostmarkBounceWebhook(c echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	bounces, err := a.bounce.Postmark.ProcessBounce(rawReq, c)
+	if err != nil {
+		a.log.Printf("error processing postmark notification: %v", err)
+		return bounceWebhookResult{}, a.normalizeBounceWebhookError(err)
+	}
+
+	return bounceWebhookResult{bounces: bounces}, nil
+}
+
+func (a *App) processForwardEmailBounceWebhook(c echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	signature := c.Request().Header.Get("X-Webhook-Signature")
+	bounces, err := a.bounce.Forwardemail.ProcessBounce(signature, rawReq)
+	if err != nil {
+		a.log.Printf("error processing forwardemail notification: %v", err)
+		return bounceWebhookResult{}, a.normalizeBounceWebhookError(err)
+	}
+
+	return bounceWebhookResult{bounces: bounces}, nil
+}
+
+func (a *App) processLettermintBounceWebhook(c echo.Context, rawReq []byte) (bounceWebhookResult, error) {
+	signature := c.Request().Header.Get("X-Lettermint-Signature")
+	bounces, err := a.bounce.Lettermint.ProcessBounce(signature, rawReq)
+	if err != nil {
+		a.log.Printf("error processing lettermint notification: %v", err)
+		return bounceWebhookResult{}, a.normalizeBounceWebhookError(err)
+	}
+
+	return bounceWebhookResult{bounces: bounces}, nil
+}
+
+func (a *App) normalizeBounceWebhookError(err error) error {
+	if _, ok := err.(*echo.HTTPError); ok {
+		return err
+	}
+
+	return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
 }
 
 func (a *App) validateBounceFields(b models.Bounce) (models.Bounce, error) {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"regexp"
 	"runtime"
 	"strings"
@@ -263,33 +262,21 @@ func (a *App) UpdateSettings(c echo.Context) error {
 		}
 	}
 
-	for n, v := range set.UploadExtensions {
-		set.UploadExtensions[n] = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(v), "."))
-	}
+	set.UploadExtensions = utils.NormalizeFileExtensions(set.UploadExtensions)
 
 	// Domain blocklist / allowlist.
 	set.DomainBlocklist = utils.NormalizeDomains(set.DomainBlocklist)
 	set.DomainAllowlist = utils.NormalizeDomains(set.DomainAllowlist)
 
 	// Validate and clean trusted URLs.
-	urls := make([]string, 0, len(set.SecurityTrustedURLs))
-	for _, d := range set.SecurityTrustedURLs {
-		if d = strings.TrimSpace(d); d != "" {
-			if d == "*" {
-				urls = append(urls, d)
-				continue
-			}
-
-			// Parse and validate the URL.
-			u, err := url.Parse(d)
-			if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-				return echo.NewHTTPError(http.StatusBadRequest,
-					a.i18n.Ts("globals.messages.invalidData")+": invalid trusted URL: "+d)
-			}
-			urls = append(urls, d)
-		}
+	trustedURLs, err := utils.NormalizeTrustedURLs(set.SecurityTrustedURLs)
+	if err != nil {
+		return echo.NewHTTPError(
+			http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidData")+": "+err.Error(),
+		)
 	}
-	set.SecurityTrustedURLs = urls
+	set.SecurityTrustedURLs = trustedURLs
 
 	// Validate slow query caching cron.
 	if set.CacheSlowQueries {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -22,6 +22,7 @@ import (
 	"github.com/knadh/listmonk/internal/auth"
 	"github.com/knadh/listmonk/internal/messenger/email"
 	"github.com/knadh/listmonk/internal/notifs"
+	"github.com/knadh/listmonk/internal/utils"
 	"github.com/knadh/listmonk/models"
 	"github.com/labstack/echo/v4"
 )
@@ -267,21 +268,8 @@ func (a *App) UpdateSettings(c echo.Context) error {
 	}
 
 	// Domain blocklist / allowlist.
-	doms := make([]string, 0, len(set.DomainBlocklist))
-	for _, d := range set.DomainBlocklist {
-		if d = strings.TrimSpace(strings.ToLower(d)); d != "" {
-			doms = append(doms, d)
-		}
-	}
-	set.DomainBlocklist = doms
-
-	doms = make([]string, 0, len(set.DomainAllowlist))
-	for _, d := range set.DomainAllowlist {
-		if d = strings.TrimSpace(strings.ToLower(d)); d != "" {
-			doms = append(doms, d)
-		}
-	}
-	set.DomainAllowlist = doms
+	set.DomainBlocklist = utils.NormalizeDomains(set.DomainBlocklist)
+	set.DomainAllowlist = utils.NormalizeDomains(set.DomainAllowlist)
 
 	// Validate and clean trusted URLs.
 	urls := make([]string, 0, len(set.SecurityTrustedURLs))

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -91,3 +91,47 @@ func NormalizeDomains(domains []string) []string {
 
 	return normalized
 }
+
+// NormalizeFileExtensions trims whitespace, removes a leading dot,
+// and converts file extensions to lowercase.
+func NormalizeFileExtensions(extensions []string) []string {
+	normalized := make([]string, len(extensions))
+
+	for i, extension := range extensions {
+		normalized[i] = strings.ToLower(
+			strings.TrimPrefix(strings.TrimSpace(extension), "."),
+		)
+	}
+
+	return normalized
+}
+
+// NormalizeTrustedURLs trims whitespace, removes empty entries,
+// and validates that each URL uses HTTP or HTTPS.
+// The wildcard "*" is accepted as a trusted URL entry.
+func NormalizeTrustedURLs(trustedURLs []string) ([]string, error) {
+	normalized := make([]string, 0, len(trustedURLs))
+
+	for _, trustedURL := range trustedURLs {
+		trustedURL = strings.TrimSpace(trustedURL)
+		if trustedURL == "" {
+			continue
+		}
+
+		if trustedURL == "*" {
+			normalized = append(normalized, trustedURL)
+			continue
+		}
+
+		parsedURL, err := url.Parse(trustedURL)
+		if err != nil ||
+			(parsedURL.Scheme != "http" && parsedURL.Scheme != "https") ||
+			parsedURL.Host == "" {
+			return nil, errors.New("invalid trusted URL: " + trustedURL)
+		}
+
+		normalized = append(normalized, trustedURL)
+	}
+
+	return normalized, nil
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -76,3 +76,18 @@ func SanitizeURI(u string) string {
 
 	return path.Clean(p.Path)
 }
+
+// NormalizeDomains trims whitespace, converts domains to lowercase,
+// and removes empty entries while preserving their original order.
+func NormalizeDomains(domains []string) []string {
+	normalized := make([]string, 0, len(domains))
+
+	for _, domain := range domains {
+		domain = strings.TrimSpace(strings.ToLower(domain))
+		if domain != "" {
+			normalized = append(normalized, domain)
+		}
+	}
+
+	return normalized
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeDomains(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "trims whitespace and converts domains to lowercase",
+			input:    []string{" Example.COM ", "TEST.org"},
+			expected: []string{"example.com", "test.org"},
+		},
+		{
+			name:     "removes empty entries",
+			input:    []string{"example.com", "", "   ", "test.org"},
+			expected: []string{"example.com", "test.org"},
+		},
+		{
+			name:     "preserves domain order",
+			input:    []string{"THIRD.com", "first.com", "SECOND.com"},
+			expected: []string{"third.com", "first.com", "second.com"},
+		},
+		{
+			name:     "handles an empty list",
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := NormalizeDomains(test.input)
+
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf(
+					"NormalizeDomains(%v) = %v; expected %v",
+					test.input,
+					result,
+					test.expected,
+				)
+			}
+		})
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -48,3 +48,80 @@ func TestNormalizeDomains(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeFileExtensions(t *testing.T) {
+	input := []string{" .JPG ", "PNG", ".Pdf", ""}
+	expected := []string{"jpg", "png", "pdf", ""}
+
+	result := NormalizeFileExtensions(input)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf(
+			"NormalizeFileExtensions(%v) = %v; expected %v",
+			input,
+			result,
+			expected,
+		)
+	}
+}
+
+func TestNormalizeTrustedURLs(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:     "trims URLs and removes empty entries",
+			input:    []string{" https://example.com ", "", "   ", "http://test.org"},
+			expected: []string{"https://example.com", "http://test.org"},
+		},
+		{
+			name:     "accepts wildcard",
+			input:    []string{"*"},
+			expected: []string{"*"},
+		},
+		{
+			name:        "rejects URL without scheme",
+			input:       []string{"example.com"},
+			expectError: true,
+		},
+		{
+			name:        "rejects unsupported scheme",
+			input:       []string{"ftp://example.com"},
+			expectError: true,
+		},
+		{
+			name:        "rejects URL without host",
+			input:       []string{"https://"},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := NormalizeTrustedURLs(test.input)
+
+			if test.expectError {
+				if err == nil {
+					t.Fatalf("NormalizeTrustedURLs(%v) expected an error", test.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NormalizeTrustedURLs(%v) returned error: %v", test.input, err)
+			}
+
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf(
+					"NormalizeTrustedURLs(%v) = %v; expected %v",
+					test.input,
+					result,
+					test.expected,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Descrição

Este PR implementa melhorias de qualidade interna no Listmonk, com foco em refatoração, redução de complexidade e organização das responsabilidades.

## Alterações realizadas

### 1. Remoção de código duplicado

A normalização de `DomainBlocklist` e `DomainAllowlist` foi extraída para:

- `utils.NormalizeDomains()`

**Justificativa técnica:** centraliza a regra de normalização, evita duplicação e reduz o risco de comportamentos inconsistentes.

### 2. Refatoração de `UpdateSettings`

Foram extraídas as funções:

- `NormalizeFileExtensions()`
- `NormalizeTrustedURLs()`
- `NormalizeDomains()`

A complexidade ciclomática de `UpdateSettings` caiu de **55 para 44**.

**Justificativa técnica:** separa regras de validação e normalização da função principal, melhora a legibilidade e permite testes unitários isolados.

### 3. Refatoração de `BounceWebhook`

O grande `switch` foi substituído por handlers específicos para cada provedor:

- SES
- Azure
- SendGrid
- Postmark
- ForwardEmail
- Lettermint
- Webhook interno

A complexidade ciclomática de `BounceWebhook` caiu de **37 para 8**.

**Justificativa técnica:** reduz condicionais complexos, isola as regras de cada provedor e facilita a inclusão de novos serviços.

## Padrões de projeto

- **Strategy:** seleção dinâmica do handler responsável por cada provedor.
- **Adapter:** padronização das diferentes interfaces, cabeçalhos e retornos dos provedores.

## Validação

Foram executados com sucesso:

- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`
- análise de complexidade com `gocyclo`

Também foram adicionados testes unitários para as novas funções de normalização e validação.