### PR TITLE
fix: abort idempotent install on non-SQL errors instead of installing

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -45,8 +45,11 @@ func install(lastVer string, db *sqlx.DB, fs stuffbin.FileSystem, prompt, idempo
 	// If idempotence is on, check if the DB is already setup.
 	if idempotent {
 		if _, err := db.Exec("SELECT count(*) FROM settings"); err != nil {
-			// If "settings" doesn't exist, assume it's a fresh install.
-			if pqErr, ok := err.(*pq.Error); ok && pqErr.Code != "42P01" {
+			// Only a missing "settings" table (42P01) indicates a fresh install.
+			// Abort on every other error (network failures, permissions etc.),
+			// as proceeding would run the destructive schema install against a
+			// database whose state is unknown.
+			if !isTableNotExistErr(err) {
 				lo.Fatalf("error checking existing DB schema: %v", err)
 			}
 		} else {


### PR DESCRIPTION
Fixes #3195.

The `--install --idempotent` check only aborted on `*pq.Error` values with a code other than `42P01`. Errors of any other type — which is what connection-level failures surface as (e.g. `*net.OpError` after `database/sql` exhausts its `ErrBadConn` retries, exactly the situation while a DB container is still coming up) — failed the type assertion, skipped the `Fatalf`, and fell through to `installSchema()`. Since `schema.sql` drops every table before recreating it, a transient connectivity blip during the check could wipe a populated database (see the issue for a real-world incident).

This change reuses `isTableNotExistErr()` from `cmd/upgrade.go` so that only the positive "settings table does not exist" (42P01) signal triggers installation; every other error — SQL or otherwise — aborts before anything destructive runs.

Behavior change: previously non-fatal check failures (network errors, `driver.ErrBadConn`, context cancellation) now abort with an error. That is intentional — none of them proves the database is empty, and in a containerized setup the process simply restarts and re-checks.

Verified with `go build ./cmd`, `go vet ./cmd` and `gofmt`.