### PR TITLE
docs: fix typo in ExchangeOIDCToken comment

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -223,7 +223,7 @@ func (o *Auth) GetOIDCAuthURL(state, nonce string) string {
 	return cfg.AuthCodeURL(state, oidc.Nonce(nonce))
 }
 
-// ExchangeOIDCToken takes an OIDC authorization code (recieved via redirect from the OIDC provider),
+// ExchangeOIDCToken takes an OIDC authorization code (received via redirect from the OIDC provider),
 // validates it, and returns an OIDC token for subsequent auth.
 func (o *Auth) ExchangeOIDCToken(code, nonce string) (string, OIDCclaim, error) {
 	cfg, err := o.getOAuthConfig()


### PR DESCRIPTION
`recieved` should be `received` in the doc comment on `ExchangeOIDCToken`.

Only the comment is changed, and it is the single occurrence in the repository.
