### PR TITLE
fix(campaigns): advance the resume checkpoint send-side, not fetch-side

### DIFF
--- a/cmd/manager_store.go
+++ b/cmd/manager_store.go
@@ -34,19 +34,23 @@ func newManagerStore(q *models.Queries, c *core.Core, m media.Store) *store {
 }
 
 // NextCampaigns retrieves active campaigns ready to be processed excluding
-// campaigns that are also being processed. Additionally, it takes a map of campaignID:sentCount
-// of campaigns that are being processed and updates them in the DB.
-func (s *store) NextCampaigns(currentIDs []int64, sentCounts []int64) ([]*models.Campaign, error) {
+// campaigns that are also being processed. Additionally, it takes the IDs,
+// incremental sent counts, and last confirmed-sent subscriber IDs (the
+// send-side resume checkpoints) of campaigns that are being processed and
+// updates them in the DB.
+func (s *store) NextCampaigns(currentIDs []int64, sentCounts []int64, lastSubIDs []int64) ([]*models.Campaign, error) {
 	var out []*models.Campaign
-	err := s.queries.NextCampaigns.Select(&out, pq.Int64Array(currentIDs), pq.Int64Array(sentCounts))
+	err := s.queries.NextCampaigns.Select(&out, pq.Int64Array(currentIDs), pq.Int64Array(sentCounts), pq.Int64Array(lastSubIDs))
 	return out, err
 }
 
 // NextSubscribers retrieves a subset of subscribers of a given campaign.
 // Since batches are processed sequentially, the retrieval is ordered by ID,
-// and every batch takes the last ID of the last batch and fetches the next
-// batch above that.
-func (s *store) NextSubscribers(campID, limit int) ([]models.Subscriber, error) {
+// and every batch starts after the given fetch cursor (the last ID of the
+// previous batch, tracked in memory by the campaign pipe). The durable
+// campaigns.last_subscriber_id checkpoint is not read or written here; it
+// only advances from the send side.
+func (s *store) NextSubscribers(campID, lastFetchedID, limit int) ([]models.Subscriber, error) {
 	var camps []runningCamp
 	if err := s.queries.GetRunningCampaign.Select(&camps, campID); err != nil {
 		return nil, err
@@ -62,7 +66,7 @@ func (s *store) NextSubscribers(campID, limit int) ([]models.Subscriber, error) 
 	}
 
 	var out []models.Subscriber
-	err := s.queries.NextCampaignSubscribers.Select(&out, camps[0].CampaignID, camps[0].CampaignType, camps[0].LastSubscriberID, camps[0].MaxSubscriberID, pq.Array(listIDs), limit)
+	err := s.queries.NextCampaignSubscribers.Select(&out, camps[0].CampaignID, camps[0].CampaignType, lastFetchedID, camps[0].MaxSubscriberID, pq.Array(listIDs), limit)
 	return out, err
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -47,8 +47,8 @@ const (
 // Store represents a data backend, such as a database,
 // that provides subscriber and campaign records.
 type Store interface {
-	NextCampaigns(currentIDs []int64, sentCounts []int64) ([]*models.Campaign, error)
-	NextSubscribers(campID, limit int) ([]models.Subscriber, error)
+	NextCampaigns(currentIDs []int64, sentCounts []int64, lastSubIDs []int64) ([]*models.Campaign, error)
+	NextSubscribers(campID, lastFetchedID, limit int) ([]models.Subscriber, error)
 	GetCampaign(campID int) (*models.Campaign, error)
 	GetAttachment(mediaID int) (models.Attachment, error)
 	GetInlineAttachmentByFilename(filename string) (models.Attachment, string, error)
@@ -453,8 +453,8 @@ func (m *Manager) scanCampaigns(tick time.Duration) {
 
 	// Periodically scan the data source for campaigns to process.
 	for range t.C {
-		ids, counts := m.getCurrentCampaigns()
-		campaigns, err := m.store.NextCampaigns(ids, counts)
+		ids, counts, lastIDs := m.getCurrentCampaigns()
+		campaigns, err := m.store.NextCampaigns(ids, counts, lastIDs)
 		if err != nil {
 			m.log.Printf("error fetching campaigns: %v", err)
 			continue
@@ -584,16 +584,18 @@ func (m *Manager) worker() {
 	}
 }
 
-// getCurrentCampaigns returns the IDs of campaigns currently being processed
-// and their sent counts.
-func (m *Manager) getCurrentCampaigns() ([]int64, []int64) {
+// getCurrentCampaigns returns the IDs of campaigns currently being processed,
+// their sent counts, and the ID of the last subscriber confirmed processed
+// (the send-side resume checkpoint) for each.
+func (m *Manager) getCurrentCampaigns() ([]int64, []int64, []int64) {
 	// Needs to return an empty slice in case there are no campaigns.
 	m.pipesMut.RLock()
 	defer m.pipesMut.RUnlock()
 
 	var (
-		ids    = make([]int64, 0, len(m.pipes))
-		counts = make([]int64, 0, len(m.pipes))
+		ids     = make([]int64, 0, len(m.pipes))
+		counts  = make([]int64, 0, len(m.pipes))
+		lastIDs = make([]int64, 0, len(m.pipes))
 	)
 	for _, p := range m.pipes {
 		ids = append(ids, int64(p.camp.ID))
@@ -602,9 +604,15 @@ func (m *Manager) getCurrentCampaigns() ([]int64, []int64) {
 		// as in the database, they're stored cumulatively (sent += $newSent).
 		counts = append(counts, p.sent.Load())
 		p.sent.Store(0)
+
+		// The last confirmed-sent subscriber ID is a high watermark (unlike
+		// sent, it's not a delta), so it's read but never reset. Persisting it
+		// keeps the durable resume checkpoint trailing confirmed sends within
+		// one scan interval.
+		lastIDs = append(lastIDs, int64(p.lastID.Load()))
 	}
 
-	return ids, counts
+	return ids, counts, lastIDs
 }
 
 // trackLink register a URL and return its UUID to be used in message templates

--- a/internal/manager/pipe.go
+++ b/internal/manager/pipe.go
@@ -11,14 +11,15 @@ import (
 )
 
 type pipe struct {
-	camp       *models.Campaign
-	rate       *ratecounter.RateCounter
-	wg         *sync.WaitGroup
-	sent       atomic.Int64
-	lastID     atomic.Uint64
-	errors     atomic.Uint64
-	stopped    atomic.Bool
-	withErrors atomic.Bool
+	camp        *models.Campaign
+	rate        *ratecounter.RateCounter
+	wg          *sync.WaitGroup
+	sent        atomic.Int64
+	lastID      atomic.Uint64
+	lastFetched atomic.Int64
+	errors      atomic.Uint64
+	stopped     atomic.Bool
+	withErrors  atomic.Bool
 
 	m *Manager
 }
@@ -54,6 +55,12 @@ func (m *Manager) newPipe(c *models.Campaign) (*pipe, error) {
 		m:    m,
 	}
 
+	// Seed the in-memory fetch cursor from the durable send-side checkpoint.
+	// After a restart, fetching resumes from the last confirmed send, so
+	// subscribers whose messages were fetched but never sent (crash, kill,
+	// OOM) are picked up again instead of being silently skipped.
+	p.lastFetched.Store(int64(c.LastSubscriberID))
+
 	// Increment the waitgroup so that Wait() blocks immediately. This is necessary
 	// as a campaign pipe is created first and subscribers/messages under it are
 	// fetched asynchronolusly later. The messages each add to the wg and that
@@ -79,8 +86,9 @@ func (m *Manager) newPipe(c *models.Campaign) (*pipe, error) {
 // in the current batch or not. A false indicates that all subscribers
 // have been processed, or that a campaign has been paused or cancelled.
 func (p *pipe) NextSubscribers() (bool, error) {
-	// Fetch the next batch of subscribers from a 'running' campaign.
-	subs, err := p.m.store.NextSubscribers(p.camp.ID, p.m.cfg.BatchSize)
+	// Fetch the next batch of subscribers from a 'running' campaign, starting
+	// from the pipe's in-memory fetch cursor.
+	subs, err := p.m.store.NextSubscribers(p.camp.ID, int(p.lastFetched.Load()), p.m.cfg.BatchSize)
 	if err != nil {
 		return false, fmt.Errorf("error fetching campaign subscribers (%s): %v", p.camp.Name, err)
 	}
@@ -90,6 +98,14 @@ func (p *pipe) NextSubscribers() (bool, error) {
 	if len(subs) == 0 {
 		return false, nil
 	}
+
+	// Advance the in-memory fetch cursor to the last ID in the batch (batches
+	// are ordered by subscriber ID). This deliberately does not touch
+	// campaigns.last_subscriber_id in the DB: the durable checkpoint advances
+	// only from the send side (pipe.lastID, flushed by the manager's campaign
+	// scan and on pipe drain), keeping it behind confirmed sends so that a
+	// crash or restart can never skip fetched-but-unsent subscribers.
+	p.lastFetched.Store(int64(subs[len(subs)-1].ID))
 
 	// Is there a sliding window limit configured?
 	hasSliding := p.m.cfg.SlidingWindow &&

--- a/internal/manager/pipe_test.go
+++ b/internal/manager/pipe_test.go
@@ -1,0 +1,222 @@
+package manager
+
+import (
+	"log"
+	"sync"
+	"testing"
+
+	"github.com/knadh/listmonk/models"
+)
+
+// mockStore implements Store, recording how the fetch cursor and the durable
+// checkpoint are used.
+type mockStore struct {
+	mu sync.Mutex
+
+	// Scripted subscriber batches returned by successive NextSubscribers calls.
+	batches [][]models.Subscriber
+
+	// Fetch cursors passed to successive NextSubscribers calls.
+	gotCursors []int
+
+	// Durable checkpoint writes (UpdateCampaignCounts lastSubID args).
+	checkpointWrites []int
+}
+
+func (s *mockStore) NextCampaigns(currentIDs []int64, sentCounts []int64, lastSubIDs []int64) ([]*models.Campaign, error) {
+	return nil, nil
+}
+
+func (s *mockStore) NextSubscribers(campID, lastFetchedID, limit int) ([]models.Subscriber, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gotCursors = append(s.gotCursors, lastFetchedID)
+	if len(s.batches) == 0 {
+		return nil, nil
+	}
+	out := s.batches[0]
+	s.batches = s.batches[1:]
+	return out, nil
+}
+
+func (s *mockStore) GetCampaign(campID int) (*models.Campaign, error) {
+	return &models.Campaign{}, nil
+}
+
+func (s *mockStore) GetAttachment(mediaID int) (models.Attachment, error) {
+	return models.Attachment{}, nil
+}
+
+func (s *mockStore) GetInlineAttachmentByFilename(filename string) (models.Attachment, string, error) {
+	return models.Attachment{}, "", nil
+}
+
+func (s *mockStore) GetMediaURLByFilename(filename string) (string, error) {
+	return "", nil
+}
+
+func (s *mockStore) UpdateCampaignStatus(campID int, status string) error { return nil }
+
+func (s *mockStore) UpdateCampaignCounts(campID int, toSend int, sent int, lastSubID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.checkpointWrites = append(s.checkpointWrites, lastSubID)
+	return nil
+}
+
+func (s *mockStore) CreateLink(url string) (string, error) { return "", nil }
+func (s *mockStore) BlocklistSubscriber(id int64) error    { return nil }
+func (s *mockStore) DeleteSubscriber(id int64) error       { return nil }
+
+type mockMessenger struct{}
+
+func (m mockMessenger) Name() string              { return "email" }
+func (m mockMessenger) Push(models.Message) error { return nil }
+func (m mockMessenger) Flush() error              { return nil }
+func (m mockMessenger) Close() error              { return nil }
+
+func newTestManager(store Store) *Manager {
+	m := &Manager{
+		cfg: Config{
+			BatchSize: 2,
+			UnsubURL:  "http://localhost:9000/subscription/%s/%s",
+		},
+		log:        log.New(testWriter{}, "", 0),
+		messengers: map[string]Messenger{"email": mockMessenger{}},
+		store:      store,
+		pipes:      make(map[int]*pipe),
+		links:      make(map[string]string),
+		campMsgQ:   make(chan CampaignMessage, 100),
+		msgQ:       make(chan models.Message, 100),
+	}
+	return m
+}
+
+type testWriter struct{}
+
+func (testWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+func newTestCampaign(lastSubID int) *models.Campaign {
+	c := &models.Campaign{
+		UUID:             "camp-uuid",
+		Type:             models.CampaignTypeRegular,
+		Name:             "test",
+		Subject:          "hi",
+		FromEmail:        "test@example.com",
+		Body:             "hello",
+		Status:           models.CampaignStatusRunning,
+		ContentType:      models.CampaignContentTypePlain,
+		Messenger:        "email",
+		LastSubscriberID: lastSubID,
+	}
+	c.ID = 1
+	return c
+}
+
+func makeSubs(ids ...int) []models.Subscriber {
+	out := make([]models.Subscriber, 0, len(ids))
+	for _, id := range ids {
+		s := models.Subscriber{UUID: "sub-uuid", Email: "u@example.com", Name: "u"}
+		s.ID = id
+		out = append(out, s)
+	}
+	return out
+}
+
+// Fetching subscriber batches must never advance the durable checkpoint:
+// messages are sent asynchronously after the fetch, so a checkpoint that runs
+// ahead of confirmed sends permanently skips subscribers on crash/restart.
+// The pipe must instead track its own in-memory fetch cursor.
+func TestNextSubscribersUsesInMemoryFetchCursor(t *testing.T) {
+	store := &mockStore{
+		batches: [][]models.Subscriber{
+			makeSubs(1, 2),
+			makeSubs(3, 4),
+			{},
+		},
+	}
+	m := newTestManager(store)
+
+	p, err := m.newPipe(newTestCampaign(0))
+	if err != nil {
+		t.Fatalf("newPipe: %v", err)
+	}
+
+	for i, want := range []bool{true, true, false} {
+		has, err := p.NextSubscribers()
+		if err != nil {
+			t.Fatalf("NextSubscribers call %d: %v", i, err)
+		}
+		if has != want {
+			t.Fatalf("NextSubscribers call %d: has=%v, want %v", i, has, want)
+		}
+	}
+
+	// The cursor passed to the store must advance in memory across batches:
+	// seeded from the durable checkpoint (0), then the last ID of each batch.
+	want := []int{0, 2, 4}
+	if len(store.gotCursors) != len(want) {
+		t.Fatalf("got %d fetch calls, want %d", len(store.gotCursors), len(want))
+	}
+	for i, w := range want {
+		if store.gotCursors[i] != w {
+			t.Fatalf("fetch call %d: cursor=%d, want %d", i, store.gotCursors[i], w)
+		}
+	}
+
+	// The fetch path must not write the durable checkpoint at all.
+	if len(store.checkpointWrites) != 0 {
+		t.Fatalf("fetch path wrote the durable checkpoint %d times; it must only advance from the send side",
+			len(store.checkpointWrites))
+	}
+}
+
+// After a restart, a new pipe must resume fetching from the durable send-side
+// checkpoint (last confirmed send), re-covering any subscribers whose messages
+// were fetched but never sent by the previous process.
+func TestNewPipeResumesFromDurableSendCheckpoint(t *testing.T) {
+	store := &mockStore{batches: [][]models.Subscriber{makeSubs(8, 9)}}
+	m := newTestManager(store)
+
+	// Durable checkpoint says subscriber 7 was the last confirmed send.
+	p, err := m.newPipe(newTestCampaign(7))
+	if err != nil {
+		t.Fatalf("newPipe: %v", err)
+	}
+
+	if _, err := p.NextSubscribers(); err != nil {
+		t.Fatalf("NextSubscribers: %v", err)
+	}
+
+	if len(store.gotCursors) != 1 || store.gotCursors[0] != 7 {
+		t.Fatalf("resume fetch started at cursor %v, want [7]", store.gotCursors)
+	}
+}
+
+// The periodic campaign scan must flush the send-side watermark (last
+// confirmed-sent subscriber ID) as a monotonic watermark, not a delta: unlike
+// the sent counter, it must not reset between scans.
+func TestGetCurrentCampaignsFlushesSendSideWatermark(t *testing.T) {
+	m := newTestManager(&mockStore{})
+
+	p, err := m.newPipe(newTestCampaign(0))
+	if err != nil {
+		t.Fatalf("newPipe: %v", err)
+	}
+	p.sent.Store(3)
+	p.lastID.Store(5)
+
+	ids, counts, lastIDs := m.getCurrentCampaigns()
+	if len(ids) != 1 || len(counts) != 1 || len(lastIDs) != 1 {
+		t.Fatalf("got ids=%v counts=%v lastIDs=%v", ids, counts, lastIDs)
+	}
+	if counts[0] != 3 || lastIDs[0] != 5 {
+		t.Fatalf("got count=%d lastID=%d, want 3 and 5", counts[0], lastIDs[0])
+	}
+
+	// sent is a delta and resets; the watermark must not.
+	_, counts, lastIDs = m.getCurrentCampaigns()
+	if counts[0] != 0 || lastIDs[0] != 5 {
+		t.Fatalf("second scan: got count=%d lastID=%d, want 0 and 5", counts[0], lastIDs[0])
+	}
+}

--- a/models/campaigns.go
+++ b/models/campaigns.go
@@ -77,6 +77,14 @@ type Campaign struct {
 	// Fetched bodies of the attachments.
 	Attachments []Attachment `json:"-" db:"-"`
 
+	// LastSubscriberID is the durable resume checkpoint: the highest subscriber
+	// ID for which a message was confirmed processed. It only advances from the
+	// send side (flushed periodically by the campaign manager and on pipe drain),
+	// never when subscriber batches are fetched, so a crash or restart resumes
+	// from the last confirmed send instead of skipping fetched-but-unsent
+	// subscribers.
+	LastSubscriberID int `db:"last_subscriber_id" json:"-"`
+
 	// Pseudofield for getting the total number of subscribers
 	// in searches and queries.
 	Total int `db:"total" json:"-"`

--- a/queries/campaigns.sql
+++ b/queries/campaigns.sql
@@ -214,9 +214,15 @@ counts AS (
     GROUP BY camps.id
 ),
 updateCounts AS (
-    WITH uc (campaign_id, sent_count) AS (SELECT * FROM unnest($1::INT[], $2::INT[]))
+    WITH uc (campaign_id, sent_count, last_sub_id) AS (SELECT * FROM unnest($1::INT[], $2::INT[], $3::INT[]))
     UPDATE campaigns
-    SET sent = sent + uc.sent_count
+    SET sent = sent + uc.sent_count,
+        -- The durable resume checkpoint only ever advances from the send side:
+        -- the highest subscriber ID for which a message was confirmed processed.
+        -- It must never move ahead of sends (see next-campaign-subscribers), or
+        -- a crash/restart would permanently skip fetched-but-unsent subscribers.
+        last_subscriber_id = (CASE WHEN uc.last_sub_id > campaigns.last_subscriber_id
+                                   THEN uc.last_sub_id ELSE campaigns.last_subscriber_id END)
     FROM uc WHERE campaigns.id = uc.campaign_id
 ),
 u AS (
@@ -317,8 +323,12 @@ SELECT campaigns.id AS campaign_id, campaigns.type as campaign_type, last_subscr
 
 -- name: next-campaign-subscribers
 -- Returns a batch of subscribers in a given campaign starting from the last checkpoint
--- (last_subscriber_id). Every fetch updates the checkpoint and the sent count, which means
--- every fetch returns a new batch of subscribers until all rows are exhausted.
+-- ($3). The caller passes the checkpoint explicitly: within a running process the pipe
+-- tracks its own in-memory fetch cursor, and across restarts it resumes from the durable
+-- campaigns.last_subscriber_id column, which only advances from the send side
+-- (next-campaigns / update-campaign-counts). Fetching must never advance the durable
+-- checkpoint: messages are sent asynchronously after a batch is fetched, so a checkpoint
+-- that runs ahead of confirmed sends permanently skips subscribers on crash/restart.
 --
 -- In previous versions, get-running-campaign + this was a single query spread across multiple
 -- CTEs, but despite numerous permutations and combinations, Postgres query planner simply would not use
@@ -363,11 +373,6 @@ subs AS (
             )
         ORDER BY s.id LIMIT $6
     ) subIDs JOIN subscribers s ON (s.id = subIDs.id) ORDER BY s.id
-),
-u AS (
-    UPDATE campaigns
-    SET last_subscriber_id = (SELECT MAX(id) FROM subs), updated_at = NOW()
-    WHERE (SELECT COUNT(id) FROM subs) > 0 AND id=$1
 )
 SELECT * FROM subs;
 


### PR DESCRIPTION
Fixes #3022.

Dug into this after hitting the same "finished with half the list unsent" shape. Root cause: the campaign resume checkpoint (`campaigns.last_subscriber_id`) is advanced at batch-FETCH time, not send time. `next-campaign-subscribers` UPDATEs the checkpoint to the max ID of every batch it reads, while that batch's messages are still queued and send asynchronously. The send-side correction only happens in `cleanup()` when a pipe drains gracefully - on a kill/crash/restart it never runs, so resume starts from the last *fetched* ID and every fetched-but-unsent subscriber is permanently skipped. When the remaining rows then read empty, `cleanup()` marks the campaign `finished` - exactly the log sequence in the issue ("start processing campaign" -> "campaign finished" right after a restart, with most of the list never mailed).

Reproduced against a real Postgres: one batch fetch of 4 moved the durable checkpoint to 4 with zero sends; after a simulated kill with only 2 messages actually sent, resume restarted at 4 - subscribers 3 and 4 gone for good.

This PR moves the fetch cursor into the campaign pipe (in-memory, seeded from the durable checkpoint) and makes the durable checkpoint strictly send-side: it advances only with confirmed sends (periodic scan flush + pipe drain), monotonically. After this, a restart re-covers the unsent window instead of skipping it - at-least-once semantics with a duplicate window bounded by one scan interval, rather than silent permanent loss. Includes unit tests for the cursor/resume/watermark behavior; verified end-to-end against Postgres 14.

Backend-only; no UI changes.

> Built by breken, your AI support engineer - breken.ai - this one's on us.