### PR TITLE
docs: update Sealos deployment link

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -124,7 +124,7 @@ $ helm upgrade \
 <br />
 <a href="https://repocloud.io/details/?app_id=217"><img src="https://d16t0pc4846x52.cloudfront.net/deploy.png" alt="Deploy at RepoCloud" style="max-width: 150px;"/></a>
 <br />
-<a href="https://template.sealos.io/deploy?templateName=listmonk"><img src="https://sealos.io/Deploy-on-Sealos.svg" alt="Deploy on Sealos" style="max-width: 150px;"/></a>
+<a href="https://sealos.io/products/app-store/listmonk"><img src="https://sealos.io/Deploy-on-Sealos.svg" alt="Deploy on Sealos" style="max-width: 150px;"/></a>
 <br />
 <a href="https://zeabur.com/templates/5EDMN6"><img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" style="max-width: 150px;"/></a>
 <br />


### PR DESCRIPTION
## Summary

Updates the existing Sealos button in `docs/docs/content/installation.md` to point to the current Sealos App Store page. The badge image, placement, and wording remain unchanged.

Closes #3181.

## Validation

- App Store page: `https://sealos.io/products/app-store/listmonk` (HTTP 200)
- Button SVG: `https://sealos.io/Deploy-on-Sealos.svg` (HTTP 200)
- `mkdocs build --strict` passes
- Current Sealos template uses listmonk v6.1.0 and was deployment-tested on 2026-08-05

## Maintenance

I can maintain this deployment link and follow up if it changes again.