### PR TITLE
docs: the backup warnings name the uploads directory as well as the database

### DIFF
--- a/docs/docs/content/installation.md
+++ b/docs/docs/content/installation.md
@@ -77,7 +77,7 @@ command: [sh, -c, "./listmonk --install --idempotent --yes --config /listmonk/co
 ## Nightly
 
 !!! Warning
-    Nightly releases are untested and may have bugs. Use at your own risk. Always take a backup of your Postgres database before using a nightly release.
+    Nightly releases are untested and may have bugs. Use at your own risk. Always take a backup of your Postgres database and of the media uploads directory (`/listmonk/uploads` in the Docker image) before using a nightly release.
 
 A nightly build is automatically published with the latest changes merged to the repository. If you want to access the latest changes without waiting for versioned releases, you can obtain the nightly builds and follow the same instructions above.
 

--- a/docs/docs/content/upgrade.md
+++ b/docs/docs/content/upgrade.md
@@ -1,7 +1,7 @@
 # Upgrade
 
 !!! Warning
-    Always take a backup of the Postgres database before upgrading listmonk
+    Always take a backup of the Postgres database before upgrading listmonk, and a copy of the media uploads directory (`/listmonk/uploads` in the Docker image, or whatever Admin -> Settings -> Media names). The database stores a row per uploaded file; the files themselves are only on disk. If you use the S3 provider, the files are in your bucket instead.
 
 ## Binary
 - Stop the running instance of listmonk.


### PR DESCRIPTION
The two places the docs say "take a backup of the Postgres database" now also name the media uploads directory. The `media` table stores a file name per upload; the file itself is only on disk (`/listmonk/uploads` in the Docker image, or the path in Admin -> Settings -> Media), so a dump-only backup restores a media library whose images cannot be loaded. Tested on v6.2.0 with the project's compose file. Two lines, no new page, as proposed in the issue.

Closes #3215.