### PR TITLE
feat: mailgun webhook

### DIFF
--- a/cmd/bounce.go
+++ b/cmd/bounce.go
@@ -273,6 +273,19 @@ func (a *App) BounceWebhook(c echo.Context) error {
 		}
 		bounces = append(bounces, bs...)
 
+	// Mailgun.
+	case service == "mailgun" && a.bounce.Mailgun != nil:
+		bs, err := a.bounce.Mailgun.ProcessBounce(rawReq)
+		if err != nil {
+			a.log.Printf("error processing mailgun notification: %v", err)
+			if _, ok := err.(*echo.HTTPError); ok {
+				return err
+			}
+
+			return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("globals.messages.invalidData"))
+		}
+		bounces = append(bounces, bs...)
+
 	default:
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.Ts("bounces.unknownService"))
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -150,6 +150,7 @@ type Config struct {
 	BouncePostmarkEnabled     bool
 	BounceForwardemailEnabled bool
 	BounceLettermintEnabled   bool
+	BounceMailgunEnabled      bool
 
 	PermissionsRaw json.RawMessage
 	Permissions    map[string]struct{}
@@ -517,6 +518,7 @@ func initConstConfig(ko *koanf.Koanf) *Config {
 	c.BouncePostmarkEnabled = ko.Bool("bounce.postmark.enabled")
 	c.BounceForwardemailEnabled = ko.Bool("bounce.forwardemail.enabled")
 	c.BounceLettermintEnabled = ko.Bool("bounce.lettermint.enabled")
+	c.BounceMailgunEnabled = ko.Bool("bounce.mailgun.enabled")
 	c.HasLegacyUser = ko.Exists("app.admin_username") || ko.Exists("app.admin_password")
 
 	b := md5.Sum([]byte(time.Now().String()))
@@ -850,6 +852,13 @@ func initBounceManager(cb func(models.Bounce) error, stmt *sqlx.Stmt, lo *log.Lo
 		}{
 			ko.Bool("bounce.lettermint.enabled"),
 			ko.String("bounce.lettermint.key"),
+		},
+		Mailgun: struct {
+			Enabled bool
+			Key     string
+		}{
+			ko.Bool("bounce.mailgun.enabled"),
+			ko.String("bounce.mailgun.key"),
 		},
 		RecordBounceCB: cb,
 	}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -78,6 +78,7 @@ func (a *App) GetSettings(c echo.Context) error {
 	s.BouncePostmark.Password = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BouncePostmark.Password))
 	s.BounceForwardEmail.Key = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceForwardEmail.Key))
 	s.BounceLettermint.Key = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceLettermint.Key))
+	s.BounceMailgun.Key = strings.Repeat(pwdMask, utf8.RuneCountInString(s.BounceMailgun.Key))
 	s.SecurityCaptcha.HCaptcha.Secret = strings.Repeat(pwdMask, utf8.RuneCountInString(s.SecurityCaptcha.HCaptcha.Secret))
 	s.OIDC.ClientSecret = strings.Repeat(pwdMask, utf8.RuneCountInString(s.OIDC.ClientSecret))
 
@@ -246,6 +247,9 @@ func (a *App) UpdateSettings(c echo.Context) error {
 	}
 	if set.BounceLettermint.Key == "" {
 		set.BounceLettermint.Key = cur.BounceLettermint.Key
+	}
+	if set.BounceMailgun.Key == "" {
+		set.BounceMailgun.Key = cur.BounceMailgun.Key
 	}
 	if set.SecurityCaptcha.HCaptcha.Secret == "" {
 		set.SecurityCaptcha.HCaptcha.Secret = cur.SecurityCaptcha.HCaptcha.Secret

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -45,6 +45,7 @@ var migList = []migFunc{
 	{"v6.0.0", migrations.V6_0_0},
 	{"v6.1.0", migrations.V6_1_0},
 	{"v6.2.0", migrations.V6_2_0},
+	{"v6.3.0", migrations.V6_3_0},
 }
 
 // upgrade upgrades the database to the current version by running SQL migration files

--- a/dev/mailgun-integration-test.md
+++ b/dev/mailgun-integration-test.md
@@ -1,0 +1,68 @@
+# Mailgun Bounce Webhook Integration Test (End-to-End)
+
+This procedure verifies end-to-end Mailgun bounce processing against a real Mailgun account and a running listmonk instance.
+
+## Prerequisites
+
+- Mailgun account with a sandbox domain.
+- At least one authorized recipient on that sandbox domain.
+- Local listmonk checkout with Mailgun bounce support.
+- Public HTTPS tunnel to local listmonk (`ngrok`, `cloudflared`, or equivalent).
+
+## Mailgun Setup
+
+1. In Mailgun, open your domain settings and copy the HTTP webhook signing key from API security settings.
+2. Configure webhooks for bounce-related events and point each to:
+   - `https://<public-tunnel-host>/webhooks/service/mailgun`
+3. Subscribe these events at minimum:
+   - `permanent_failure`
+   - `temporary_failure`
+   - `complained`
+
+Use the webhook signing key, not the Mailgun sending/API key.
+
+## listmonk Setup
+
+1. Run DB upgrades so `bounce.mailgun` exists:
+   - `./listmonk --upgrade`
+2. Start listmonk locally (default: `http://localhost:9000`).
+3. In admin settings under bounces, enable Mailgun and set `bounce.mailgun.key` to the Mailgun webhook signing key.
+4. Start your HTTPS tunnel for local port 9000 (example: `ngrok http 9000`) and update Mailgun webhook URLs with the active tunnel URL.
+
+## Trigger Events
+
+1. Use Mailgun’s webhook UI "send test webhook" action for:
+   - `permanent_failure`
+   - `temporary_failure`
+   - `complained`
+2. Real hard bounce test:
+   - Send to `bounce@simulator.mailgun.org`.
+3. Real complaint test:
+   - Use Mailgun complaint simulator if available on your plan, or mark a received test email as spam in a real inbox.
+
+For campaign linkage checks, include campaign UUID metadata when sending:
+- API send: `v:X-Listmonk-Campaign=<campaign-uuid>`
+- SMTP send: `X-Mailgun-Variables: {"X-Listmonk-Campaign":"<campaign-uuid>"}`
+
+## Expected Outcomes
+
+- listmonk accepts webhook requests with HTTP 200.
+- A bounce row is created with:
+  - `source = mailgun`
+  - correct bounce `type` (`hard`, `soft`, `complaint`)
+  - linked campaign when `X-Listmonk-Campaign` is present
+- Negative check:
+  1. Set an incorrect `bounce.mailgun.key` in listmonk.
+  2. Re-send a Mailgun test webhook.
+  3. Request fails with HTTP 400 and no bounce is recorded.
+
+## Teardown
+
+- Disable Mailgun bounce webhook settings in listmonk or clear the key.
+- Remove webhook URLs from Mailgun (or disable them) to avoid stray events hitting your dev tunnel.
+
+## Troubleshooting
+
+- Signature failures: verify you are using the webhook signing key, not the API key.
+- No webhook hits: verify tunnel is active and Mailgun URLs use HTTPS.
+- Missing campaign linkage: verify `X-Listmonk-Campaign` is present in `user-variables` or message headers.

--- a/docs/docs/content/bounces.md
+++ b/docs/docs/content/bounces.md
@@ -53,6 +53,7 @@ listmonk supports receiving bounce webhook events from the following SMTP provid
 | `https://listmonk.yoursite.com/webhooks/service/postmark`     | Postmark webhook                       | [More info](https://postmarkapp.com/developer/webhooks/webhooks-overview)                                             |
 | `https://listmonk.yoursite.com/webhooks/service/forwardemail` | Forward Email webhook                  | [More info](https://forwardemail.net/en/faq#do-you-support-bounce-webhooks)                                           |
 | `https://listmonk.yoursite.com/webhooks/service/lettermint`   | Lettermint webhook                     | [More info](https://lettermint.co/knowledge-base/guides/send-newsletter-with-listmonk)                                                |
+| `https://listmonk.yoursite.com/webhooks/service/mailgun`      | Mailgun webhook                        | [More info](https://help.mailgun.com/hc/en-us/articles/202236504-Webhooks)                                    |
 
 ## Amazon Simple Email Service (SES)
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -183,11 +183,16 @@ export default Vue.extend({
       } else if (this.hasDummy(form['bounce.forwardemail'].key)) {
         hasDummy = 'forwardemail';
       }
-
       if (this.isDummy(form['bounce.lettermint'].key)) {
         form['bounce.lettermint'].key = '';
       } else if (this.hasDummy(form['bounce.lettermint'].key)) {
         hasDummy = 'lettermint';
+      }
+
+      if (this.isDummy(form['bounce.mailgun'].key)) {
+        form['bounce.mailgun'].key = '';
+      } else if (this.hasDummy(form['bounce.mailgun'].key)) {
+        hasDummy = 'mailgun';
       }
 
       for (let i = 0; i < form.messengers.length; i += 1) {

--- a/frontend/src/views/settings/bounces.vue
+++ b/frontend/src/views/settings/bounces.vue
@@ -164,7 +164,24 @@
             </b-field>
           </div>
         </div>
+        <div class="columns">
+          <div class="column is-3">
+            <b-field>
+              <b-switch v-model="data['bounce.mailgun'].enabled" name="mailgun_enabled" :native-value="true"
+                data-cy="btn-enable-bounce-mailgun">
+                {{ $t('settings.bounces.enableMailgun') }}
+              </b-switch>
+            </b-field>
+          </div>
+          <div class="column">
+            <b-field :label="$t('settings.bounces.mailgunKey')" :message="$t('globals.messages.passwordChange')">
+              <b-input v-model="data['bounce.mailgun'].key" type="password"
+                :disabled="!data['bounce.mailgun'].enabled" name="mailgun_key" data-cy="bounce-mailgun-key" />
+            </b-field>
+          </div>
+        </div>
       </div>
+
     </div>
 
     <!-- bounce mailbox -->

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -407,6 +407,8 @@
     "settings.bounces.forwardemailKey": "Forward Email Key",
     "settings.bounces.enableLettermint": "Enable Lettermint",
     "settings.bounces.lettermintKey": "Lettermint Webhook Secret",
+    "settings.bounces.enableMailgun": "Enable Mailgun",
+    "settings.bounces.mailgunKey": "Mailgun Webhook Signing Key",
     "settings.bounces.invalidScanInterval": "Bounce scan interval should be minimum 1 minute.",
     "settings.bounces.name": "Bounces",
     "settings.bounces.none": "None",

--- a/internal/bounce/bounce.go
+++ b/internal/bounce/bounce.go
@@ -42,6 +42,10 @@ type Opt struct {
 		Enabled bool
 		Key     string
 	}
+	Mailgun struct {
+		Enabled bool
+		Key     string
+	}
 
 	RecordBounceCB func(models.Bounce) error
 }
@@ -56,6 +60,7 @@ type Manager struct {
 	Postmark     *webhooks.Postmark
 	Forwardemail *webhooks.Forwardemail
 	Lettermint   *webhooks.Lettermint
+	Mailgun      *webhooks.Mailgun
 	queries      *Queries
 	opt          Opt
 	log          *log.Logger
@@ -114,6 +119,10 @@ func New(opt Opt, q *Queries, lo *log.Logger) (*Manager, error) {
 
 		if opt.Lettermint.Enabled {
 			m.Lettermint = webhooks.NewLettermint([]byte(opt.Lettermint.Key))
+		}
+
+		if opt.Mailgun.Enabled {
+			m.Mailgun = webhooks.NewMailgun([]byte(opt.Mailgun.Key))
 		}
 	}
 

--- a/internal/bounce/webhooks/mailgun.go
+++ b/internal/bounce/webhooks/mailgun.go
@@ -1,0 +1,118 @@
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/knadh/listmonk/models"
+)
+
+const mailgunSignatureToleranceSeconds = 300
+
+type mailgunNotif struct {
+	Signature struct {
+		Timestamp string `json:"timestamp"`
+		Token     string `json:"token"`
+		Signature string `json:"signature"`
+	} `json:"signature"`
+	EventData struct {
+		Event         string            `json:"event"`
+		Severity      string            `json:"severity"`
+		Timestamp     float64           `json:"timestamp"`
+		Recipient     string            `json:"recipient"`
+		Message       mailgunMessage    `json:"message"`
+		UserVariables map[string]string `json:"user-variables"`
+	} `json:"event-data"`
+}
+
+type mailgunMessage struct {
+	Headers map[string]string `json:"headers"`
+}
+
+// Mailgun handles bounce webhook notifications from Mailgun.
+type Mailgun struct {
+	hmacKey []byte
+}
+
+// NewMailgun returns a new Mailgun webhook handler.
+func NewMailgun(key []byte) *Mailgun {
+	return &Mailgun{hmacKey: key}
+}
+
+// ProcessBounce processes an incoming Mailgun webhook payload and returns bounce objects.
+func (m *Mailgun) ProcessBounce(body []byte) ([]models.Bounce, error) {
+	if len(m.hmacKey) == 0 {
+		return nil, fmt.Errorf("webhook key is not configured")
+	}
+
+	var n mailgunNotif
+	if err := json.Unmarshal(body, &n); err != nil {
+		return nil, fmt.Errorf("error unmarshalling Mailgun notification: %v", err)
+	}
+
+	sigTS, err := strconv.ParseInt(strings.TrimSpace(n.Signature.Timestamp), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signature timestamp: %v", err)
+	}
+
+	if math.Abs(float64(time.Now().Unix()-sigTS)) > mailgunSignatureToleranceSeconds {
+		return nil, fmt.Errorf("signature timestamp expired")
+	}
+
+	providedSig, err := hex.DecodeString(strings.TrimSpace(n.Signature.Signature))
+	if err != nil {
+		return nil, fmt.Errorf("invalid signature encoding: %v", err)
+	}
+
+	mac := hmac.New(sha256.New, m.hmacKey)
+	mac.Write([]byte(n.Signature.Timestamp + n.Signature.Token))
+	if !hmac.Equal(mac.Sum(nil), providedSig) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+
+	var typ string
+	switch n.EventData.Event {
+	case "failed":
+		switch n.EventData.Severity {
+		case "permanent":
+			typ = models.BounceTypeHard
+		case "temporary":
+			typ = models.BounceTypeSoft
+		default:
+			return nil, nil
+		}
+	case "complained":
+		typ = models.BounceTypeComplaint
+	default:
+		return nil, nil
+	}
+
+	campUUID := ""
+	if v, ok := n.EventData.UserVariables["X-Listmonk-Campaign"]; ok {
+		campUUID = v
+	} else if v, ok := n.EventData.Message.Headers["X-Listmonk-Campaign"]; ok {
+		campUUID = v
+	}
+
+	sec, dec := math.Modf(n.EventData.Timestamp)
+	createdAt := time.Unix(int64(sec), int64(dec*float64(time.Second)))
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+
+	return []models.Bounce{{
+		Email:        strings.ToLower(n.EventData.Recipient),
+		CampaignUUID: campUUID,
+		Type:         typ,
+		Source:       "mailgun",
+		Meta:         json.RawMessage(body),
+		CreatedAt:    createdAt,
+	}}, nil
+}

--- a/internal/bounce/webhooks/mailgun_test.go
+++ b/internal/bounce/webhooks/mailgun_test.go
@@ -1,0 +1,300 @@
+package webhooks
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/knadh/listmonk/models"
+)
+
+const testMailgunKey = "test-signing-key"
+
+type mailgunTestPayload struct {
+	Signature struct {
+		Timestamp string `json:"timestamp"`
+		Token     string `json:"token"`
+		Signature string `json:"signature"`
+	} `json:"signature"`
+	EventData struct {
+		Event         string            `json:"event"`
+		Severity      string            `json:"severity,omitempty"`
+		Timestamp     float64           `json:"timestamp"`
+		Recipient     string            `json:"recipient"`
+		Message       mailgunMessage    `json:"message"`
+		UserVariables map[string]string `json:"user-variables,omitempty"`
+	} `json:"event-data"`
+}
+
+func signMailgun(t *testing.T, key, timestamp, token string) string {
+	t.Helper()
+
+	mac := hmac.New(sha256.New, []byte(key))
+	if _, err := mac.Write([]byte(timestamp + token)); err != nil {
+		t.Fatalf("writing signature payload: %v", err)
+	}
+
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func buildMailgunPayload(t *testing.T, key string, signedAt, eventAt time.Time, event, severity, recipient string, userVars, headers map[string]string) []byte {
+	t.Helper()
+
+	ts := strconv.FormatInt(signedAt.Unix(), 10)
+	token := "test-token"
+
+	var p mailgunTestPayload
+	p.Signature.Timestamp = ts
+	p.Signature.Token = token
+	p.Signature.Signature = signMailgun(t, key, ts, token)
+	p.EventData.Event = event
+	p.EventData.Severity = severity
+	p.EventData.Timestamp = float64(eventAt.Unix())
+	p.EventData.Recipient = recipient
+	p.EventData.Message = mailgunMessage{Headers: headers}
+	p.EventData.UserVariables = userVars
+
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	return out
+}
+
+func TestProcessBounce_HardBounce(t *testing.T) {
+	eventAt := time.Unix(1700000000, 0)
+	body := buildMailgunPayload(t, testMailgunKey, time.Now(), eventAt, "failed", "permanent", "Foo@Bar.COM", nil, nil)
+
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bs) != 1 {
+		t.Fatalf("expected one bounce, got %d", len(bs))
+	}
+
+	b := bs[0]
+	if b.Type != models.BounceTypeHard {
+		t.Fatalf("expected type %q, got %q", models.BounceTypeHard, b.Type)
+	}
+	if b.Source != "mailgun" {
+		t.Fatalf("expected source mailgun, got %q", b.Source)
+	}
+	if b.Email != "foo@bar.com" {
+		t.Fatalf("expected lowercased email, got %q", b.Email)
+	}
+	if b.CreatedAt.Unix() != eventAt.Unix() {
+		t.Fatalf("expected created_at from event timestamp %v, got %v", eventAt, b.CreatedAt)
+	}
+	if !bytes.Equal(b.Meta, body) {
+		t.Fatalf("expected meta to equal raw body")
+	}
+}
+
+func TestProcessBounce_SoftBounce(t *testing.T) {
+	body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Unix(1700000100, 0), "failed", "temporary", "test@example.com", nil, nil)
+
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bs) != 1 {
+		t.Fatalf("expected one bounce, got %d", len(bs))
+	}
+
+	b := bs[0]
+	if b.Type != models.BounceTypeSoft {
+		t.Fatalf("expected type %q, got %q", models.BounceTypeSoft, b.Type)
+	}
+	if b.Source != "mailgun" {
+		t.Fatalf("expected source mailgun, got %q", b.Source)
+	}
+	if b.Email != "test@example.com" {
+		t.Fatalf("unexpected email: %q", b.Email)
+	}
+	if !bytes.Equal(b.Meta, body) {
+		t.Fatalf("expected meta to equal raw body")
+	}
+}
+
+func TestProcessBounce_Complaint(t *testing.T) {
+	body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Unix(1700000200, 0), "complained", "", "test@example.com", nil, nil)
+
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bs) != 1 {
+		t.Fatalf("expected one bounce, got %d", len(bs))
+	}
+
+	b := bs[0]
+	if b.Type != models.BounceTypeComplaint {
+		t.Fatalf("expected type %q, got %q", models.BounceTypeComplaint, b.Type)
+	}
+	if b.Source != "mailgun" {
+		t.Fatalf("expected source mailgun, got %q", b.Source)
+	}
+	if b.Email != "test@example.com" {
+		t.Fatalf("unexpected email: %q", b.Email)
+	}
+	if !bytes.Equal(b.Meta, body) {
+		t.Fatalf("expected meta to equal raw body")
+	}
+}
+
+func TestProcessBounce_IgnoredEvents(t *testing.T) {
+	tests := []string{"delivered", "opened", "clicked", "unsubscribed", "accepted"}
+
+	for _, event := range tests {
+		t.Run(event, func(t *testing.T) {
+			body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Unix(1700000300, 0), event, "", "test@example.com", nil, nil)
+
+			bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(bs) != 0 {
+				t.Fatalf("expected ignored event to return no bounces, got %d", len(bs))
+			}
+		})
+	}
+}
+
+func TestProcessBounce_InvalidSignature(t *testing.T) {
+	body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Now(), "failed", "permanent", "test@example.com", nil, nil)
+
+	var p mailgunNotif
+	if err := json.Unmarshal(body, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	p.Signature.Signature = strings.Repeat("0", 64)
+
+	tampered, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal tampered payload: %v", err)
+	}
+
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(tampered)
+	if err == nil {
+		t.Fatalf("expected invalid signature error")
+	}
+	if len(bs) != 0 {
+		t.Fatalf("expected no bounces on signature failure, got %d", len(bs))
+	}
+}
+
+func TestProcessBounce_ExpiredTimestamp(t *testing.T) {
+	body := buildMailgunPayload(t, testMailgunKey, time.Now().Add(-10*time.Minute), time.Now(), "failed", "permanent", "test@example.com", nil, nil)
+
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+	if err == nil {
+		t.Fatalf("expected expired timestamp error")
+	}
+	if len(bs) != 0 {
+		t.Fatalf("expected no bounces on expired timestamp, got %d", len(bs))
+	}
+}
+
+func TestProcessBounce_MalformedJSON(t *testing.T) {
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce([]byte("{not json"))
+	if err == nil {
+		t.Fatalf("expected malformed json error")
+	}
+	if len(bs) != 0 {
+		t.Fatalf("expected no bounces on malformed json, got %d", len(bs))
+	}
+}
+
+func TestProcessBounce_MissingKey(t *testing.T) {
+	body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Now(), "failed", "permanent", "test@example.com", nil, nil)
+
+	tests := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "nil", key: nil},
+		{name: "empty", key: []byte{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bs, err := NewMailgun(tc.key).ProcessBounce(body)
+			if err == nil {
+				t.Fatalf("expected missing key error")
+			}
+			if len(bs) != 0 {
+				t.Fatalf("expected no bounces when key is missing, got %d", len(bs))
+			}
+		})
+	}
+}
+
+func TestProcessBounce_CampaignUUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		userVars map[string]string
+		headers  map[string]string
+		want     string
+	}{
+		{
+			name:     "user-variables only",
+			userVars: map[string]string{"X-Listmonk-Campaign": "camp-user"},
+			want:     "camp-user",
+		},
+		{
+			name:    "headers only",
+			headers: map[string]string{"X-Listmonk-Campaign": "camp-header"},
+			want:    "camp-header",
+		},
+		{
+			name:     "user-variables take precedence",
+			userVars: map[string]string{"X-Listmonk-Campaign": "camp-user"},
+			headers:  map[string]string{"X-Listmonk-Campaign": "camp-header"},
+			want:     "camp-user",
+		},
+		{
+			name: "not present",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Now(), "failed", "permanent", "test@example.com", tc.userVars, tc.headers)
+
+			bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(bs) != 1 {
+				t.Fatalf("expected one bounce, got %d", len(bs))
+			}
+			if bs[0].CampaignUUID != tc.want {
+				t.Fatalf("expected campaign uuid %q, got %q", tc.want, bs[0].CampaignUUID)
+			}
+		})
+	}
+}
+
+func TestProcessBounce_EmailLowercased(t *testing.T) {
+	body := buildMailgunPayload(t, testMailgunKey, time.Now(), time.Now(), "failed", "permanent", "Foo@Bar.COM", nil, nil)
+
+	bs, err := NewMailgun([]byte(testMailgunKey)).ProcessBounce(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bs) != 1 {
+		t.Fatalf("expected one bounce, got %d", len(bs))
+	}
+	if bs[0].Email != "foo@bar.com" {
+		t.Fatalf("expected lowercased email, got %q", bs[0].Email)
+	}
+}

--- a/internal/migrations/v6.3.0.go
+++ b/internal/migrations/v6.3.0.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	"log"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/koanf/v2"
+	"github.com/knadh/stuffbin"
+)
+
+// V6_3_0 performs the DB migrations.
+func V6_3_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf, lo *log.Logger) error {
+	if _, err := db.Exec(`
+		INSERT INTO settings (key, value) VALUES('bounce.mailgun', '{"enabled": false, "key": ""}') ON CONFLICT DO NOTHING;
+	`); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/settings.go
+++ b/models/settings.go
@@ -141,6 +141,10 @@ type Settings struct {
 		Enabled bool   `json:"enabled"`
 		Key     string `json:"key"`
 	} `json:"bounce.lettermint"`
+	BounceMailgun struct {
+		Enabled bool   `json:"enabled"`
+		Key     string `json:"key"`
+	} `json:"bounce.mailgun"`
 	BounceBoxes []struct {
 		UUID          string `json:"uuid"`
 		Enabled       bool   `json:"enabled"`


### PR DESCRIPTION
This pull request add Mailgun webhook support to the bounce manager. See https://github.com/knadh/listmonk/issues/3163.  
I hope I got the part with the Listmonk campaign UUID detection right (expecting `X-Listmonk-Campaign` header).

This change also adds some lines to front end code. Since https://github.com/knadh/listmonk/issues/3073 forbids changes in the UI until 7.0 this pull request might need to wait..

A new migration is at [internal/migrations/v6.3.0.go](https://github.com/gdressel/listmonk/blob/feat/mailgun-webhook/internal/migrations/v6.3.0.go) because new settings are required for the Mailgun integration.

I used AI agents to create this code.

Event though the project seems not to have many tests I let the generated unit tests stay here. An integration test guide is also available to manually check the functionality with Mailgun services directly.