### PR TITLE
Update Helm chart documentation

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -96,20 +96,17 @@ To compile the latest unreleased version (`master` branch):
 
 ## Helm chart for Kubernetes
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+A Helm chart for installing listmonk on a Kubernetes cluster is maintained by the community in the [HelmForge charts repository](https://github.com/helmforgedev/charts/tree/main/charts/listmonk).
 
-A helm chart for easily installing listmonk on a kubernetes cluster is made available by community [here](https://github.com/th0th/helm-charts/tree/main/charts/listmonk).
-
-In order to use the helm chart, you can configure `values.yaml` according to your needs, and then run the following command:
+To use the Helm chart, configure `values.yaml` according to your needs, and then run the following command:
 
 ```shell
 $ helm upgrade \
     --create-namespace \
     --install listmonk listmonk \
     --namespace listmonk \
-    --repo https://th0th.github.io/helm-charts \
-    --values values.yaml \
-    --version 0.1.0
+    --repo https://repo.helmforge.dev \
+    --values values.yaml
 ```
 
 ## 3rd party hosting


### PR DESCRIPTION
## What changed

- Replace the outdated community Helm chart link with the HelmForge chart.
- Update the Helm repository URL to `https://repo.helmforge.dev`.
- Remove the stale chart and application version badges.
- Stop pinning the installation example to chart version `0.1.0`.

## Why

The installation guide still referenced the old `th0th/helm-charts` chart and pinned version `0.1.0`, whose application version was listmonk 3.0.0. The HelmForge chart is actively maintained and currently tracks recent listmonk releases.

Removing the hard-coded chart version also keeps the example from becoming stale whenever a new chart release is published.

Closes #3157.

## Validation

- Confirmed the HelmForge repository URL and installation syntax against the chart documentation.
- Ran `git diff --check`.
- Confirmed the installation guide no longer references the old repository or version badges.
