### PR TITLE
Reject PUT /api/settings that would blank out upload.provider

### DIFF
--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -98,6 +98,16 @@ func (a *App) UpdateSettings(c echo.Context) error {
 		return err
 	}
 
+	// `upload.provider` is a required enum. A partial update that omits it
+	// zeroes it out to an empty string, which is silently accepted here but
+	// crashes the process with a fatal error the next time it starts up
+	// (initMediaStore() only recognizes "s3" and "filesystem" and calls
+	// lo.Fatalf() for anything else), leaving the instance unbootable.
+	if set.UploadProvider != "s3" && set.UploadProvider != "filesystem" {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			a.i18n.Ts("globals.messages.invalidFields", "name", "upload.provider"))
+	}
+
 	// Validate and sanitize postback Messenger names along with SMTP names
 	// (where each SMTP is also considered as a standalone messenger).
 	// Duplicates are disallowed and "email" is a reserved name.


### PR DESCRIPTION
## What

`PUT /api/settings` currently accepts a partial payload that omits `upload.provider`. Go's JSON unmarshalling leaves the omitted field at its zero value (`""`), and `UpdateSettings` (`cmd/settings.go`) writes it straight to the DB with no validation.

On the next process restart, `initMediaStore()` (`cmd/init.go`) only recognizes `"s3"` and `"filesystem"`:

```go
switch provider := ko.String("upload.provider"); provider {
case "s3":
    ...
case "filesystem":
    ...
default:
    lo.Fatalf("unknown provider. select filesystem or s3")
}
```

An empty (or otherwise invalid) value falls into `default` and `lo.Fatalf()`s, crashing the process — the instance is unbootable until the `settings` row is fixed by hand in the DB. This matches the core problem described in #2892 (a partial `PUT` wiping a required field and bricking the instance on restart).

## Fix

Validate `upload.provider` against its known enum in `UpdateSettings` before writing, right next to where the handler already validates other required settings (e.g. requiring at least one enabled SMTP block, or the OIDC default role ID). An invalid/missing value is now rejected with a `400` instead of being silently persisted.

```go
if set.UploadProvider != "s3" && set.UploadProvider != "filesystem" {
    return echo.NewHTTPError(http.StatusBadRequest,
        a.i18n.Ts("globals.messages.invalidFields", "name", "upload.provider"))
}
```

## Scope

This is intentionally narrow: it targets the one field I could confirm actually crashes the process on restart (verified by reading `initMediaStore()`). The issue also proposes broader options — validating every required field, or adding `PATCH` support for true partial updates — which are bigger, more opinionated changes better suited to a separate discussion/PR. Happy to extend this if a broader validation pass is preferred instead.

Backend-only change (`cmd/settings.go`), no frontend/Vue changes, in line with the current pre-v7 contribution freeze on the admin UI.

## Testing

- `go build ./...` and `go vet ./cmd/...` pass.
- Manually traced the exact crash path in `cmd/init.go`'s `initMediaStore()` to confirm the failure mode described in #2892 (I could not repro the exact log line quoted in the issue, but the underlying mechanism — an empty/invalid `upload.provider` causing a fatal error on the next boot — reproduces from the current `master` code).
- There's no existing Go test suite in this repo (`cmd`/`internal`/`models` have no `_test.go` files) to extend, so this was tested manually via a build/vet pass and code tracing rather than an automated test.

Addresses #2892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)