### PR TITLE
Send a PKCE code challenge on the OIDC login flow when the provider supports it.

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -196,8 +196,21 @@ func (a *App) OIDCLogin(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, a.i18n.T("globals.messages.internalError"))
 	}
 
+	authURL, codeVerifier := a.auth.GetOIDCAuthURL(base64.URLEncoding.EncodeToString(b), nonce.Value)
+
+	// Stash the PKCE code verifier in a cookie for the callback to use in the exchange.
+	if codeVerifier != "" {
+		c.SetCookie(&http.Cookie{
+			Name:     "oidc_code_verifier",
+			Value:    codeVerifier,
+			HttpOnly: true,
+			Path:     "/",
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
 	// Redirect to the external OIDC provider.
-	return c.Redirect(http.StatusFound, a.auth.GetOIDCAuthURL(base64.URLEncoding.EncodeToString(b), nonce.Value))
+	return c.Redirect(http.StatusFound, authURL)
 }
 
 // OIDCFinish receives the redirect callback from the OIDC provider and completes the handshake.
@@ -208,8 +221,14 @@ func (a *App) OIDCFinish(c echo.Context) error {
 		return a.renderLoginPage(c, echo.NewHTTPError(http.StatusUnauthorized, a.i18n.T("users.invalidRequest")))
 	}
 
+	// Get the PKCE code verifier set on the login request, if any.
+	codeVerifier := ""
+	if ck, err := c.Cookie("oidc_code_verifier"); err == nil {
+		codeVerifier = ck.Value
+	}
+
 	// Validate the OIDC token.
-	oidcToken, claims, err := a.auth.ExchangeOIDCToken(c.Request().URL.Query().Get("code"), nonce.Value)
+	oidcToken, claims, err := a.auth.ExchangeOIDCToken(c.Request().URL.Query().Get("code"), nonce.Value, codeVerifier)
 	if err != nil {
 		return a.renderLoginPage(c, err)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -72,6 +72,9 @@ type Auth struct {
 	sessStore *postgres.Store
 	cb        *Callbacks
 	log       *log.Logger
+
+	// Whether the OIDC provider supports PKCE with the S256 challenge method.
+	pkce bool
 }
 
 var sessPruneInterval = time.Hour * 12
@@ -171,6 +174,22 @@ func (o *Auth) initOIDC() error {
 	}
 	o.provider = provider
 
+	// Only use PKCE (RFC 7636) if the provider's metadata advertises it, as providers
+	// that don't support it may reject the extra params.
+	var meta struct {
+		CodeChallengeMethods []string `json:"code_challenge_methods_supported"`
+	}
+	if err := provider.Claims(&meta); err != nil {
+		o.log.Printf("error reading OIDC provider metadata: %v", err)
+	} else {
+		for _, m := range meta.CodeChallengeMethods {
+			if m == "S256" {
+				o.pkce = true
+				break
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -200,38 +219,55 @@ func (o *Auth) getVerifier() (*oidc.IDTokenVerifier, error) {
 	return o.verifier, nil
 }
 
-// getOAuthConfig returns the OAuth config, initializing it if necessary.
-func (o *Auth) getOAuthConfig() (*oauth2.Config, error) {
+// getOAuthConfig returns the OAuth config and whether the provider supports PKCE,
+// initializing them if necessary.
+func (o *Auth) getOAuthConfig() (*oauth2.Config, bool, error) {
 	o.Lock()
 	defer o.Unlock()
 
 	if o.oauthCfg.ClientID == "" {
 		if err := o.initOIDC(); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
-	return &o.oauthCfg, nil
+	return &o.oauthCfg, o.pkce, nil
 }
 
-// GetOIDCAuthURL returns the OIDC provider's auth URL to redirect to.
-func (o *Auth) GetOIDCAuthURL(state, nonce string) string {
-	cfg, err := o.getOAuthConfig()
+// GetOIDCAuthURL returns the OIDC provider's auth URL to redirect to and the PKCE code
+// verifier for the subsequent token exchange, empty if the provider doesn't support PKCE.
+func (o *Auth) GetOIDCAuthURL(state, nonce string) (string, string) {
+	cfg, pkce, err := o.getOAuthConfig()
 	if err != nil {
 		o.log.Printf("error getting OAuth config: %v", err)
-		return ""
+		return "", ""
 	}
-	return cfg.AuthCodeURL(state, oidc.Nonce(nonce))
+
+	opts := []oauth2.AuthCodeOption{oidc.Nonce(nonce)}
+
+	codeVerifier := ""
+	if pkce {
+		codeVerifier = oauth2.GenerateVerifier()
+		opts = append(opts, oauth2.S256ChallengeOption(codeVerifier))
+	}
+
+	return cfg.AuthCodeURL(state, opts...), codeVerifier
 }
 
-// ExchangeOIDCToken takes an OIDC authorization code (recieved via redirect from the OIDC provider),
-// validates it, and returns an OIDC token for subsequent auth.
-func (o *Auth) ExchangeOIDCToken(code, nonce string) (string, OIDCclaim, error) {
-	cfg, err := o.getOAuthConfig()
+// ExchangeOIDCToken takes an OIDC authorization code (recieved via redirect from the OIDC provider)
+// and the PKCE code verifier from the auth request, validates it, and returns an OIDC token for
+// subsequent auth.
+func (o *Auth) ExchangeOIDCToken(code, nonce, codeVerifier string) (string, OIDCclaim, error) {
+	cfg, _, err := o.getOAuthConfig()
 	if err != nil {
 		return "", OIDCclaim{}, echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("error getting OAuth config: %v", err))
 	}
 
-	tk, err := cfg.Exchange(context.TODO(), code)
+	var opts []oauth2.AuthCodeOption
+	if codeVerifier != "" {
+		opts = append(opts, oauth2.VerifierOption(codeVerifier))
+	}
+
+	tk, err := cfg.Exchange(context.TODO(), code, opts...)
 	if err != nil {
 		return "", OIDCclaim{}, echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("error exchanging token: %v", err))
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// newTestOIDCProvider starts a server that serves an OIDC discovery document,
+// optionally advertising PKCE support.
+func newTestOIDCProvider(t *testing.T, pkce bool) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		doc := map[string]any{
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/authorize",
+			"token_endpoint":                        srv.URL + "/token",
+			"jwks_uri":                              srv.URL + "/jwks.json",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		}
+		if pkce {
+			doc["code_challenge_methods_supported"] = []string{"S256"}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+
+	return srv
+}
+
+func newTestAuth(providerURL string) *Auth {
+	return &Auth{
+		cfg: Config{OIDC: OIDCConfig{
+			Enabled:     true,
+			ProviderURL: providerURL,
+			ClientID:    "listmonk",
+			RedirectURL: "http://localhost:9000/auth/oidc",
+		}},
+		log: log.New(io.Discard, "", 0),
+	}
+}
+
+// TestGetOIDCAuthURLWithPKCE tests that a PKCE challenge is sent to a provider that
+// supports it, and that the returned verifier is the one the challenge was derived from.
+func TestGetOIDCAuthURLWithPKCE(t *testing.T) {
+	srv := newTestOIDCProvider(t, true)
+
+	authURL, verifier := newTestAuth(srv.URL).GetOIDCAuthURL("state123", "nonce123")
+	if verifier == "" {
+		t.Fatal("expected a code verifier for a provider that supports PKCE")
+	}
+
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("error parsing auth URL: %v", err)
+	}
+	q := u.Query()
+
+	if got := q.Get("code_challenge_method"); got != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", got)
+	}
+
+	sum := sha256.Sum256([]byte(verifier))
+	if want := base64.RawURLEncoding.EncodeToString(sum[:]); q.Get("code_challenge") != want {
+		t.Errorf("code_challenge = %q, want %q (S256 of the verifier)", q.Get("code_challenge"), want)
+	}
+
+	// The existing params should be untouched.
+	if got := q.Get("nonce"); got != "nonce123" {
+		t.Errorf("nonce = %q, want nonce123", got)
+	}
+	if got := q.Get("state"); got != "state123" {
+		t.Errorf("state = %q, want state123", got)
+	}
+}
+
+// TestGetOIDCAuthURLWithoutPKCE tests that nothing is sent to a provider that doesn't
+// advertise PKCE support.
+func TestGetOIDCAuthURLWithoutPKCE(t *testing.T) {
+	srv := newTestOIDCProvider(t, false)
+
+	authURL, verifier := newTestAuth(srv.URL).GetOIDCAuthURL("state123", "nonce123")
+	if verifier != "" {
+		t.Errorf("got a code verifier %q for a provider that doesn't support PKCE", verifier)
+	}
+
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("error parsing auth URL: %v", err)
+	}
+
+	for _, p := range []string{"code_challenge", "code_challenge_method"} {
+		if got := u.Query().Get(p); got != "" {
+			t.Errorf("%s = %q, want it to be absent", p, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3218

The OIDC login doesn't use PKCE. `GetOIDCAuthURL` builds the authorization request with just a nonce, and `ExchangeOIDCToken` exchanges the code without a verifier. Providers that require PKCE reject the authorization request, so listmonk can't be used with them at all. Ours does, and we've had to add an exemption for listmonk on the provider side to get past it.

This generates a verifier in `GetOIDCAuthURL`, keeps it in an HttpOnly cookie next to the `nonce` cookie the flow already sets, and passes it to the exchange.

It only does that when the provider advertises `S256` in `code_challenge_methods_supported`, so anything without PKCE support gets the same requests it does today. Always sending it would be simpler, and per RFC 6749 §3.1 a server should ignore params it doesn't know, but I didn't want to bet existing setups on every provider getting that right. Happy to make it unconditional or put it behind a setting if you'd rather.

I noticed there are no Go tests in the repo, so `internal/auth/auth_test.go` is the first one and I've put it in its own commit in case you'd rather not have it. It runs under the existing `make test`, adds no dependencies, needs no database and takes milliseconds: it points `GetOIDCAuthURL` at an `httptest` server serving a discovery document and checks the challenge is the S256 hash of the returned verifier, then checks both params are absent when the document doesn't advertise PKCE. Drop that commit if it isn't wanted.

Since the test doesn't cover the cookie round trip in `cmd/auth.go`, I also ran the login by hand against a local provider that rejects an authorization request without an S256 challenge, and a token request whose verifier doesn't hash to it. Login works, and with the same provider not advertising PKCE the requests go out unchanged and login still works. No settings, schema or frontend changes.
