### PR TITLE
Fix literal subscriber search

### DIFF
--- a/queries/subscribers.sql
+++ b/queries/subscribers.sql
@@ -293,7 +293,9 @@ SELECT subscribers.* FROM subscribers
         AND ($2 = '' OR subscriber_lists.status = $2::subscription_status)
     )
     WHERE (CARDINALITY($1) = 0 OR subscriber_lists.list_id = ANY($1::INT[]))
-    AND (CASE WHEN $3 != '' THEN name ~* $3 OR email ~* $3 ELSE TRUE END)
+    AND (CASE WHEN $3 != '' THEN
+        STRPOS(LOWER(name), LOWER($3)) > 0 OR STRPOS(LOWER(email), LOWER($3)) > 0
+        ELSE TRUE END)
     AND %query%
     ORDER BY %order% OFFSET $4 LIMIT (CASE WHEN $5 < 1 THEN NULL ELSE $5 END);
 
@@ -308,7 +310,9 @@ SELECT COUNT(*) AS total FROM subscribers
         AND ($2 = '' OR subscriber_lists.status = $2::subscription_status)
     )
     WHERE (CARDINALITY($1) = 0 OR subscriber_lists.list_id = ANY($1::INT[]))
-    AND (CASE WHEN $3 != '' THEN name ~* $3 OR email ~* $3 ELSE TRUE END)
+    AND (CASE WHEN $3 != '' THEN
+        STRPOS(LOWER(name), LOWER($3)) > 0 OR STRPOS(LOWER(email), LOWER($3)) > 0
+        ELSE TRUE END)
     AND %query%;
 
 -- name: query-subscribers-count-all
@@ -339,7 +343,9 @@ SELECT subscribers.id,
     )
     WHERE subscriber_lists.list_id = ALL($1::INT[]) AND id > $2
     AND (CASE WHEN CARDINALITY($3::INT[]) > 0 THEN id=ANY($3) ELSE true END)
-    AND (CASE WHEN $5 != '' THEN name ~* $5 OR email ~* $5 ELSE TRUE END)
+    AND (CASE WHEN $5 != '' THEN
+        STRPOS(LOWER(name), LOWER($5)) > 0 OR STRPOS(LOWER(email), LOWER($5)) > 0
+        ELSE TRUE END)
     AND %query%
     ORDER BY subscribers.id ASC LIMIT (CASE WHEN $6 < 1 THEN NULL ELSE $6 END);
 
@@ -361,7 +367,9 @@ ON (
     AND ($3 = '' OR subscriber_lists.status = $3::subscription_status)
 )
 WHERE subscriber_lists.list_id = ALL($2::INT[])
-    AND (CASE WHEN $4 != '' THEN name ~* $4 OR email ~* $4 ELSE TRUE END)
+    AND (CASE WHEN $4 != '' THEN
+        STRPOS(LOWER(name), LOWER($4)) > 0 OR STRPOS(LOWER(email), LOWER($4)) > 0
+        ELSE TRUE END)
     AND %query%
 LIMIT (CASE WHEN $1 THEN 1 END)
 


### PR DESCRIPTION
## Summary

Treat the subscriber `search` parameter as a case-insensitive literal substring across listing, count, CSV export, and bulk-action queries.

## Root cause

The simple search value was passed directly to PostgreSQL’s `~*` regex operator. In a valid subaddress such as `user+subaddr@example.net`, `+` is interpreted as a regex quantifier instead of a literal character, so searching for the exact email returns no rows. Other regex metacharacters can likewise change the meaning of a normal text search.

This replaces the regex comparisons with `STRPOS(LOWER(column), LOWER(search)) > 0`. The separate advanced SQL-expression `query` feature is unchanged, and this PR does not touch the admin frontend currently being replaced for v7.

## Verification

- PostgreSQL regression check: the old comparison returned `false` for `user+subaddr@example.net`; the new comparison returned `true`
- Local `GET /api/subscribers` returned the seeded plus-address subscriber with `total: 1`
- Local `GET /api/subscribers/export` exported that subscriber
- Local `PUT /api/subscribers/query/lists` matched that subscriber and added the requested confirmed subscription
- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/listmonk-build ./cmd`
- `git diff --check`

Closes #3167

## AI disclosure

This contribution was developed with AI assistance (Codex).