### PR TITLE
docs: add Hostim to 3rd party hosting

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -126,6 +126,8 @@ $ helm upgrade \
 <a href="https://zeabur.com/templates/5EDMN6"><img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" style="max-width: 150px;"/></a>
 <br />
 <a href="https://www.cloudron.io/store/app.listmonk.cloudronapp.html"><img src="https://cloudron.io/img/button.svg" alt="Install on Cloudron" style="max-width: 150px;"/></a>
+<br />
+<a href="https://console.hostim.dev/dashboard?preview=1&modal=1&template=listmonk"><img src="https://hostim.dev/img/deploy-button.svg" alt="Deploy on Hostim" style="max-width: 150px;"/></a>
 
 ## Tutorials
 * [Listmonk with Forward Email for Secure Newsletter Delivery](https://forwardemail.net/en/guides/newsletter-with-listmonk)


### PR DESCRIPTION
Adds a one-click deploy button for [Hostim](https://hostim.dev) to the 3rd party hosting list, in the same shape as the existing Elestio/PikaPods/Northflank/Sealos entries.

The template deploys the official `listmonk/listmonk:latest` image against a managed PostgreSQL instance, using the start command from the repo's own `docker-compose.yml`:

```
sh -c "./listmonk --install --idempotent --yes --config '' && ./listmonk --upgrade --yes --config '' && ./listmonk --config ''"
```

so schema install happens once and migrations run on image updates. `LISTMONK_db__*` is wired to the managed database, `LISTMONK_ADMIN_USER`/`LISTMONK_ADMIN_PASSWORD` seed the super admin on first boot (password randomly generated per deploy), and `/listmonk/uploads` is mounted on a persistent volume.

Tested on listmonk v6.2.0: install, upgrade-on-restart, login, media upload, and persistence across restarts. Setup guide: https://hostim.dev/docs/templates/listmonk

Disclosure: I work on Hostim. Tell me if you want the wording or the button changed to fit the list better.
