### PR TITLE
Give user the option to override the confirmation sending address

### DIFF
--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/mail"
 	"strconv"
 	"strings"
 
@@ -103,6 +104,13 @@ func (a *App) CreateList(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("lists.invalidName"))
 	}
 
+	// Validate confirmation_from if provided.
+	if l.ConfirmationFrom.Valid && l.ConfirmationFrom.String != "" {
+		if _, err := mail.ParseAddress(l.ConfirmationFrom.String); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid confirmation_from email address")
+		}
+	}
+
 	out, err := a.core.CreateList(l)
 	if err != nil {
 		return err
@@ -132,6 +140,13 @@ func (a *App) UpdateList(c echo.Context) error {
 	// Validate.
 	if !strHasLen(l.Name, 1, stdInputMaxLen) {
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("lists.invalidName"))
+	}
+
+	// Validate confirmation_from if provided.
+	if l.ConfirmationFrom.Valid && l.ConfirmationFrom.String != "" {
+		if _, err := mail.ParseAddress(l.ConfirmationFrom.String); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid confirmation_from email address")
+		}
 	}
 
 	// Update the list in the DB.

--- a/cmd/subscribers.go
+++ b/cmd/subscribers.go
@@ -895,8 +895,23 @@ func makeOptinNotifyHook(unsubHeader bool, u *UrlConfig, q *models.Queries, i *i
 			hdr.Set("List-Unsubscribe", `<`+unsubURL+`>`)
 		}
 
-		// Send the e-mail.
-		if err := notifs.Notify([]string{sub.Email}, i.T("subscribers.optinSubject"), notifs.TplSubscriberOptin, out, hdr); err != nil {
+		// Validate: confirmation_from can only be used with single list subscriptions.
+		if len(lists) > 1 {
+			for _, l := range lists {
+				if l.ConfirmationFrom.Valid && l.ConfirmationFrom.String != "" {
+					lo.Printf("error: confirmation_from cannot be used when subscribing to multiple lists (subscriber %d)", sub.ID)
+					return 0, fmt.Errorf("confirmation_from can only be used when subscribing to a single list")
+				}
+			}
+		}
+
+		// Send the e-mail. Use the list's custom confirmation_from if it's a single list subscription.
+		var fromAddr string
+		if len(lists) == 1 && lists[0].ConfirmationFrom.Valid && lists[0].ConfirmationFrom.String != "" {
+			fromAddr = lists[0].ConfirmationFrom.String
+		}
+
+		if err := notifs.Notify([]string{sub.Email}, i.T("subscribers.optinSubject"), notifs.TplSubscriberOptin, out, hdr, fromAddr); err != nil {
 			lo.Printf("error sending opt-in e-mail for subscriber %d (%s): %s", sub.ID, sub.UUID, err)
 			return 0, err
 		}

--- a/docs/docs/content/apis/lists.md
+++ b/docs/docs/content/apis/lists.md
@@ -1,5 +1,18 @@
 # API / Lists
 
+## Overview
+
+The Lists API allows you to manage your mailing lists. Each list can have optional per-list settings for customization.
+
+### Confirmation Email Configuration
+
+For lists with double opt-in enabled (`optin: "double"`), confirmation emails are sent to subscribers. The `confirmation_from` field allows you to specify a custom sender address for these emails. This is useful when running multiple services through a single listmonk instance, where each service needs to send confirmation emails from its own address.
+
+- If `confirmation_from` is not set, confirmation emails use the system default sender address (configured globally).
+- If `confirmation_from` is set to a valid email address, confirmation emails for that list will be sent from that address.
+
+**Important:** The custom `confirmation_from` address can only be used when subscribing a user to **a single list**. Attempting to subscribe a user to multiple lists where any of them has a `confirmation_from` configured will return an error. This ensures clarity and prevents ambiguous email sender configurations. To subscribe to multiple lists, either use lists without `confirmation_from` set, or make separate API calls for each list with a custom sender address.
+
 | Method | Endpoint                                        | Description               |
 | :----- | :---------------------------------------------- | :------------------------ |
 | GET    | [/api/lists](#get-apilists)                     | Retrieve all lists.       |
@@ -62,6 +75,7 @@ curl -u "api_user:token" -X GET 'http://localhost:9000/api/lists?status=archived
                 "tags": [
                     "test"
                 ],
+                "confirmation_from": "noreply@example.com",
                 "subscriber_count": 2
             },
             {
@@ -74,6 +88,7 @@ curl -u "api_user:token" -X GET 'http://localhost:9000/api/lists?status=archived
                 "optin": "single",
                 "status": "active",
                 "tags": [],
+                "confirmation_from": null,
                 "subscriber_count": 0
             }
         ],
@@ -140,6 +155,7 @@ curl -u "api_user:token" -X GET 'http://localhost:9000/api/lists/5'
         "optin": "double",
         "status": "active",
         "tags": [],
+        "confirmation_from": null,
         "subscriber_count": 0
     }
 }
@@ -153,19 +169,28 @@ Create a new list.
 
 ##### Parameters
 
-| Name        | Type       | Required | Description                                                        |
-| :---------- | :--------- | :------- | :----------------------------------------------------------------- |
-| name        | string     | Yes      | Name of the new list.                                              |
-| type        | string     | Yes      | Type of list. Options: private, public.                            |
-| optin       | string     | Yes      | Opt-in type. Options: single, double.                              |
-| status      | string     | No       | Status of the list. Options: active, archived. Defaults to active. |
-| tags        | string\[\] |          | Associated tags for a list.                                        |
-| description | string     | No       | Description of the new list.                                       |
+| Name              | Type       | Required | Description                                                                      |
+| :---------------- | :--------- | :------- | :------------------------------------------------------------------------------- |
+| name              | string     | Yes      | Name of the new list.                                                           |
+| type              | string     | Yes      | Type of list. Options: private, public.                                         |
+| optin             | string     | Yes      | Opt-in type. Options: single, double.                                           |
+| status            | string     | No       | Status of the list. Options: active, archived. Defaults to active.              |
+| tags              | string\[\] |          | Associated tags for a list.                                                     |
+| description       | string     | No       | Description of the new list.                                                    |
+| confirmation_from | string     | No       | Email address to use as the "from" address for confirmation emails (double opt-in). If not set, the system default is used. |
 
 ##### Example Request
 
 ```shell
-curl -u "api_user:token" -X POST 'http://localhost:9000/api/lists'
+curl -u "api_user:token" -X POST 'http://localhost:9000/api/lists' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Test list",
+    "type": "public",
+    "optin": "double",
+    "description": "This is a test list",
+    "confirmation_from": "noreply@example.com"
+  }'
 ```
 
 ##### Example Response
@@ -179,9 +204,10 @@ curl -u "api_user:token" -X POST 'http://localhost:9000/api/lists'
         "uuid": "1bb246ab-7417-4cef-bddc-8fc8fc941d3a",
         "name": "Test list",
         "type": "public",
-        "optin": "single",
+        "optin": "double",
         "status": "active",
         "tags": [],
+        "confirmation_from": "noreply@example.com",
         "subscriber_count": 0,
         "description": "This is a test list"
     }
@@ -196,15 +222,16 @@ Update a list.
 
 ##### Parameters
 
-| Name        | Type       | Required | Description                                    |
-| :---------- | :--------- | :------- | :--------------------------------------------- |
-| list_id     | number     | Yes      | ID of the list to update.                      |
-| name        | string     |          | New name for the list.                         |
-| type        | string     |          | Type of list. Options: private, public.        |
-| optin       | string     |          | Opt-in type. Options: single, double.          |
-| status      | string     |          | Status of the list. Options: active, archived. |
-| tags        | string\[\] |          | Associated tags for the list.                  |
-| description | string     |          | Description of the list.                       |
+| Name              | Type       | Required | Description                                                                      |
+| :---------------- | :--------- | :------- | :------------------------------------------------------------------------------- |
+| list_id           | number     | Yes      | ID of the list to update.                                                       |
+| name              | string     |          | New name for the list.                                                          |
+| type              | string     |          | Type of list. Options: private, public.                                         |
+| optin             | string     |          | Opt-in type. Options: single, double.                                           |
+| status            | string     |          | Status of the list. Options: active, archived.                                  |
+| tags              | string\[\] |          | Associated tags for the list.                                                   |
+| description       | string     |          | Description of the list.                                                        |
+| confirmation_from | string     |          | Email address to use as the "from" address for confirmation emails (double opt-in). If not set, the system default is used. |
 
 ##### Example Request
 
@@ -228,6 +255,7 @@ curl -u "api_user:token" -X PUT 'http://localhost:9000/api/lists/5' \
         "optin": "single",
         "status": "active",
         "tags": [],
+        "confirmation_from": null,
         "subscriber_count": 0,
         "description": "This is a test list"
     }

--- a/docs/docs/content/apis/subscribers.md
+++ b/docs/docs/content/apis/subscribers.md
@@ -311,6 +311,8 @@ Create a new subscriber.
 | attribs                  | JSON       |          | Optional JSON object attributes for the subscriber that can be used in message templates. Example `{"location": "Somewhere"}` |
 | preconfirm_subscriptions | bool       |          | If true, subscriptions are marked as confirmed and no opt-in emails are sent for double opt-in lists.                         |
 
+> **Note on confirmation email addresses:** Custom `confirmation_from` addresses on double opt-in lists can only be used when subscribing a user to a **single list**. Attempting to subscribe a user to multiple lists where any has a `confirmation_from` configured will return an error. To use custom confirmation addresses, either subscribe to one list at a time, or use lists without custom `confirmation_from` settings for multi-list subscriptions.
+
 ##### Example Request
 
 ```shell

--- a/internal/migrations/v6.3.0.go
+++ b/internal/migrations/v6.3.0.go
@@ -1,0 +1,14 @@
+package migrations
+
+import (
+	"log"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/koanf/v2"
+	"github.com/knadh/stuffbin"
+)
+
+func V6_3_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf, lo *log.Logger) error {
+	_, err := db.Exec(`ALTER TABLE lists ADD COLUMN IF NOT EXISTS confirmation_from TEXT NULL DEFAULT NULL`)
+	return err
+}

--- a/internal/notifs/notifs.go
+++ b/internal/notifs/notifs.go
@@ -68,7 +68,8 @@ func NotifySystem(subject, tplName string, data any, hdr textproto.MIMEHeader) e
 }
 
 // Notify sends out an e-mail notification.
-func Notify(toEmails []string, subject, tplName string, data any, hdr textproto.MIMEHeader) error {
+// If fromAddr is provided and not empty, it's used instead of the default From address.
+func Notify(toEmails []string, subject, tplName string, data any, hdr textproto.MIMEHeader, fromAddr ...string) error {
 	if len(toEmails) == 0 {
 		return nil
 	}
@@ -82,10 +83,15 @@ func Notify(toEmails []string, subject, tplName string, data any, hdr textproto.
 
 	subject, body = GetTplSubject(subject, body)
 
+	from := no.opt.FromEmail
+	if len(fromAddr) > 0 && fromAddr[0] != "" {
+		from = fromAddr[0]
+	}
+
 	m := models.Message{
 		Messenger:   "email",
 		ContentType: no.opt.ContentType,
-		From:        no.opt.FromEmail,
+		From:        from,
 		To:          toEmails,
 		Subject:     subject,
 		Body:        body,

--- a/models/lists.go
+++ b/models/lists.go
@@ -18,16 +18,17 @@ const (
 type List struct {
 	Base
 
-	UUID             string         `db:"uuid" json:"uuid"`
-	Name             string         `db:"name" json:"name"`
-	Type             string         `db:"type" json:"type"`
-	Optin            string         `db:"optin" json:"optin"`
-	Status           string         `db:"status" json:"status"`
-	Tags             pq.StringArray `db:"tags" json:"tags"`
-	Description      string         `db:"description" json:"description"`
-	SubscriberCount  int            `db:"subscriber_count" json:"subscriber_count"`
-	SubscriberCounts StringIntMap   `db:"subscriber_statuses" json:"subscriber_statuses"`
-	SubscriberID     int            `db:"subscriber_id" json:"-"`
+	UUID              string         `db:"uuid" json:"uuid"`
+	Name              string         `db:"name" json:"name"`
+	Type              string         `db:"type" json:"type"`
+	Optin             string         `db:"optin" json:"optin"`
+	Status            string         `db:"status" json:"status"`
+	Tags              pq.StringArray `db:"tags" json:"tags"`
+	Description       string         `db:"description" json:"description"`
+	ConfirmationFrom  null.String    `db:"confirmation_from" json:"confirmation_from"`
+	SubscriberCount   int            `db:"subscriber_count" json:"subscriber_count"`
+	SubscriberCounts  StringIntMap   `db:"subscriber_statuses" json:"subscriber_statuses"`
+	SubscriberID      int            `db:"subscriber_id" json:"-"`
 
 	// This is only relevant when querying the lists of a subscriber.
 	SubscriptionStatus    string    `db:"subscription_status" json:"subscription_status,omitempty"`


### PR DESCRIPTION
This is a draft related to https://github.com/knadh/listmonk/issues/3155 to show how this could look like. It's not fully tested yet, but more of a conversation starter.