### PR TITLE
Add configurable campaign analytics granularity

### DIFF
--- a/cmd/campaigns.go
+++ b/cmd/campaigns.go
@@ -626,9 +626,10 @@ func (a *App) GetCampaignViewAnalytics(c echo.Context) error {
 	}
 
 	var (
-		typ  = c.Param("type")
-		from = c.QueryParams().Get("from")
-		to   = c.QueryParams().Get("to")
+		typ         = c.Param("type")
+		from        = c.QueryParams().Get("from")
+		to          = c.QueryParams().Get("to")
+		granularity = c.QueryParams().Get("granularity")
 	)
 	if !strHasLen(from, 10, 30) || !strHasLen(to, 10, 30) {
 		return echo.NewHTTPError(http.StatusBadRequest, a.i18n.T("analytics.invalidDates"))
@@ -645,7 +646,7 @@ func (a *App) GetCampaignViewAnalytics(c echo.Context) error {
 	}
 
 	// Get the analytics numbers from the DB for the campaigns.
-	out, err := a.core.GetCampaignAnalyticsCounts(ids, typ, from, to)
+	out, err := a.core.GetCampaignAnalyticsCounts(ids, typ, from, to, granularity)
 	if err != nil {
 		return err
 	}

--- a/docs/docs/content/apis/campaigns.md
+++ b/docs/docs/content/apis/campaigns.md
@@ -207,13 +207,20 @@ Retrieve stats of specified campaigns.
 | id   | number\[\] | Yes      | Campaign IDs to get stats for.                |
 | type | string     | Yes      | Analytics type: views, links, clicks, bounces |
 | from | string     | Yes      | Start value of date range.                    |
-| to   | string     | Yes      | End value of date range.                      |
+| to          | string     | Yes      | End value of date range.                                      |
+| granularity | string     |          | Optional time bucket: hour, day, week, or month.             |
 
 
 ##### Example Request
 
 ```shell
 curl -u "api_user:token" -X GET 'http://localhost:9000/api/campaigns/analytics/views?id=1&from=2024-08-04&to=2024-08-12'
+```
+
+Use the optional `granularity` query parameter to override the automatic time bucket. Supported values are `hour`, `day`, `week`, and `month`. When omitted, intervals shorter than seven days remain hourly and longer intervals remain daily.
+
+```shell
+curl -u "api_user:token" -X GET 'http://localhost:9000/api/campaigns/analytics/views?id=1&from=2024-08-04&to=2024-08-12&granularity=week'
 ```
 
 ##### Example Response

--- a/internal/core/campaigns.go
+++ b/internal/core/campaigns.go
@@ -381,7 +381,7 @@ func (c *Core) GetRunningCampaignStats() ([]models.CampaignStats, error) {
 	return out, nil
 }
 
-func (c *Core) GetCampaignAnalyticsCounts(campIDs []int, typ, fromDate, toDate string) ([]models.CampaignAnalyticsCount, error) {
+func (c *Core) GetCampaignAnalyticsCounts(campIDs []int, typ, fromDate, toDate, granularity string) ([]models.CampaignAnalyticsCount, error) {
 	// Pick campaign view counts or click counts.
 	var stmt *sqlx.Stmt
 	switch typ {
@@ -398,15 +398,27 @@ func (c *Core) GetCampaignAnalyticsCounts(campIDs []int, typ, fromDate, toDate s
 	if !strHasLen(fromDate, 10, 30) || !strHasLen(toDate, 10, 30) {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, c.i18n.T("analytics.invalidDates"))
 	}
+	if !isValidAnalyticsGranularity(granularity) {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, c.i18n.T("globals.messages.invalidData"))
+	}
 
 	out := []models.CampaignAnalyticsCount{}
-	if err := stmt.Select(&out, pq.Array(campIDs), fromDate, toDate); err != nil {
+	if err := stmt.Select(&out, pq.Array(campIDs), fromDate, toDate, granularity); err != nil {
 		c.log.Printf("error fetching campaign %s: %v", typ, err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError,
 			c.i18n.Ts("globals.messages.errorFetching", "name", "{globals.terms.analytics}", "error", pqErrMsg(err)))
 	}
 
 	return out, nil
+}
+
+func isValidAnalyticsGranularity(granularity string) bool {
+	switch granularity {
+	case "", "hour", "day", "week", "month":
+		return true
+	default:
+		return false
+	}
 }
 
 // GetCampaignAnalyticsLinks returns link click analytics for the given campaign IDs.

--- a/internal/core/campaigns_test.go
+++ b/internal/core/campaigns_test.go
@@ -1,0 +1,22 @@
+package core
+
+import "testing"
+
+func TestIsValidAnalyticsGranularity(t *testing.T) {
+	tests := map[string]bool{
+		"":      true,
+		"hour":  true,
+		"day":   true,
+		"week":  true,
+		"month": true,
+		"raw":   false,
+		"year":  false,
+		"DAY":   false,
+	}
+
+	for granularity, want := range tests {
+		if got := isValidAnalyticsGranularity(granularity); got != want {
+			t.Errorf("isValidAnalyticsGranularity(%q) = %t, want %t", granularity, got, want)
+		}
+	}
+}

--- a/queries/campaigns.sql
+++ b/queries/campaigns.sql
@@ -233,8 +233,8 @@ SELECT camps.*, campMedia.media_id FROM camps LEFT JOIN campMedia ON (campMedia.
 
 -- name: get-campaign-analytics-unique-counts
 WITH intval AS (
-    -- For intervals < a week, aggregate counts hourly, otherwise daily.
-    SELECT CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END
+    -- Use an explicit granularity when provided; otherwise preserve the automatic interval.
+    SELECT COALESCE(NULLIF($4, ''), CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END)
 ),
 uniqIDs AS (
     SELECT DISTINCT ON(subscriber_id, campaign_id) subscriber_id, campaign_id, DATE_TRUNC((SELECT * FROM intval), created_at) AS "timestamp"
@@ -248,8 +248,8 @@ SELECT COUNT(*) AS "count", campaign_id, "timestamp"
 -- name: get-campaign-analytics-counts
 -- raw: true
 WITH intval AS (
-    -- For intervals < a week, aggregate counts hourly, otherwise daily.
-    SELECT CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END
+    -- Use an explicit granularity when provided; otherwise preserve the automatic interval.
+    SELECT COALESCE(NULLIF($4, ''), CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END)
 )
 SELECT campaign_id, COUNT(*) AS "count", DATE_TRUNC((SELECT * FROM intval), created_at) AS "timestamp"
     FROM %s
@@ -258,8 +258,8 @@ SELECT campaign_id, COUNT(*) AS "count", DATE_TRUNC((SELECT * FROM intval), crea
 
 -- name: get-campaign-bounce-counts
 WITH intval AS (
-    -- For intervals < a week, aggregate counts hourly, otherwise daily.
-    SELECT CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END
+    -- Use an explicit granularity when provided; otherwise preserve the automatic interval.
+    SELECT COALESCE(NULLIF($4, ''), CASE WHEN (EXTRACT (EPOCH FROM ($3::TIMESTAMP - $2::TIMESTAMP)) / 86400) >= 7 THEN 'day' ELSE 'hour' END)
 )
 SELECT campaign_id, COUNT(*) AS "count", DATE_TRUNC((SELECT * FROM intval), created_at) AS "timestamp"
     FROM bounces


### PR DESCRIPTION
Fixes #3199 by adding an optional analytics granularity parameter while preserving the existing automatic grouping when the parameter is omitted.

The parameter is validated before reaching the SQL layer, and focused unit coverage documents the accepted, default, and rejected values.